### PR TITLE
fix: correct swapped ISO 639-1 language mapping

### DIFF
--- a/cereja/mltools/pln.py
+++ b/cereja/mltools/pln.py
@@ -36,7 +36,7 @@ from ..system import Path
 __all__ = ["LanguageData", "Preprocessor", "LanguageDetector"]
 
 _LANGUAGE_ISO_639_2 = {"eng": "English", "por": "Portuguese"}
-_LANGUAGE_ISO_639_1 = {"pt": "English", "en": "Portuguese"}
+_LANGUAGE_ISO_639_1 = {"pt": "Portuguese", "en": "English"}
 
 
 def separate(


### PR DESCRIPTION
## Summary
- Fix `_LANGUAGE_ISO_639_1` dict in `mltools/pln.py` where `"pt"` was mapped to `"English"` and `"en"` to `"Portuguese"` (swapped values)

## Test plan
- Verify that `_LANGUAGE_ISO_639_1["pt"]` returns `"Portuguese"`
- Verify that `_LANGUAGE_ISO_639_1["en"]` returns `"English"`