### PR TITLE
fix: rename misspelled 'depreciation' decorator to 'deprecation'

### DIFF
--- a/cereja/concurrently/process.py
+++ b/cereja/concurrently/process.py
@@ -79,7 +79,7 @@ class MultiProcess(_IMultiProcess):
         else:
             self._store_response(response)
 
-    @decorators.depreciation(alternative='map')
+    @decorators.deprecation(alternative='map')
     def execute(self, function, values, *args, verbose=True, **kwargs) -> list:
         return self.map(function, values, *args, verbose=verbose, **kwargs)
 

--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -39,7 +39,7 @@ from copy import copy, deepcopy
 import inspect
 from pprint import PrettyPrinter
 
-from .decorators import depreciation
+from .decorators import deprecation
 # Needed init configs
 from ..config.cj_types import T_CLASS, T_FUNC, T_NUMBER
 from itertools import combinations as itertools_combinations
@@ -497,7 +497,7 @@ def camel_case_to_snake(value: str):
     return "".join(snaked_).lower()
 
 
-@depreciation(alternative="camel_case_to_snake")
+@deprecation(alternative="camel_case_to_snake")
 def camel_to_snake(value: str):
     return camel_case_to_snake(value)
 
@@ -1335,7 +1335,7 @@ class SourceCodeAnalyzer:
         FileIO.create(path, self.source_code).save(**kwargs)
 
 
-@depreciation(alternative="SourceCodeAnalyzer")
+@deprecation(alternative="SourceCodeAnalyzer")
 class Source(SourceCodeAnalyzer):
     def __init__(self,
                  reference: Any):

--- a/cereja/utils/decorators.py
+++ b/cereja/utils/decorators.py
@@ -30,7 +30,8 @@ import warnings
 import random
 
 __all__ = [
-    "depreciation",
+    "deprecation",
+    "depreciation",  # backward-compatible alias
     "synchronized",
     "thread_safe_generator",
     "singleton",
@@ -151,7 +152,7 @@ __deprecated = __Deprecated()
 
 
 # Function version
-def depreciation(alternative: str = None):
+def deprecation(alternative: str = None):
     alternative = (
             f"You can use {alternative}" or "There is no alternative to this function"
     )
@@ -171,6 +172,10 @@ def depreciation(alternative: str = None):
         return wrapper
 
     return register
+
+
+# Backward-compatible alias (was misspelled as "depreciation")
+depreciation = deprecation
 
 
 def on_except(return_value=None,


### PR DESCRIPTION
## Summary

Fix the misspelling of the `depreciation` decorator — the correct English term is **deprecation** (marking as obsolete), not "depreciation" (financial devaluation).

### Changes

- Rename `depreciation()` to `deprecation()` in `utils/decorators.py`
- Add backward-compatible alias: `depreciation = deprecation`
- Both names are exported in `__all__`
- Update all internal usages (3 total):
  - `utils/_utils.py:42` — import
  - `utils/_utils.py:500` — `@deprecation(alternative="camel_case_to_snake")`
  - `utils/_utils.py:1338` — `@deprecation(alternative="SourceCodeAnalyzer")`
  - `concurrently/process.py:82` — `@decorators.deprecation(alternative='map')`

### Backward compatibility

The old name `depreciation` continues to work as an alias:

```python
from cereja.utils.decorators import depreciation  # still works
from cereja.utils.decorators import deprecation    # preferred
assert deprecation is depreciation  # True
```

All 220 tests pass.