### PR TITLE
Updates to truncate function

### DIFF
--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -46,7 +46,7 @@ from .mathtools import *
 from . import experimental
 from ._requests import request
 
-VERSION = "1.8.7.final.0"
+VERSION = "1.8.8.final.0"
 
 __version__ = get_version_pep440_compliant(VERSION)
 

--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -46,7 +46,7 @@ from .mathtools import *
 from . import experimental
 from ._requests import request
 
-VERSION = "1.8.5.final.0"
+VERSION = "1.8.6.final.0"
 
 __version__ = get_version_pep440_compliant(VERSION)
 

--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -46,7 +46,7 @@ from .mathtools import *
 from . import experimental
 from ._requests import request
 
-VERSION = "1.8.6.final.0"
+VERSION = "1.8.7.final.0"
 
 __version__ = get_version_pep440_compliant(VERSION)
 

--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -46,7 +46,7 @@ from .mathtools import *
 from . import experimental
 from ._requests import request
 
-VERSION = "1.8.4.final.0"
+VERSION = "1.8.5.final.0"
 
 __version__ = get_version_pep440_compliant(VERSION)
 

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -254,19 +254,22 @@ def truncate(data: Union[Sequence], k: int):
         for key, value in data.items():
             data[key] = truncate(value, k)
 
-    k = min(k, len(data))
-    n = k // 2
+    if is_iterable(data):
+        k = min(k, len(data))
+        n = k // 2
 
-    if isinstance(data, str):
-        filler = '…' if len(data) > k else ''
-    elif isinstance(data, bytes):
-        filler = b'...' if len(data) > k else b''
-    else:
-        filler = ['…'] if len(data) > k else []
-    if isinstance(data, (str, list, bytes)):
-        return data[:(k-n)] + filler + data[-n:] if n else data[:(k-n)] + filler
-    elif isinstance(data, set):
-        return set(list(data)[:(k-n)] + filler + list(data)[-n:]) if n else set(list(data)[:(k-n)] + filler)
+        if isinstance(data, str):
+            filler = '…' if len(data) > k else ''
+        elif isinstance(data, bytes):
+            filler = b'...' if len(data) > k else b''
+        else:
+            filler = ['…'] if len(data) > k else []
+        if isinstance(data, (str, list, bytes)):
+            return data[:(k-n)] + filler + data[-n:] if n else data[:(k-n)] + filler
+        elif isinstance(data, set):
+            return set(list(data)[:(k-n)] + filler + list(data)[-n:]) if n else set(list(data)[:(k-n)] + filler)
+        else:
+            return data
     else:
         return data
 
@@ -355,7 +358,7 @@ def sample(
     return result
 
 
-def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 10, p_print: bool = True):
+def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 5, p_print: bool = True):
     """
     Samples then (p)prints a truncated version of the sample. Helpful for visualizing data structures.
     Args:

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -248,17 +248,19 @@ def truncate(data: Union[Sequence], k: int):
     Returns:
         truncated data
     """
+    assert(k > 0), 'k should be an integer larger than 0'
 
-    n = k//2
+    k = min(k, len(data))
+    n = k // 2
     if isinstance(data, dict):
         for key, value in data.items():
             data[key] = truncate(value, k)
     if isinstance(data, str):
-        filler = '...' if len(data) > k else ''
+        filler = '…' if len(data) > k else ''
     elif isinstance(data, bytes):
         filler = b'...' if len(data) > k else b''
     else:
-        filler = ['...'] if len(data) > k else []
+        filler = ['…'] if len(data) > k else []
     if isinstance(data, (str, list, bytes)):
         return data[:(k-n)] + filler + data[-n:]
     elif isinstance(data, set):

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -237,7 +237,7 @@ def clipboard() -> str:
     return _get_tkinter().clipboard_get()
 
 
-def truncate(data: Union[Sequence], k: int, k_str_mult: int):
+def truncate(data: Union[Sequence], k: int, k_str_mult: int = 1):
     """
     Truncates the data to the specified number of elements in half(+1 if odd) + half, adding a filler in between.
     If the data is a dictionary, then truncates recursively until data is "truncatable".

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -237,24 +237,30 @@ def clipboard() -> str:
     return _get_tkinter().clipboard_get()
 
 
-def truncate(data: Union[Sequence], k: int):
+def truncate(data: Union[Sequence], k: int, k_str_mult: int):
     """
     Truncates the data to the specified number of elements in half(+1 if odd) + half, adding a filler in between.
     If the data is a dictionary, then truncates recursively until data is "truncatable".
