### PR TITLE
fix: correct type_table_of dict check and 'Alredy' typo

### DIFF
--- a/cereja/utils/_utils.py
+++ b/cereja/utils/_utils.py
@@ -479,7 +479,7 @@ def type_table_of(o: Union[list, tuple, dict]):
     elif isinstance(o, dict):
         type_table = {}
         for k, v in o.items():
-            if isinstance(o, dict):
+            if isinstance(v, dict):
                 v = type_table_of(v)
             type_table[k] = (v, type(v))
     else:
@@ -742,7 +742,7 @@ def install_if_not(lib_name: str):
 
     try:
         importlib.import_module(lib_name)
-        output = "Alredy Installed"
+        output = "Already Installed"
     except ImportError:
         from ..system.commons import run_on_terminal
 


### PR DESCRIPTION
## Summary
- Fix `isinstance(o, dict)` which should be `isinstance(v, dict)` inside `type_table_of`, causing infinite recursion on the outer dict instead of recursing into nested dict values
- Fix `"Alredy Installed"` -> `"Already Installed"` typo in `install_if_not`

## Test plan
- Verify `type_table_of({"a": {"b": 1}})` correctly recurses into nested dicts
- Verify `install_if_not` shows correct spelling