### PR TITLE
fix: add functools.wraps to all decorators missing it

### DIFF
--- a/cereja/utils/decorators.py
+++ b/cereja/utils/decorators.py
@@ -52,6 +52,7 @@ _exclude = ["BaseDecorator", "Decorator", "logger"]
 def synchronized(func):
     func.__lock__ = threading.Lock()
 
+    @functools.wraps(func)
     def synced_func(*args,
                     **kws):
         with func.__lock__:
@@ -61,6 +62,7 @@ def synchronized(func):
 
 
 def use_thread(func):
+    @functools.wraps(func)
     def threaded_func(*args,
                       **kws):
         th = threading.Thread(target=func, args=args, kwargs=kws)
@@ -85,6 +87,7 @@ class _ThreadSafeIterator:
 
 
 def thread_safe_generator(func):
+    @functools.wraps(func)
     def gen(*a,
             **kw):
         return _ThreadSafeIterator(func(*a, **kw))
@@ -157,6 +160,7 @@ def depreciation(alternative: str = None):
     )
 
     def register(func):
+        @functools.wraps(func)
         def wrapper(*args,
                     **kwargs):
             warnings.warn(
@@ -176,6 +180,7 @@ def depreciation(alternative: str = None):
 def on_except(return_value=None,
               warn_text=None):
     def register(func):
+        @functools.wraps(func)
         def wrapper(*args,
                     **kwargs):
             try:
@@ -196,6 +201,7 @@ def retry_on_failure(retries: int = 3,
                      exceptions: tuple = (Exception,),
                      verbose: bool = False):
     def register(func):
+        @functools.wraps(func)
         def wrapper(*args,
                     **kwargs):
             delay = initial_delay


### PR DESCRIPTION
## Summary
- Add `@functools.wraps(func)` to `synchronized`, `use_thread`, `thread_safe_generator`, `depreciation`, `on_except`, and `retry_on_failure` decorators
- Without it, decorated functions lose their `__name__`, `__doc__`, and `__module__` attributes

## Test plan
- Verify that a function decorated with each decorator preserves its `__name__` and `__doc__`