+    Allows to apply a multiplier to k in the case of strings.
     Args:
         data: sequence
         k: number of elements of original data to return
-
+        k_str_mult: multiplier to k to apply for strings
     Returns:
         truncated data
     """
-    assert(k > 0), 'k should be an integer larger than 0'
+    assert all([k >= 0, k_str_mult >= 0]), 'k/k_str_mult should be an integer equal to or larger than 0'
+
+    if k == 0:
+        return data
 
     if isinstance(data, dict):
         for key, value in data.items():
-            data[key] = truncate(value, k)
+            data[key] = truncate(value, k, k_str_mult)
 
     if is_iterable(data):
+        if isinstance(data, str):
+            k *= k_str_mult
         k = min(k, len(data))
         n = k // 2
 
@@ -356,7 +362,7 @@ def sample(
     return result
 
 
-def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 5, p_print: bool = True):
+def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 5, truncate_k_str_multiplier: int = 10, p_print: bool = True):
     """
     Samples then (p)prints a truncated version of the sample. Helpful for visualizing data structures.
     Args:
@@ -364,11 +370,12 @@ def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, trunca
         k: number of samples
         is_random: should shuffle
         truncate_k: how many items to keep in the truncated version of the sample
+        truncate_k_str_multiplier: k multiplier for string data
         p_print: should pprint or print
     """
 
     obj_sample = sample(v=v, k=k, is_random=is_random)
-    truncated_sample = truncate(obj_sample, truncate_k)
+    truncated_sample = truncate(obj_sample, truncate_k, truncate_k_str_multiplier)
     if p_print:
         pprint(truncated_sample)
     else:

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -268,10 +268,8 @@ def truncate(data: Union[Sequence], k: int):
             return data[:(k-n)] + filler + data[-n:] if n else data[:(k-n)] + filler
         elif isinstance(data, set):
             return set(list(data)[:(k-n)] + filler + list(data)[-n:]) if n else set(list(data)[:(k-n)] + filler)
-        else:
-            return data
-    else:
         return data
+    return data
 
 
 def obj_repr(

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -250,11 +250,13 @@ def truncate(data: Union[Sequence], k: int):
     """
     assert(k > 0), 'k should be an integer larger than 0'
 
-    k = min(k, len(data))
-    n = k // 2
     if isinstance(data, dict):
         for key, value in data.items():
             data[key] = truncate(value, k)
+
+    k = min(k, len(data))
+    n = k // 2
+
     if isinstance(data, str):
         filler = '…' if len(data) > k else ''
     elif isinstance(data, bytes):
@@ -262,9 +264,9 @@ def truncate(data: Union[Sequence], k: int):
     else:
         filler = ['…'] if len(data) > k else []
     if isinstance(data, (str, list, bytes)):
-        return data[:(k-n)] + filler + data[-n:]
+        return data[:(k-n)] + filler + data[-n:] if n else data[:(k-n)] + filler
     elif isinstance(data, set):
-        return set(list(data)[:(k-n)] + filler + list(data)[-n:])
+        return set(list(data)[:(k-n)] + filler + list(data)[-n:]) if n else set(list(data)[:(k-n)] + filler)
     else:
         return data
 

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -136,7 +136,7 @@ def split_sequence(seq, is_break_fn):
     sub_seqs = []
     sub_seq = [seq[0]]
     for i in range(1, len(seq)):
-        if is_break_fn(seq[i-1], seq[i]):
+        if is_break_fn(seq[i - 1], seq[i]):
             sub_seqs.append(sub_seq)
             sub_seq = []
         sub_seq.append(seq[i])
@@ -237,43 +237,50 @@ def clipboard() -> str:
     return _get_tkinter().clipboard_get()
 
 
-def truncate(data: Union[Sequence], k: int, k_str_mult: int = 1):
+def truncate(data: Union[Sequence], k: int = 0, k_str: int = 0):
     """
     Truncates the data to the specified number of elements in half(+1 if odd) + half, adding a filler in between.
     If the data is a dictionary, then truncates recursively until data is "truncatable".
-    Allows to apply a multiplier to k in the case of strings.
+    Allows to specify a different to k to strings.
     Args:
         data: sequence
         k: number of elements of original data to return
-        k_str_mult: multiplier to k to apply for strings
+        k_str: number of elements of strings to return
     Returns:
         truncated data
     """
