### PR TITLE
chore: update minimum Python version to 3.9 and add 3.12/3.13 classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,14 @@ description = "Cereja is a bundle of useful functions that I don't want to rewri
 readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["progress bar", "utils", "array", "pln", "file utils"]
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary

Update `pyproject.toml` to reflect the actual supported Python versions.

### Changes

- `requires-python`: `>=3.6` -> `>=3.9`
- Remove EOL classifiers: 3.6 (EOL Dec 2021), 3.7 (EOL Jun 2023), 3.8 (EOL Oct 2024)
- Add classifiers: 3.12, 3.13

### Why

- Python 3.6, 3.7, and 3.8 are all past end-of-life and no longer receive security patches
- The CI test matrix already only tests 3.9, 3.10, 3.11
- The codebase uses f-strings (3.6+), `asyncio.run()` (3.7+), and `contextvars` (3.7+), so 3.6 was already not truly supported
- Accurate metadata helps `pip` give better error messages when users on old Python try to install