### PR TITLE
feat: add type hints to hashtools and _requests modules

### DIFF
--- a/cereja/_requests/_http.py
+++ b/cereja/_requests/_http.py
@@ -21,6 +21,7 @@ SOFTWARE.
 """
 import threading
 import time
+from typing import Any, Dict, Optional, Tuple
 from urllib import request as urllib_req
 import json
 import io
@@ -36,10 +37,10 @@ from cereja import Progress
 
 class _Http:
     def __init__(self,
-                 url,
-                 data=None,
-                 headers=None,
-                 port=None):
+                 url: str,
+                 data: Any = None,
+                 headers: Optional[Dict[str, str]] = None,
+                 port: Optional[int] = None) -> None:
         self.headers = headers or {}
         self._protocol, self._port, self._domains, self._endpoint = self.parse_url(
                 url=url, port=port
@@ -47,7 +48,7 @@ class _Http:
         self._data = data or None
 
     @staticmethod
-    def is_url(val):
+    def is_url(val: Any) -> bool:
         try:
             result = urlparse(val)
             return all([result.scheme, result.netloc])
@@ -55,43 +56,43 @@ class _Http:
             return False
 
     @property
-    def protocol(self):
+    def protocol(self) -> str:
         return self._protocol
 
     @property
-    def port(self):
+    def port(self) -> Any:
         return self._port
 
     @property
-    def domains(self):
+    def domains(self) -> str:
         return self._domains
 
     @property
-    def endpoint(self):
+    def endpoint(self) -> str:
         return self._endpoint
 
     @property
-    def data(self):
+    def data(self) -> Any:
         return self._data
 
     @property
-    def url(self):
+    def url(self) -> str:
         port = f":{self._port}" if self._port else self._port
         endpoint = f"/{self._endpoint}" if self._endpoint else self._endpoint
         return f"{self._protocol}://{self._domains}{port}{endpoint}"
 
     @property
-    def content_type(self):
+    def content_type(self) -> Optional[str]:
         return self.headers.get("Content-type")
 
     @property
-    def content_length(self):
+    def content_length(self) -> Optional[str]:
         return self.headers.get("Content-length")
 
     @classmethod
     def parse_url(cls,
                   url: str,
-                  port=None):
+                  port: Optional[int] = None) -> Tuple[str, Any, str, str]:
 
         url = url.replace("://", ".")
         url = url.split("/", maxsplit=1)

--- a/cereja/hashtools/_hash.py
+++ b/cereja/hashtools/_hash.py
@@ -23,7 +23,7 @@ import binascii
 import hashlib
 import base64 as _b64
 import secrets
-from typing import Union
+from typing import Any, Union
 
 from cereja import string_to_literal
 from cereja.config.cj_types import T_NUMBER
@@ -31,25 +31,33 @@ from cereja.config.cj_types import T_NUMBER
 __all__ = ["md5", "base64_encode", "base64_decode", "is_base64", "random_hash"]
 
 
-def md5(o: Union[list, dict, set, str, T_NUMBER]):
+def md5(o: Union[list, dict, set, str, T_NUMBER]) -> str:
+    """Return the MD5 hex digest of the given object.
+
+    Note: MD5 is not suitable for cryptographic purposes. Use SHA-256
+    or stronger for security-sensitive hashing.
+    """
     if not isinstance(o, str):
         o = repr(o)
     return hashlib.md5(o.encode()).hexdigest()
 
 
-def base64_encode(content) -> bytes:
+def base64_encode(content: Any) -> bytes:
+    """Encode content to base64 bytes."""
     if not isinstance(content, bytes):
         content = str(content).encode()
     return _b64.b64encode(content)
 
 
-def base64_decode(content, eval_str=False):
+def base64_decode(content: Union[str, bytes], eval_str: bool = False) -> Union[bytes, Any]:
+    """Decode base64 content. If eval_str is True, attempt to evaluate the decoded string as a Python literal."""
     decoded_val = _b64.b64decode(content)
     decoded_val = string_to_literal(decoded_val.decode()) if eval_str else decoded_val
     return decoded_val
 
 
-def is_base64(content):
+def is_base64(content: Union[str, bytes]) -> bool:
+    """Check if content is valid base64."""
     try:
         base64_decode(content)
         return True
@@ -57,5 +65,6 @@ def is_base64(content):
         return False
 
 
-def random_hash(n_bytes):
+def random_hash(n_bytes: int) -> str:
+    """Generate a random hex string with n_bytes of randomness."""
     return secrets.token_hex(nbytes=n_bytes)


### PR DESCRIPTION
## Summary

Add return type annotations and parameter type hints to the `hashtools/_hash.py` and `_requests/_http.py` modules.

### Changes

**`hashtools/_hash.py`** — all 5 public functions:
- `md5(o) -> str`
- `base64_encode(content: Any) -> bytes`
- `base64_decode(content, eval_str: bool = False) -> Union[bytes, Any]`
- `is_base64(content: Union[str, bytes]) -> bool`
- `random_hash(n_bytes: int) -> str`
- Added docstring with MD5 security note

**`_requests/_http.py`** — `_Http` class:
- Constructor: full parameter types
- `is_url(val: Any) -> bool`
- `parse_url(url, port) -> Tuple[str, Any, str, str]`
- All properties: `protocol -> str`, `port -> Any`, `url -> str`, `content_type -> Optional[str]`, etc.

### Why

Type hints improve IDE autocompletion, enable static analysis with mypy, and serve as inline documentation. These two modules are among the smallest and most self-contained, making them good starting points.

All 220 tests pass. Partially addresses #217.