-    assert all([k >= 0, k_str_mult >= 0]), 'k/k_str_mult should be an integer equal to or larger than 0'
-
-    if k == 0:
-        return data
+    assert all([k >= 0, k_str >= 0]), 'k/k_str should be an integer equal to or larger than 0'
 
     if isinstance(data, dict):
         for key, value in data.items():
-            data[key] = truncate(value, k, k_str_mult)
-
-    if is_iterable(data):
-        if isinstance(data, str):
-            k *= k_str_mult
-        k = min(k, len(data))
-        n = k // 2
-
-        if isinstance(data, str):
-            filler = '…' if len(data) > k else ''
-        elif isinstance(data, bytes):
+            data[key] = truncate(value, k, k_str)
+    elif isinstance(data, str):
+        if k_str == 0:
+            return data
+        k_str = min(k_str, len(data))
+        n = k_str // 2
+        filler = '…' if len(data) > k_str else ''
+        return data[:(k_str - n)] + filler + data[-n:] if n else data[:(k_str - n)] + filler
+    elif is_iterable(data):
+        if k == 0:
+            return data
+        k_iter = min(k, len(data))
+        n = k_iter // 2
+        if isinstance(data, bytes):
             filler = b'...' if len(data) > k else b''
+            return data[:(k_iter - n)] + filler + data[-n:] if n else data[:(k_iter - n)] + filler
         else:
-            filler = ['…'] if len(data) > k else []
-        if isinstance(data, (str, list, bytes)):
-            return data[:(k-n)] + filler + data[-n:] if n else data[:(k-n)] + filler
+            filler = ['<…>'] if len(data) > k else []
+        if isinstance(data, list):
+            if n:
+                return [truncate(dt, k, k_str) for dt in data[:(k_iter - n)]] + filler + \
+                    [truncate(dt, k, k_str) for dt in data[-n:]]
+            return [truncate(dt, k, k_str) for dt in data[:(k_iter - n)]] + filler
         elif isinstance(data, set):
-            return set(list(data)[:(k-n)] + filler + list(data)[-n:]) if n else set(list(data)[:(k-n)] + filler)
+            if n:
+                return set([truncate(dt, k, k_str) for dt in list(data)[:(k_iter - n)]] + filler + \
+                           [truncate(dt, k, k_str) for dt in list(data)[-n:]])
+            return set([truncate(dt, k, k_str) for dt in list(data)[:(k_iter - n)]] + filler)
         return data
     return data
 
@@ -362,7 +369,8 @@ def sample(
     return result
 
 
-def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 5, truncate_k_str_multiplier: int = 10, p_print: bool = True):
+def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, truncate_k: int = 6, truncate_k_str: int = 20,
+                     p_print: bool = True):
     """
     Samples then (p)prints a truncated version of the sample. Helpful for visualizing data structures.
     Args:
@@ -370,12 +378,12 @@ def visualize_sample(v: Sequence, k: int = None, is_random: bool = False, trunca
         k: number of samples
         is_random: should shuffle
         truncate_k: how many items to keep in the truncated version of the sample
-        truncate_k_str_multiplier: k multiplier for string data
+        truncate_k_str_multiplier: k multiplier for string data; if you do not want to truncate strings, use `0`
         p_print: should pprint or print
     """
 
-    obj_sample = sample(v=v, k=k, is_random=is_random)
-    truncated_sample = truncate(obj_sample, truncate_k, truncate_k_str_multiplier)
+    obj_sample = sample(v=copy(v), k=k, is_random=is_random)
+    truncated_sample = truncate(obj_sample, truncate_k, truncate_k_str)
     if p_print:
         pprint(truncated_sample)
     else:
@@ -504,7 +512,7 @@ def import_string(dotted_path):
         return getattr(module, class_name)
     except AttributeError as err:
         raise ImportError(
-                f"Module {module_path} does not define a {class_name} attribute/class"
+            f"Module {module_path} does not define a {class_name} attribute/class"
         ) from err
 
 
