### PR TITLE
fix: remove duplicate import, debug print, and hardcoded Portuguese strings

### DIFF
--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -32,7 +32,6 @@ from . import array
 from .array import *
 from . import system
 from .system import *
-from .system.unicode import *
 from .utils import decorators
 from .concurrently import *
 from . import mltools

--- a/cereja/_requests/_http.py
+++ b/cereja/_requests/_http.py
@@ -261,7 +261,6 @@ class HttpRequest(_Http):
     @classmethod
     def get_proxies_list(cls):
         if cls.PROXIES:
-            print("já tem proxies")
             return cls.PROXIES
         try:
             cls.PROXIES = json.loads(cls("GET", PROXIES_URL).send_request().data)

--- a/cereja/concurrently/process.py
+++ b/cereja/concurrently/process.py
@@ -287,12 +287,12 @@ class Processor:
             return result
         except Exception as exc:
             print(
-                    f"Falha ao processa dado, mas será armazenado para conferência.\n"
+                    f"Failed to process item, storing for review.\n"
                     f"Error: {exc}")
             self._failure_data.append(item)
 
     def get_status(self):
-        return f"{round(self.total_processed / (time.monotonic() - self._started_at), 2)} cpf/s " \
+        return f"{round(self.total_processed / (time.monotonic() - self._started_at), 2)} items/s " \
                f"- processing: {self.in_progress_count} " \
                f"- success: {self._total_success} " \
                f"- fail: {len(self._failure_data)} "
@@ -312,7 +312,7 @@ class Processor:
             self._progress.start()
 
         with ThreadPoolExecutor(max_workers=self._num_workers,
-                                thread_name_prefix="CPF_PROCESS_WORKER") as self._executor:
+                                thread_name_prefix="PROCESS_WORKER") as self._executor:
             for item in data:
                 start_time = time.monotonic()
 
@@ -326,7 +326,7 @@ class Processor:
                     time.sleep(self.interval_seconds - elapsed_time)
                 if self.in_progress_count >= self._max_in_progress:
                     print(
-                        f"O Total de dados sendo processado {self.in_progress_count} é maior que o predefinido {self._max_in_progress}")
+                        f"In-progress count {self.in_progress_count} exceeds limit {self._max_in_progress}")
                     while self.in_progress_count >= self._max_in_progress * 0.9:
                         time.sleep(0.05)
                         if self.stopped:


### PR DESCRIPTION
## Summary

Small cleanup of dead code, debug output, and hardcoded Portuguese strings.

### Changes

| File | What | Before | After |
|------|------|--------|-------|
| `cereja/__init__.py` | Duplicate import | `from .system.unicode import *` appears on lines 35 and 41 | Removed line 35 duplicate |
| `cereja/_requests/_http.py:264` | Debug print | `print("já tem proxies")` | Removed |
| `cereja/concurrently/process.py:290` | Portuguese string | `"Falha ao processa dado..."` | `"Failed to process item..."` |
| `cereja/concurrently/process.py:295` | Domain-specific unit | `"cpf/s"` | `"items/s"` |
| `cereja/concurrently/process.py:315` | Thread prefix | `"CPF_PROCESS_WORKER"` | `"PROCESS_WORKER"` |
| `cereja/concurrently/process.py:329` | Portuguese string | `"O Total de dados..."` | `"In-progress count..."` |

### Why

- The duplicate import wastes namespace and can confuse static analysis tools
- Debug prints should not be in library code (users see them unexpectedly)
- An international library should use English for log/error messages
- `"cpf/s"` and `"CPF_PROCESS_WORKER"` were leftover from a specific use case and don't belong in a general-purpose library

All 220 tests pass. Partially addresses #216.