### PR TITLE
test: fill empty hashtools tests and add md5/random_hash coverage

### DIFF
--- a/tests/testhashtools.py
+++ b/tests/testhashtools.py
@@ -1,4 +1,5 @@
 import unittest
+import hashlib
 from cereja import hashtools
 
 
@@ -24,11 +25,53 @@ class HashtoolsTest(unittest.TestCase):
             hashtools.base64_encode({"oi": "tudo bem"}), b"eydvaSc6ICd0dWRvIGJlbSd9"
         )
 
-    def test_is_base64(self):
-        pass
+    def test_is_base64_valid(self):
+        # Valid base64 strings
+        self.assertTrue(hashtools.is_base64(b"YWJjZGVmIGcgaCBpIGo="))
+        self.assertTrue(hashtools.is_base64(b"SGVsbG8gV29ybGQ="))
+        self.assertTrue(hashtools.is_base64(b""))  # empty is valid base64
 
-    def test_md5(self):
-        pass
+    def test_is_base64_invalid(self):
+        # Invalid base64 (bad padding, invalid chars)
+        self.assertFalse(hashtools.is_base64(b"not-valid-base64!!!"))
+
+    def test_md5_string(self):
+        expected = hashlib.md5(b"hello").hexdigest()
+        self.assertEqual(hashtools.md5("hello"), expected)
+
+    def test_md5_number(self):
+        expected = hashlib.md5(b"42").hexdigest()
+        self.assertEqual(hashtools.md5(42), expected)
+
+    def test_md5_dict(self):
+        d = {"key": "value"}
+        expected = hashlib.md5(repr(d).encode()).hexdigest()
+        self.assertEqual(hashtools.md5(d), expected)
+
+    def test_md5_list(self):
+        lst = [1, 2, 3]
+        expected = hashlib.md5(repr(lst).encode()).hexdigest()
+        self.assertEqual(hashtools.md5(lst), expected)
+
+    def test_md5_consistency(self):
+        # Same input always produces same hash
+        self.assertEqual(hashtools.md5("test"), hashtools.md5("test"))
+
+    def test_md5_different_inputs(self):
+        self.assertNotEqual(hashtools.md5("hello"), hashtools.md5("world"))
+
+    def test_random_hash_length(self):
+        h = hashtools.random_hash(16)
+        self.assertEqual(len(h), 32)  # hex: 16 bytes = 32 chars
+
+    def test_random_hash_uniqueness(self):
+        h1 = hashtools.random_hash(16)
+        h2 = hashtools.random_hash(16)
+        self.assertNotEqual(h1, h2)
+
+    def test_random_hash_is_hex(self):
+        h = hashtools.random_hash(8)
+        int(h, 16)  # Should not raise ValueError
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fill the empty `test_is_base64` and `test_md5` test cases in `tests/testhashtools.py` and add new tests for `random_hash`.

### Before

```python
def test_is_base64(self):
    pass  # empty

def test_md5(self):
    pass  # empty
```

### After (13 tests total, was 4 with 2 empty)

| Test | What it verifies |
|------|-----------------|
| `test_is_base64_valid` | Valid base64 strings return True |
| `test_is_base64_invalid` | Invalid base64 returns False |
| `test_md5_string` | MD5 of string matches hashlib directly |
| `test_md5_number` | MD5 of int uses repr() encoding |
| `test_md5_dict` | MD5 of dict uses repr() encoding |
| `test_md5_list` | MD5 of list uses repr() encoding |
| `test_md5_consistency` | Same input always produces same hash |
| `test_md5_different_inputs` | Different inputs produce different hashes |
| `test_random_hash_length` | 16 bytes produces 32 hex chars |
| `test_random_hash_uniqueness` | Two calls produce different values |
| `test_random_hash_is_hex` | Output is valid hexadecimal |

No changes to source code — tests only. Partially addresses #217.