### PR TITLE
fix: move LanguageDetector mutable state to instance and fix __contains__

### DIFF
--- a/cereja/mltools/pln.py
+++ b/cereja/mltools/pln.py
@@ -207,6 +207,7 @@ class LanguageData(BaseData):
             return True
         if item in self.phrases_freq:
             return True
+        return False
 
     def __repr__(self):
         return f"LanguageData(examples: {len(self)} - vocab_size: {self.vocab_size})"
@@ -312,11 +313,10 @@ class LanguageData(BaseData):
 
 
 class LanguageDetector:
-    __language_data: Dict[str, Union[LanguageData, dict]] = {}
-    __memory = {}
-
     def __init__(self):
         self._is_model = False
+        self.__language_data: Dict[str, Union[LanguageData, dict]] = {}
+        self.__memory = {}
 
     def load(self, filepath: str):
         self._is_model = True


### PR DESCRIPTION
## Summary
- Move `__language_data` and `__memory` from class variables to instance variables in `LanguageDetector.__init__`, preventing all instances from sharing the same mutable state
- Add explicit `return False` to `LanguageData.__contains__` to avoid returning `None` implicitly

## Test plan
- Create two `LanguageDetector` instances and verify they have independent data
- Verify `"word" in language_data` returns `False` (not `None`) when word is not found