@@ -576,7 +584,7 @@ def module_references(instance: types.ModuleType, **kwargs) -> dict:
     :return: List[str]
     """
     assert isinstance(
-            instance, types.ModuleType
+        instance, types.ModuleType
     ), "You need to submit a module instance."
     logger.debug(f"Checking module {instance.__name__}")
     definitions = {}
@@ -704,7 +712,7 @@ if __name__ == '__main__':
     @property
     def _instance_obj_attrs(self):
         return filter(
-                lambda attr_: attr_.__contains__("__") is False, dir(self._instance_obj)
+            lambda attr_: attr_.__contains__("__") is False, dir(self._instance_obj)
         )
 
     def _get_attr_obj(self, attr_: str):
@@ -801,7 +809,7 @@ if __name__ == '__main__':
 
     def _valid_attr(self, attr_name: str):
         assert hasattr(
-                self._instance_obj, attr_name
+            self._instance_obj, attr_name
         ), f"{self.__prefix_attr_err.format(attr_=repr(attr_name))} isn't defined."
         return attr_name
 
@@ -833,11 +841,11 @@ if __name__ == '__main__':
     @classmethod
     def _get_class_test(cls, ref):
         func_tests = "".join(
-                cls.__template_unittest_function.format(func_name=i)
-                for i in list_methods(ref)
+            cls.__template_unittest_function.format(func_name=i)
+            for i in list_methods(ref)
         )
         return cls.__template_unittest_class.format(
-                class_name=ref.__name__, func_tests=func_tests
+            class_name=ref.__name__, func_tests=func_tests
         )
 
     @classmethod
@@ -871,7 +879,7 @@ if __name__ == '__main__':
             module_func_test = "".join(module_func_test)
             tests = [
                         cls.__template_unittest_class.format(
-                                class_name="Module", func_tests=module_func_test
+                            class_name="Module", func_tests=module_func_test
                         )
                     ] + tests
         return cls.__template_unittest.format(tests="\n".join(tests))
@@ -1002,7 +1010,7 @@ def rescale_values(
             result = list(_rescale_down(values, granularity))
         else:
             result = list(
-                    _rescale_up(values, granularity, fill_with=fill_with, filling=filling)
+                _rescale_up(values, granularity, fill_with=fill_with, filling=filling)
             )
 
     assert (
@@ -1103,7 +1111,7 @@ def sort_dict(
 
 def list_to_tuple(obj):
     assert isinstance(
-            obj, (list, set, tuple)
+        obj, (list, set, tuple)
     ), f"Isn't possible convert {type(obj)} into {tuple}"
     result = []
     for i in obj:
@@ -1126,7 +1134,7 @@ def dict_values_len(obj, max_len=None, min_len=None, take_len=False):
 
 def dict_to_tuple(obj):
     assert isinstance(
-            obj, (dict, set)
+        obj, (dict, set)
     ), f"Isn't possible convert {type(obj)} into {tuple}"
     result = []
     if isinstance(obj, set):
@@ -1258,7 +1266,7 @@ def get_batch_strides(data, kernel_size, strides=1, fill_=True, take_index=False
             batches = batches[strides:]
     if len(batches):
         yield rescale_values(
-                batches, granularity=kernel_size, filling="post"
+            batches, granularity=kernel_size, filling="post"
         ) if fill_ else batches
 
 

--- a/tests/testsutils.py
+++ b/tests/testsutils.py
@@ -283,16 +283,16 @@ class UtilsTest(unittest.TestCase):
         pass
 
     def test_truncate(self):
-        self.assertEqual(utils.truncate("Cereja is fun.", k=3), "Ce….")
+        self.assertEqual(utils.truncate("Cereja is fun.", k_str=3), "Ce….")
         self.assertEqual(utils.truncate(b"Cereja is fun.", k=3), b"Ce....")
         self.assertRaises(AssertionError, utils.truncate, "Cereja is fun.", -1)
-        self.assertEqual(utils.truncate("Cereja is fun.", k=1000), "Cereja is fun.")
-        self.assertEqual(utils.truncate("Cereja is fun.", k=10), "Cerej… fun.")
+        self.assertEqual(utils.truncate(["Cereja is fun."], k=1000), ["Cereja is fun."])
+        self.assertEqual(utils.truncate("Cereja is fun.", k_str=10), "Cerej… fun.")
 
-        self.assertEqual(utils.truncate([0, 1, 2, 3], k=3), [0, 1, '…', 3])
+        self.assertEqual(utils.truncate([0, 1, 2, 3], k=3), [0, 1, '<…>', 3])
         self.assertRaises(AssertionError, utils.truncate, [0, 1, 2, 3], -1)
         self.assertEqual(utils.truncate([0, 1, 2, 3], k=1000), [0, 1, 2, 3])
-        self.assertEqual(utils.truncate(list(range(50)), k=5), [0, 1, 2, '…', 48, 49])
+        self.assertEqual(utils.truncate(list(range(50)), k=5), [0, 1, 2, '<…>', 48, 49])
 
     def test_type_table_of(self):
         pass

--- a/tests/testsutils.py
+++ b/tests/testsutils.py
@@ -284,15 +284,15 @@ class UtilsTest(unittest.TestCase):
 
     def test_truncate(self):
         self.assertEqual(utils.truncate("Cereja is fun.", k_str=3), "Ce….")
-        self.assertEqual(utils.truncate(b"Cereja is fun.", k=3), b"Ce....")
+        self.assertEqual(utils.truncate(b"Cereja is fun.", k_iter=3), b"Ce....")
         self.assertRaises(AssertionError, utils.truncate, "Cereja is fun.", -1)
-        self.assertEqual(utils.truncate(["Cereja is fun."], k=1000), ["Cereja is fun."])
+        self.assertEqual(utils.truncate(["Cereja is fun."], k_iter=1000), ["Cereja is fun."])
         self.assertEqual(utils.truncate("Cereja is fun.", k_str=10), "Cerej… fun.")
 
-        self.assertEqual(utils.truncate([0, 1, 2, 3], k=3), [0, 1, '<…>', 3])
+        self.assertEqual(utils.truncate([0, 1, 2, 3], k_iter=3), [0, 1, '<…>', 3])
         self.assertRaises(AssertionError, utils.truncate, [0, 1, 2, 3], -1)
-        self.assertEqual(utils.truncate([0, 1, 2, 3], k=1000), [0, 1, 2, 3])
-        self.assertEqual(utils.truncate(list(range(50)), k=5), [0, 1, 2, '<…>', 48, 49])
+        self.assertEqual(utils.truncate([0, 1, 2, 3], k_iter=1000), [0, 1, 2, 3])
+        self.assertEqual(utils.truncate(list(range(50)), k_iter=5), [0, 1, 2, '<…>', 48, 49])
 
     def test_type_table_of(self):
         pass

--- a/tests/testsutils.py
+++ b/tests/testsutils.py
@@ -283,13 +283,16 @@ class UtilsTest(unittest.TestCase):
         pass
 
     def test_truncate(self):
-        self.assertEqual(utils.truncate("Cereja is fun.", k=3), "Cereja is fun.")
-        self.assertEqual(utils.truncate(b"Cereja is fun.", k=3), b"Cereja is fun.")
-        self.assertEqual(utils.truncate("Cereja is fun.", k=-1), "Cereja is fun.")
+        self.assertEqual(utils.truncate("Cereja is fun.", k=3), "Ce….")
+        self.assertEqual(utils.truncate(b"Cereja is fun.", k=3), b"Ce....")
+        self.assertRaises(AssertionError, utils.truncate, "Cereja is fun.", -1)
         self.assertEqual(utils.truncate("Cereja is fun.", k=1000), "Cereja is fun.")
-        self.assertEqual(utils.truncate("Cereja is fun.", k=10), "Cer....un.")
+        self.assertEqual(utils.truncate("Cereja is fun.", k=10), "Cerej… fun.")
 
-        self.assertRaises(AssertionError, utils.truncate, 1123)
+        self.assertEqual(utils.truncate([0, 1, 2, 3], k=3), [0, 1, '…', 3])
+        self.assertRaises(AssertionError, utils.truncate, [0, 1, 2, 3], -1)
+        self.assertEqual(utils.truncate([0, 1, 2, 3], k=1000), [0, 1, 2, 3])
+        self.assertEqual(utils.truncate(list(range(50)), k=5), [0, 1, 2, '…', 48, 49])
 
     def test_type_table_of(self):
         pass


### PR DESCRIPTION
This merge changes some parameter names and how they are treated (for example, k_str_multiplier --> k_str, k --> k_iter), and also allows truncating the number of keys in dictionaries, which is useful when the data to be visualized by `visualize_sample` contains ids as dict keys.