### PR TITLE
V2.1.4

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade build

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ CMakeLists.txt
 MANIFEST.in
 *.png
 /local
+.ai

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ MANIFEST.in
 *.png
 /local
 .ai
+.aiassistant
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) 💻
 
 ## Setup
 
-* [Python 3.6+](https://www.python.org/downloads/ "Download python")
+* [Python 3.11+](https://www.python.org/downloads/ "Download python")
 * [Pip3](https://pip.pypa.io "Download Pip")
 
 ## Install

--- a/cereja/__init__.py
+++ b/cereja/__init__.py
@@ -51,7 +51,7 @@ from . import scraping
 from . import wcag
 from .utils import time
 
-VERSION = "2.1.3.final.0"
+VERSION = "2.1.4.final.0"
 
 __version__ = get_version_pep440_compliant(VERSION)
 

--- a/cereja/__main__.py
+++ b/cereja/__main__.py
@@ -1,47 +1,6 @@
-"""
-
-Copyright (c) 2019 The Cereja Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-import argparse
 import sys
-from cereja import get_version_pep440_compliant, Path
-from cereja.config import BASE_DIR
-from cereja.file import FileIO
+
+from cereja.cli import main
 
 if __name__ == "__main__":
-    sys.stdout.write("\U0001F352 Cereja Tools\n")
-    sys.stdout.flush()
-    parser = argparse.ArgumentParser(description="Cereja Tools.")
-    parser.add_argument(
-            "--version", action="version", version=get_version_pep440_compliant()
-    )
-    parser.add_argument("--startmodule", type=str)
-    args = parser.parse_args()
-    if args.startmodule:
-        base_dir = Path(BASE_DIR)
-        license_ = b"".join(FileIO.load(base_dir.parent.join("LICENSE")).data).decode()
-        license_ = '"""\n' + license_ + '"""'
-        new_module_path = base_dir.join(*args.startmodule.split("/"))
-        if new_module_path.parent.exists and new_module_path.parent.is_dir:
-            FileIO.create(new_module_path, license_).save()
-        else:
-            print(f"{new_module_path} is not valid.")
+    sys.exit(main())

--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -40,6 +40,7 @@ from cereja.hashtools import (
     decompress_file,
     decrypt_file,
     encrypt_file,
+    is_encrypted_archive,
 )
 
 COMPRESSION_STRATEGIES = (
@@ -97,6 +98,8 @@ def create_parser() -> argparse.ArgumentParser:
         help="Compression strategy.",
     )
     compress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    compress_parser.add_argument("--quiet", action="store_true", help="Disable progress output.")
+    compress_parser.add_argument("--encrypt", action="store_true", help="Encrypt the compressed archive.")
     compress_parser.set_defaults(handler=_handle_compress)
 
     decompress_parser = subparsers.add_parser("decompress", help="Decompress a file or directory archive.")
@@ -109,6 +112,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="Archive type to decompress.",
     )
     decompress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    decompress_parser.add_argument("--quiet", action="store_true", help="Disable progress output.")
     decompress_parser.set_defaults(handler=_handle_decompress)
 
     encrypt_parser = subparsers.add_parser("encrypt", help="Encrypt a file.")
@@ -128,28 +132,57 @@ def create_parser() -> argparse.ArgumentParser:
 
 def _handle_compress(args: argparse.Namespace) -> int:
     input_path = Path(args.input)
+    verbose = not args.quiet
+    password = _prompt_new_password() if args.encrypt else None
     if input_path.is_dir():
-        output_path = Path(args.output) if args.output else Path(str(input_path).rstrip("/\\") + ".cjz")
+        output_path = _compressed_dir_output(input_path, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path, stats = compress_dir(str(input_path), str(output_path), strategy=args.strategy)
+        if password is None:
+            result_path, stats = compress_dir(str(input_path), str(output_path), strategy=args.strategy, verbose=verbose)
+        else:
+            result_path, stats = compress_dir(
+                str(input_path),
+                str(output_path),
+                strategy=args.strategy,
+                verbose=verbose,
+                password=password,
+            )
     else:
-        output_path = Path(args.output) if args.output else Path(str(input_path) + ".cjz")
+        output_path = _compressed_file_output(input_path, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path, stats = compress_file(str(input_path), str(output_path), strategy=args.strategy)
+        if password is None:
+            result_path, stats = compress_file(str(input_path), str(output_path), strategy=args.strategy, verbose=verbose)
+        else:
+            result_path, stats = compress_file(
+                str(input_path),
+                str(output_path),
+                strategy=args.strategy,
+                verbose=verbose,
+                password=password,
+            )
 
     _print_compression_result(result_path, stats)
     return 0
 
 
 def _handle_decompress(args: argparse.Namespace) -> int:
+    verbose = not args.quiet
     if args.archive_type == "file":
         output_path = _decompressed_file_output(args.input, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path = decompress_file(args.input, str(output_path))
+        password = _prompt_existing_password(args.input)
+        if password is None:
+            result_path = decompress_file(args.input, str(output_path), verbose=verbose)
+        else:
+            result_path = decompress_file(args.input, str(output_path), verbose=verbose, password=password)
     elif args.archive_type == "dir":
         output_path = _decompressed_dir_output(args.input, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path = decompress_dir(args.input, str(output_path))
+        password = _prompt_existing_password(args.input)
+        if password is None:
+            result_path = decompress_dir(args.input, str(output_path), verbose=verbose)
+        else:
+            result_path = decompress_dir(args.input, str(output_path), verbose=verbose, password=password)
     else:
         result_path = _decompress_auto(args)
 
@@ -181,16 +214,59 @@ def _handle_decrypt(args: argparse.Namespace) -> int:
     return 0
 
 
-def _decompress_auto(args: argparse.Namespace) -> str:
+def _decompress_auto(args: argparse.Namespace, password: Optional[str] = None) -> str:
     file_output = _decompressed_file_output(args.input, args.output)
     _ensure_output_available(file_output, args.force)
+    verbose = not args.quiet
+    if password is None:
+        password = _prompt_existing_password(args.input)
 
     try:
-        return decompress_file(args.input, str(file_output))
+        if password is None:
+            return decompress_file(args.input, str(file_output), verbose=verbose)
+        return decompress_file(args.input, str(file_output), verbose=verbose, password=password)
     except CompressionError:
         dir_output = _decompressed_dir_output(args.input, args.output)
         _ensure_output_available(dir_output, args.force)
-        return decompress_dir(args.input, str(dir_output))
+        if password is None:
+            return decompress_dir(args.input, str(dir_output), verbose=verbose)
+        return decompress_dir(args.input, str(dir_output), verbose=verbose, password=password)
+
+
+def _prompt_new_password() -> str:
+    password = getpass.getpass("Password: ")
+    confirmation = getpass.getpass("Confirm password: ")
+    if password != confirmation:
+        raise CliError("Password confirmation does not match.")
+    return password
+
+
+def _prompt_existing_password(input_path: str) -> Optional[str]:
+    if not is_encrypted_archive(input_path):
+        return None
+    return getpass.getpass("Password: ")
+
+
+def _ensure_cjz_suffix(output_path: Path) -> Path:
+    if output_path.suffix:
+        return output_path
+    return output_path.with_name(output_path.name + ".cjz")
+
+
+def _compressed_dir_output(input_path: Path, output_path: Optional[str]) -> Path:
+    if output_path:
+        return _ensure_cjz_suffix(Path(output_path))
+
+    if str(input_path) in (".", ""):
+        return Path(input_path.resolve().name + ".cjz")
+
+    return Path(str(input_path).rstrip("/\\") + ".cjz")
+
+
+def _compressed_file_output(input_path: Path, output_path: Optional[str]) -> Path:
+    if output_path:
+        return _ensure_cjz_suffix(Path(output_path))
+    return Path(str(input_path) + ".cjz")
 
 
 def _decompressed_file_output(input_path: str, output_path: Optional[str]) -> Path:

--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -97,6 +97,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="Compression strategy.",
     )
     compress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    compress_parser.add_argument("--quiet", action="store_true", help="Disable progress output.")
     compress_parser.set_defaults(handler=_handle_compress)
 
     decompress_parser = subparsers.add_parser("decompress", help="Decompress a file or directory archive.")
@@ -109,6 +110,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="Archive type to decompress.",
     )
     decompress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    decompress_parser.add_argument("--quiet", action="store_true", help="Disable progress output.")
     decompress_parser.set_defaults(handler=_handle_decompress)
 
     encrypt_parser = subparsers.add_parser("encrypt", help="Encrypt a file.")
@@ -128,28 +130,30 @@ def create_parser() -> argparse.ArgumentParser:
 
 def _handle_compress(args: argparse.Namespace) -> int:
     input_path = Path(args.input)
+    verbose = not args.quiet
     if input_path.is_dir():
-        output_path = Path(args.output) if args.output else Path(str(input_path).rstrip("/\\") + ".cjz")
+        output_path = _compressed_dir_output(input_path, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path, stats = compress_dir(str(input_path), str(output_path), strategy=args.strategy)
+        result_path, stats = compress_dir(str(input_path), str(output_path), strategy=args.strategy, verbose=verbose)
     else:
-        output_path = Path(args.output) if args.output else Path(str(input_path) + ".cjz")
+        output_path = _compressed_file_output(input_path, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path, stats = compress_file(str(input_path), str(output_path), strategy=args.strategy)
+        result_path, stats = compress_file(str(input_path), str(output_path), strategy=args.strategy, verbose=verbose)
 
     _print_compression_result(result_path, stats)
     return 0
 
 
 def _handle_decompress(args: argparse.Namespace) -> int:
+    verbose = not args.quiet
     if args.archive_type == "file":
         output_path = _decompressed_file_output(args.input, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path = decompress_file(args.input, str(output_path))
+        result_path = decompress_file(args.input, str(output_path), verbose=verbose)
     elif args.archive_type == "dir":
         output_path = _decompressed_dir_output(args.input, args.output)
         _ensure_output_available(output_path, args.force)
-        result_path = decompress_dir(args.input, str(output_path))
+        result_path = decompress_dir(args.input, str(output_path), verbose=verbose)
     else:
         result_path = _decompress_auto(args)
 
@@ -184,13 +188,36 @@ def _handle_decrypt(args: argparse.Namespace) -> int:
 def _decompress_auto(args: argparse.Namespace) -> str:
     file_output = _decompressed_file_output(args.input, args.output)
     _ensure_output_available(file_output, args.force)
+    verbose = not args.quiet
 
     try:
-        return decompress_file(args.input, str(file_output))
+        return decompress_file(args.input, str(file_output), verbose=verbose)
     except CompressionError:
         dir_output = _decompressed_dir_output(args.input, args.output)
         _ensure_output_available(dir_output, args.force)
-        return decompress_dir(args.input, str(dir_output))
+        return decompress_dir(args.input, str(dir_output), verbose=verbose)
+
+
+def _ensure_cjz_suffix(output_path: Path) -> Path:
+    if output_path.suffix:
+        return output_path
+    return output_path.with_name(output_path.name + ".cjz")
+
+
+def _compressed_dir_output(input_path: Path, output_path: Optional[str]) -> Path:
+    if output_path:
+        return _ensure_cjz_suffix(Path(output_path))
+
+    if str(input_path) in (".", ""):
+        return Path(input_path.resolve().name + ".cjz")
+
+    return Path(str(input_path).rstrip("/\\") + ".cjz")
+
+
+def _compressed_file_output(input_path: Path, output_path: Optional[str]) -> Path:
+    if output_path:
+        return _ensure_cjz_suffix(Path(output_path))
+    return Path(str(input_path) + ".cjz")
 
 
 def _decompressed_file_output(input_path: str, output_path: Optional[str]) -> Path:

--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -1,0 +1,244 @@
+"""
+Command-line interface for Cereja.
+
+Copyright (c) 2019 The Cereja Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from cereja import get_version_pep440_compliant
+from cereja.config import BASE_DIR
+from cereja.file import FileIO
+from cereja.hashtools import (
+    CompressionError,
+    CryptoError,
+    compress_dir,
+    compress_file,
+    decompress_dir,
+    decompress_file,
+    decrypt_file,
+    encrypt_file,
+)
+
+COMPRESSION_STRATEGIES = (
+    "auto",
+    "dict",
+    "rle",
+    "delta",
+    "bitpack",
+    "zlib",
+    "bz2",
+    "lzma",
+    "hybrid",
+)
+
+
+class CliError(Exception):
+    """Raised for expected command-line usage errors."""
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the Cereja command-line interface."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.startmodule:
+            return _start_module(args.startmodule)
+
+        command = getattr(args, "command", None)
+        if command is None:
+            parser.print_help()
+            return 0
+
+        return args.handler(args)
+    except (CliError, CompressionError, CryptoError, FileNotFoundError, NotADirectoryError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser used by the CLI."""
+    parser = argparse.ArgumentParser(prog="cereja", description="Cereja Tools.")
+    parser.add_argument("--version", action="version", version=get_version_pep440_compliant())
+    parser.add_argument("--startmodule", type=str, help="Scaffold a new Cereja module.")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    compress_parser = subparsers.add_parser("compress", help="Compress a file or directory.")
+    compress_parser.add_argument("input", help="File or directory to compress.")
+    compress_parser.add_argument("-o", "--output", help="Output path.")
+    compress_parser.add_argument(
+        "--strategy",
+        choices=COMPRESSION_STRATEGIES,
+        default="auto",
+        help="Compression strategy.",
+    )
+    compress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    compress_parser.set_defaults(handler=_handle_compress)
+
+    decompress_parser = subparsers.add_parser("decompress", help="Decompress a file or directory archive.")
+    decompress_parser.add_argument("input", help="Compressed file or directory archive.")
+    decompress_parser.add_argument("-o", "--output", help="Output path.")
+    decompress_parser.add_argument(
+        "--archive-type",
+        choices=("auto", "file", "dir"),
+        default="auto",
+        help="Archive type to decompress.",
+    )
+    decompress_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    decompress_parser.set_defaults(handler=_handle_decompress)
+
+    encrypt_parser = subparsers.add_parser("encrypt", help="Encrypt a file.")
+    encrypt_parser.add_argument("input", help="File to encrypt.")
+    encrypt_parser.add_argument("-o", "--output", help="Output path.")
+    encrypt_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    encrypt_parser.set_defaults(handler=_handle_encrypt)
+
+    decrypt_parser = subparsers.add_parser("decrypt", help="Decrypt a file.")
+    decrypt_parser.add_argument("input", help="File to decrypt.")
+    decrypt_parser.add_argument("-o", "--output", help="Output path.")
+    decrypt_parser.add_argument("--force", action="store_true", help="Overwrite existing output.")
+    decrypt_parser.set_defaults(handler=_handle_decrypt)
+
+    return parser
+
+
+def _handle_compress(args: argparse.Namespace) -> int:
+    input_path = Path(args.input)
+    if input_path.is_dir():
+        output_path = Path(args.output) if args.output else Path(str(input_path).rstrip("/\\") + ".cjz")
+        _ensure_output_available(output_path, args.force)
+        result_path, stats = compress_dir(str(input_path), str(output_path), strategy=args.strategy)
+    else:
+        output_path = Path(args.output) if args.output else Path(str(input_path) + ".cjz")
+        _ensure_output_available(output_path, args.force)
+        result_path, stats = compress_file(str(input_path), str(output_path), strategy=args.strategy)
+
+    _print_compression_result(result_path, stats)
+    return 0
+
+
+def _handle_decompress(args: argparse.Namespace) -> int:
+    if args.archive_type == "file":
+        output_path = _decompressed_file_output(args.input, args.output)
+        _ensure_output_available(output_path, args.force)
+        result_path = decompress_file(args.input, str(output_path))
+    elif args.archive_type == "dir":
+        output_path = _decompressed_dir_output(args.input, args.output)
+        _ensure_output_available(output_path, args.force)
+        result_path = decompress_dir(args.input, str(output_path))
+    else:
+        result_path = _decompress_auto(args)
+
+    print(f"Decompressed: {result_path}")
+    return 0
+
+
+def _handle_encrypt(args: argparse.Namespace) -> int:
+    output_path = Path(args.output) if args.output else Path(args.input + ".enc")
+    _ensure_output_available(output_path, args.force)
+
+    password = getpass.getpass("Password: ")
+    confirmation = getpass.getpass("Confirm password: ")
+    if password != confirmation:
+        raise CliError("Password confirmation does not match.")
+
+    result_path = encrypt_file(args.input, password, str(output_path))
+    print(f"Encrypted: {result_path}")
+    return 0
+
+
+def _handle_decrypt(args: argparse.Namespace) -> int:
+    output_path = _decrypted_file_output(args.input, args.output)
+    _ensure_output_available(output_path, args.force)
+
+    password = getpass.getpass("Password: ")
+    result_path = decrypt_file(args.input, password, str(output_path))
+    print(f"Decrypted: {result_path}")
+    return 0
+
+
+def _decompress_auto(args: argparse.Namespace) -> str:
+    file_output = _decompressed_file_output(args.input, args.output)
+    _ensure_output_available(file_output, args.force)
+
+    try:
+        return decompress_file(args.input, str(file_output))
+    except CompressionError:
+        dir_output = _decompressed_dir_output(args.input, args.output)
+        _ensure_output_available(dir_output, args.force)
+        return decompress_dir(args.input, str(dir_output))
+
+
+def _decompressed_file_output(input_path: str, output_path: Optional[str]) -> Path:
+    if output_path:
+        return Path(output_path)
+    if input_path.endswith(".cjz"):
+        return Path(input_path[:-4])
+    return Path(input_path + ".decompressed")
+
+
+def _decompressed_dir_output(input_path: str, output_path: Optional[str]) -> Path:
+    if output_path:
+        return Path(output_path)
+    if input_path.endswith(".cjz"):
+        return Path(input_path[:-4])
+    return Path(input_path + "_extracted")
+
+
+def _decrypted_file_output(input_path: str, output_path: Optional[str]) -> Path:
+    if output_path:
+        return Path(output_path)
+    if input_path.endswith(".enc"):
+        return Path(input_path[:-4])
+    return Path(input_path + ".dec")
+
+
+def _ensure_output_available(output_path: Path, force: bool) -> None:
+    if output_path.exists() and not force:
+        raise CliError(f"Output already exists: {output_path}. Use --force to overwrite.")
+
+
+def _print_compression_result(result_path: str, stats) -> None:
+    print(f"Compressed: {result_path}")
+    print(f"Strategy: {stats.strategy.value}")
+    print(f"Original size: {stats.original_size} bytes")
+    print(f"Compressed size: {stats.compressed_size} bytes")
+    print(f"Ratio: {stats.ratio:.2f}x")
+    print(f"Savings: {stats.savings_percent:.2f}%")
+
+
+def _start_module(module_path: str) -> int:
+    base_dir = Path(BASE_DIR)
+    license_text = b"".join(FileIO.load(base_dir.parent / "LICENSE").data).decode()
+    license_text = '"""\n' + license_text + '"""'
+    new_module_path = base_dir.joinpath(*module_path.split("/"))
+
+    if new_module_path.parent.exists() and new_module_path.parent.is_dir():
+        FileIO.create(new_module_path, license_text).save()
+        return 0
+
+    raise CliError(f"{new_module_path} is not valid.")

--- a/cereja/concurrently/process.py
+++ b/cereja/concurrently/process.py
@@ -29,6 +29,8 @@ from ..utils import decorators
 
 __all__ = ["MultiProcess", "Processor"]
 
+logger = logging.getLogger(__name__)
+
 
 class _IMultiProcess(abc.ABC):
     """Minimal protocol for classes that store and retrieve async responses."""
@@ -140,7 +142,7 @@ class MultiProcess(_IMultiProcess):
             try:
                 self._create_task(function, value, indx, *args, **kwargs)
             except ChildProcessError:
-                print("Terminating due to an exception in one of the threads. Returning processed data...")
+                logger.error("Terminating due to an exception in one of the threads. Returning processed data.")
                 break
 
         if self._on_result is None:
@@ -163,7 +165,7 @@ class MultiProcess(_IMultiProcess):
             if not self._terminate:
                 self._process_response((indx, function(value, *args, **kwargs)))
         except Exception as err:
-            print(f"Error encountered in thread: {err}")
+            logger.exception("Error encountered in worker thread %s", indx)
             self._terminate = True
             self._exception_err = err
         finally:
@@ -223,7 +225,8 @@ class WorkerQueue(MultiProcess):
 
     def _get(self, take_indx=False, timeout=30):
         """Internal single-result retrieval helper."""
-        assert self._on_result is None, "task results are being sent to the callback defined 'on_result'"
+        if self._on_result is not None:
+            raise RuntimeError("task results are being sent to the callback defined 'on_result'")
         while (self._results.qsize() > 0 or self._active_threads > 0) or not self.is_empty:
             indx, item = self._results.get(timeout=timeout)
             self._results.task_done()
@@ -233,7 +236,8 @@ class WorkerQueue(MultiProcess):
 
     def _get_response(self, take_indx=False):
         """Wait for queue drain and return all collected responses ordered."""
-        assert self._on_result is None, "task results are being sent to the callback defined 'on_result'"
+        if self._on_result is not None:
+            raise RuntimeError("task results are being sent to the callback defined 'on_result'")
         self._q.join()
         self._indx = -1
         result = []
@@ -258,7 +262,7 @@ class WorkerQueue(MultiProcess):
             try:
                 self._create_task(self._func_task, item, indx, **kwargs)
             except ChildProcessError as err:
-                print(f"WorkerQueue failed to enqueue item {indx}: {err}")
+                logger.exception("WorkerQueue failed to enqueue item %s: %s", indx, err)
             finally:
                 self._q.task_done()
 
@@ -397,8 +401,8 @@ class Processor:
                 result = future.result()
                 if self._on_result is not None:
                     self._on_result(result)
-            except Exception as exc:
-                print(f"Failed to process future result.\nError: {exc}")
+            except Exception:
+                logger.exception("Failed to process future result.")
             finally:
                 with self._future_lock:
                     self._future_to_data.discard(future)
@@ -413,8 +417,8 @@ class Processor:
             with self._metrics_lock:
                 self._total_success += 1
             return result
-        except Exception as exc:
-            print(f"Failed to process item, storing for review.\nError: {exc}")
+        except Exception:
+            logger.exception("Failed to process item, storing for review.")
             with self._metrics_lock:
                 self._failure_data.append(item)
 

--- a/cereja/display/_display.py
+++ b/cereja/display/_display.py
@@ -1048,6 +1048,8 @@ class Progress:
         """Para o progresso e limpa recursos."""
         with self._lock:
             if self._started:
+                if self.completed and not self._err:
+                    self._show_progress(self._max_value, force=True)
                 self._awaiting_update = False
                 self._started = False
                 self._console.disable()

--- a/cereja/display/_display.py
+++ b/cereja/display/_display.py
@@ -19,6 +19,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+from __future__ import annotations
+
 import io
 import os
 import threading
@@ -26,21 +28,27 @@ import time
 import sys
 import random
 import weakref
-from typing import Tuple, Callable
-from abc import ABCMeta as ABC
-from typing import List
+from collections.abc import Callable, Iterable, Iterator, Sized
 from abc import ABCMeta, abstractmethod
-from typing import Sequence, Any, Union, AnyStr
+from typing import Any, AnyStr, cast
 
-from cereja import has_length
 from cereja.utils import is_iterable
-from cereja.config.cj_types import T_NUMBER
 from cereja.system.unicode import Unicode
 from cereja.utils import fill, get_instances_of, import_string
 from cereja.utils.time import time_format
 from cereja.mathtools import proportional, estimate, percent
 
 __all__ = ["Progress", "State", "console"]
+
+ProgressNumber = int | float
+
+
+def _as_float(value: int | float | complex) -> float:
+    if isinstance(value, int):
+        return float(value)
+    if isinstance(value, float):
+        return value
+    return float(value.real)
 
 _exclude = [
     "_Stdout",
@@ -76,28 +84,29 @@ _STDERR_ORIGINAL_COPY = sys.stderr
 class _Stdout:
     """Class to manage console output with improved memory management."""
 
-    __user_msg = []
+    __user_msg: list[str] = []
     _stdout_original = _STDOUT_ORIGINAL_COPY
     _stderr_original = _STDERR_ORIGINAL_COPY
 
     def __init__(self,
-                 console_):
-        self.persisting = False
-        self.th_console = None
-        self.last_console_msg = ""
-        self.use_th_console = False
+                 console_: _ConsoleBase | None):
+        self.persisting: bool = False
+        self.th_console: threading.Thread | None = None
+        self.last_console_msg: str = ""
+        self.use_th_console: bool = False
+        self._persist_depth: int = 0
         # Keep the active runtime streams as defaults. They are refreshed when
         # persistence starts, before replacing sys.stdout/sys.stderr.
         self._stdout_original = sys.stdout
         self._stderr_original = sys.stderr
-        self._stdout_buffer = io.StringIO()
-        self._stderr_buffer = io.StringIO()
+        self._stdout_buffer: io.StringIO = io.StringIO()
+        self._stderr_buffer: io.StringIO = io.StringIO()
         # Use weakref to avoid circular reference
-        self.console_ref = weakref.ref(console_) if console_ else None
-        self._lock = threading.Lock()  # Add thread safety
+        self.console_ref: weakref.ReferenceType[_ConsoleBase] | None = weakref.ref(console_) if console_ else None
+        self._lock: threading.RLock = threading.RLock()
 
     @property
-    def console(self):
+    def console(self) -> _ConsoleBase | None:
         """Return the console reference or None if garbage collected."""
         return self.console_ref() if self.console_ref else None
 
@@ -130,7 +139,7 @@ class _Stdout:
     def _has_user_msg(self):
         """Check if there are messages in the buffer."""
         with self._lock:
-            return bool(self._stdout_buffer.getvalue())
+            return bool(self._stdout_buffer.getvalue() or self._stderr_buffer.getvalue())
 
     @property
     def stdout_buffer_values(self):
@@ -160,8 +169,8 @@ class _Stdout:
 
     def write_user_msg(self):
         """Write user messages with console verification."""
-        console = self.console
-        if not console:
+        active_console = self.console
+        if active_console is None:
             return
 
         stdout, stderr = self.stdout_buffer_values, self.stderr_buffer_values
@@ -169,7 +178,7 @@ class _Stdout:
         if stdout and not (stdout in ["\n", "\r\n", "\n"]):
             values = []
             for value in stdout.splitlines():
-                value = f"{console.parse(value, title='Sys[out]')}"
+                value = f"{active_console.parse(value, title='Sys[out]')}"
                 values.append(value)
             value = "\n".join(values)
             value = f"\r{value}\n{self.last_console_msg}"
@@ -177,30 +186,24 @@ class _Stdout:
 
         if stderr and not (stderr in ["\n", "\r\n", "\n"]):
             unicode_err = "\U0000274C"
-            prefix = console.template_format(
+            prefix = active_console.template_format(
                     f"{{red}}{unicode_err} Error:{{endred}}"
             )
-            msg_err_prefix = f"{console.parse(prefix, title='Sys[err]')}"
-            msg_err = console.format(stderr, color="red")
+            msg_err_prefix = f"{active_console.parse(prefix, title='Sys[err]')}"
+            msg_err = active_console.format(stderr, color="red")
             msg_err = f"\r{msg_err_prefix}\n{msg_err}\n{self.last_console_msg}"
             self._write(msg_err)
 
     def _write_user_msg_loop(self):
-        """Main thread loop with improved resource management."""
-        try:
-            while self.use_th_console and threading.current_thread().is_alive():
-                try:
-                    self.write_user_msg()
-                    time.sleep(0.1)
-                except Exception:
-                    # On error, stop the loop to avoid infinite loops
-                    break
+        """Flush buffered user messages.
 
-            # Final check after exiting the loop
+        Kept for compatibility with older internal callers; progress rendering is
+        now synchronous and does not rely on a background polling thread.
+        """
+        try:
             if self._has_user_msg():
                 self.write_user_msg()
-        except Exception:
-            # Ensure the thread doesn't fail silently
+        except (AttributeError, ValueError, RuntimeError):
             pass
 
     def _write(self,
@@ -209,13 +212,13 @@ class _Stdout:
         if not msg or msg.strip(" ") == "":
             return
 
-        console = self.console
+        active_console = self.console
         try:
             self._stdout_original.write(msg)
             self._stdout_original.flush()
         except (UnicodeError, UnicodeEncodeError):
-            if console:
-                msg = console.translate_non_bmp(msg)
+            if active_console:
+                msg = active_console.translate_non_bmp(msg)
             encoded_msg = msg.encode("ascii", errors="replace").decode()
             self._stdout_original.write(encoded_msg)
             self._stdout_original.flush()
@@ -229,6 +232,8 @@ class _Stdout:
                replace_last=False):
         """Send message with thread safety."""
         with self._lock:
+            if self.persisting:
+                self.write_user_msg()
             self.last_console_msg = msg
             if replace_last:
                 msg = f"\r{msg}"
@@ -240,9 +245,9 @@ class _Stdout:
                     msg,
                     **args):
         """Write error to the buffer."""
-        console = self.console
-        if console:
-            msg = console.format(msg, color="red")
+        active_console = self.console
+        if active_console:
+            msg = active_console.format(msg, color="red")
             with self._lock:
                 self._stdout_buffer.write(msg)
 
@@ -255,40 +260,47 @@ class _Stdout:
 
     def persist(self):
         """Start persistence with improved thread management."""
-        if not self.persisting:
-            self.use_th_console = True
+        with self._lock:
+            if self.persisting:
+                self._persist_depth += 1
+                return
             # Capture the current streams at runtime so restoration does not
             # clobber external runners (e.g. PyCharm TeamCity unittest runner).
             self._stdout_original = sys.stdout
             self._stderr_original = sys.stderr
-            self.th_console = threading.Thread(
-                    name="Console", target=self._write_user_msg_loop, daemon=True
-            )
-            self.th_console.start()
             sys.stdout = self._stdout_buffer
             sys.stderr = self._stderr_buffer
+            self._persist_depth = 1
             self.persisting = True
 
     def disable(self):
         """Stop persistence and clean up resources."""
-        if self.use_th_console:
-            self.use_th_console = False
-            if self.th_console and self.th_console.is_alive():
-                # Timeout to avoid hanging
-                self.th_console.join(timeout=1.0)
+        with self._lock:
+            if not self.persisting:
+                self.restore_sys_module_state()
+                return
+
+            self.write_user_msg()
+            if self._persist_depth > 1:
+                self._persist_depth -= 1
+                return
+
+            self._persist_depth = 0
             self.persisting = False
 
-            console = self.console
-            if console:
-                console.set_prefix(_LOGIN_NAME)
+            active_console = self.console
+            if active_console:
+                active_console.set_prefix(_LOGIN_NAME)
 
-        self.restore_sys_module_state()
+            self.restore_sys_module_state()
 
     def restore_sys_module_state(self):
         """Restore system state with verifications."""
-        if JUPYTER and IP:
+        active_ip = IP
+        if JUPYTER and active_ip is not None:
             try:
-                IP.restore_sys_module_state()
+                restore_sys_module_state = getattr(active_ip, "restore_sys_module_state")
+                restore_sys_module_state()
             except (AttributeError, RuntimeError):
                 pass
             return
@@ -305,6 +317,7 @@ class _Stdout:
         with self._lock:
             # Stop thread if running
             self.use_th_console = False
+            self._persist_depth = 0
 
             # Clear buffers
             self._clear_buffer(self._stdout_buffer)
@@ -334,7 +347,7 @@ class _Stdout:
             pass
 
 
-class _ConsoleBase(metaclass=ABC):
+class _ConsoleBase:
     """Console base com melhor gestão de instância singleton."""
 
     _instance = None
@@ -454,7 +467,7 @@ class _ConsoleBase(metaclass=ABC):
     def _parse(self,
                msg,
                title=None,
-               color: str = None,
+               color: str | None = None,
                remove_line_sep=True):
         if color is None:
             color = "default"
@@ -512,7 +525,7 @@ class _ConsoleBase(metaclass=ABC):
         return self.template_format(template_format)
 
     def colorful_words(self,
-                       text: Union[List[str], str]) -> str:
+                       text: list[str] | str) -> str:
         msg_error = "You need send string or list of string."
         if isinstance(text, str):
             text = text.split()
@@ -570,7 +583,7 @@ class _ConsoleBase(metaclass=ABC):
     def __print(self,
                 msg,
                 title=None,
-                color: str = None,
+                color: str | None = None,
                 end=__os_line_sep):
         remove_line_sep = True if end is None else False
         msg = self._parse(
@@ -622,10 +635,10 @@ class State(metaclass=ABCMeta):
     @abstractmethod
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
     ) -> str:
         """
@@ -636,10 +649,10 @@ class State(metaclass=ABCMeta):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
     ) -> str:
         return self.display(current_value, max_value, current_percent, time_it, n_times)
@@ -648,6 +661,9 @@ class State(metaclass=ABCMeta):
               *args,
               **kwargs) -> str:
         return self.display(*args, **kwargs)
+
+
+StateInput = str | State | type[State]
 
 
 class _StateLoading(State):
@@ -669,10 +685,10 @@ class _StateLoading(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -684,10 +700,10 @@ class _StateLoading(State):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -702,10 +718,10 @@ class _StateAwaiting(_StateLoading):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -724,10 +740,10 @@ class _StateAwaiting(_StateLoading):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -739,10 +755,10 @@ class _StateDownloadData(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -767,10 +783,10 @@ class _StateBar(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> AnyStr:
@@ -785,10 +801,10 @@ class _StateBar(State):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -804,10 +820,10 @@ class _StatePercent(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -815,10 +831,10 @@ class _StatePercent(State):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -832,10 +848,10 @@ class _StateTime(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -845,16 +861,16 @@ class _StateTime(State):
                 time_it,
         )
         idx = int(proportional(current_value, max_value, self.__max_sequence))
-        t_format = f"{time_format(time_estimate)}"
+        t_format = f"{time_format(_as_float(time_estimate))}"
         value = f"{self.__clock + idx} {time_format(time_it)}/{t_format}"
         return f"{value}{self.blanks(len(value))} estimated"
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: float,
             **kwargs,
     ) -> str:
@@ -867,10 +883,10 @@ class _StateValue(State):
 
     def display(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -879,10 +895,10 @@ class _StateValue(State):
 
     def done(
             self,
-            current_value: T_NUMBER,
-            max_value: T_NUMBER,
-            current_percent: T_NUMBER,
-            time_it: T_NUMBER,
+            current_value: ProgressNumber,
+            max_value: ProgressNumber,
+            current_percent: ProgressNumber,
+            time_it: ProgressNumber,
             n_times: int,
             **kwargs,
     ) -> str:
@@ -901,7 +917,7 @@ class Progress:
     __awaiting_state = None  # Initialized when needed
     __done_unicode = Unicode("\U00002705")
     __err_unicode = Unicode("\U0000274C")
-    __key_map = {
+    __key_map: dict[str, type[State]] = {
         "loading":  _StateLoading,
         "time":     _StateTime,
         "percent":  _StatePercent,
@@ -909,8 +925,8 @@ class Progress:
         "value":    _StateValue,
         "download": _StateDownloadData,
     }
-    _with_context = False
-    __built = False
+    _with_context: bool = False
+    __built: bool = False
     _console = console
     # Usa WeakValueDictionary para permitir garbage collection automático
     _progresses = weakref.WeakValueDictionary()
@@ -918,17 +934,18 @@ class Progress:
 
     def __init__(
             self,
-            sequence=None,
-            name="Progress",
-            max_value: int = None,
-            states=("value", "bar", "percent", "time"),
-            custom_state_func=None,
-            custom_state_name=None,
-    ):
+            sequence: Iterable[Any] | None = None,
+            name: str | None = "Progress",
+            max_value: ProgressNumber | None = None,
+            states: StateInput | Iterable[StateInput] | None = ("value", "bar", "percent", "time"),
+            custom_state_func: Callable[[], Any] | None = None,
+            custom_state_name: str | None = None,
+    ) -> None:
         # Initialize awaiting_state only when needed
         if Progress.__awaiting_state is None:
             Progress.__awaiting_state = _StateAwaiting()
 
+        self._lock = threading.RLock()
         self._is_generator = False
         self._n_times = 0
         self._name = name or "Progress"
@@ -944,15 +961,17 @@ class Progress:
             custom_state_name if custom_state_name else "Custom State"
         )
         self._started_time = None
-        self._states = ()
+        self._states: tuple[State, ...] = ()
         self.add_state(states)
-        self._max_value = max_value
-        self._current_value = 0
-        self._th_root = self._create_progress_service()
+        self._max_value: ProgressNumber | None = max_value
+        self._current_value: ProgressNumber = 0
+        self._th_root: threading.Thread | None = None
         self._was_done = False
         self._err = False
         self.__built = True
-        self._lock = threading.Lock()
+        self._last_progress_msg = None
+        self._last_render_time = 0.0
+        self._min_render_interval = 0.05
 
         if sequence is not None:
             self.__call__(sequence)
@@ -974,23 +993,23 @@ class Progress:
         gc.collect()
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def max_value(self):
+    def max_value(self) -> ProgressNumber:
         with self._lock:
             return self._max_value or self._current_value + 1
 
     def set_name(self,
-                 value: str):
+                 value: str) -> None:
         if not isinstance(value, str):
             raise TypeError("Please send string.")
         with self._lock:
             self._name = value
         self._console.set_prefix(f"{self._name}")
 
-    def _create_progress_service(self):
+    def _create_progress_service(self) -> threading.Thread:
         """Cria thread de serviço com configuração daemon."""
         return threading.Thread(
                 name=f"Progress-{id(self)}", target=self._progress_service, daemon=True
@@ -1006,7 +1025,7 @@ class Progress:
             self.stop()
 
     @property
-    def completed(self):
+    def completed(self) -> bool:
         with self._lock:
             return self._was_done or self._err or self._iter_finaly
 
@@ -1025,24 +1044,19 @@ class Progress:
                 # to ensure best-effort cleanup of all registered instances.
                 pass
 
-    def stop(self):
+    def stop(self) -> None:
         """Para o progresso e limpa recursos."""
         with self._lock:
             if self._started:
                 self._awaiting_update = False
                 self._started = False
-
-                # Stop thread with timeout
-                if self._th_root and self._th_root.is_alive():
-                    self._th_root.join(timeout=2.0)
-
                 self._console.disable()
 
         # Remove from the progress list
         with Progress._progress_lock:
             Progress._progresses.pop(id(self), None)
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Clean up all instance resources."""
         with self._lock:
             # Stop thread
@@ -1065,11 +1079,11 @@ class Progress:
         except Exception:
             pass
 
-    def _parse_states(self):
+    def _parse_states(self) -> tuple[str, ...]:
         return tuple(map(lambda stt: stt.__class__.__name__, self._states))
 
     def _get_done_state(self,
-                        **kwargs):
+                        **kwargs) -> list[str]:
         if self._current_value == 0:
             result = [self.__awaiting_state.done(**kwargs)]
         else:
@@ -1080,19 +1094,19 @@ class Progress:
         return result
 
     def _get_state(self,
-                   **kwargs):
+                   **kwargs) -> list[str]:
         return list(map(lambda state: state.display(**kwargs), self._states))
 
     @property
-    def time_it(self):
+    def time_it(self) -> float:
         return time.monotonic() - (self._started_time or time.monotonic())
 
     @property
-    def total_completed(self):
+    def total_completed(self) -> str:
         return f"{self.percent_(self._current_value)}%"
 
     def _states_view(self,
-                     for_value: T_NUMBER) -> str:
+                     for_value: ProgressNumber) -> str:
         self._n_times += 1
         kwargs = {
             "current_value":   for_value,
@@ -1127,38 +1141,40 @@ class Progress:
         return f"{state_conf}\n{self._console.parse(progress_example_view, title='Example States View')}"
 
     def add_state(self,
-                  state: Union[State, Sequence[State]],
-                  idx=-1):
+                  state: StateInput | Iterable[StateInput] | None,
+                  idx: int = -1) -> None:
         self._filter_and_add_state(state, idx)
 
     def remove_state(self,
-                     idx):
+                     idx: int) -> None:
         states = list(self._states)
         states.pop(idx)
         self._states = tuple(states)
 
     def _parse_state(self,
-                     state):
+                     state: StateInput) -> State:
         if isinstance(state, str):
-            state = self.__key_map.get(state)
-        assert issubclass(state, State) or isinstance(
-                state, State
-        ), f"State `{state}` not found in valid values [{list(self.__key_map)}]"
-        if not isinstance(state, State):
+            state_class = self.__key_map.get(state)
+            if state_class is None:
+                raise ValueError(f"State `{state}` not found in valid values [{list(self.__key_map)}]")
+            return state_class()
+        if isinstance(state, State):
+            return state
+        if isinstance(state, type) and issubclass(state, State):
             return state()
-        return state
+        raise ValueError(f"State `{state}` not found in valid values [{list(self.__key_map)}]")
 
     def _valid_states(self,
-                      states: Union[State, Sequence[State]]):
-        if states is not None:
-            if not is_iterable(states):
-                states = (states,)
-            return tuple(map(self._parse_state, states))
-        return (None,)
+                      states: StateInput | Iterable[StateInput] | None) -> tuple[State, ...]:
+        if states is None:
+            return ()
+        if isinstance(states, (str, State, type)):
+            return (self._parse_state(states),)
+        return tuple(self._parse_state(state) for state in states)
 
     def _filter_and_add_state(self,
-                              state: Union[State, Sequence[State]],
-                              index_=-1):
+                              state: StateInput | Iterable[StateInput] | None,
+                              index_: int = -1) -> None:
         state = self._valid_states(state)
         filtered = tuple(filter(lambda stt: stt not in self._states, tuple(state)))
         if any(filtered):
@@ -1173,27 +1189,27 @@ class Progress:
                 self._console.log(f"Added new states! {filtered}")
 
     @property
-    def states(self):
+    def states(self) -> tuple[str, ...]:
         return self._parse_states()
 
     def percent_(self,
-                 for_value: T_NUMBER) -> T_NUMBER:
-        return percent(for_value, self.max_value)
+                 for_value: ProgressNumber) -> ProgressNumber:
+        return _as_float(percent(for_value, self.max_value))
 
     def update_max_value(self,
-                         max_value: int):
+                         max_value: ProgressNumber) -> None:
         """
         You can modify the progress to another value. It is not a percentage,
         although it is purposely set to 100 by default.
 
         :param max_value: This number represents the maximum amount you want to achieve.
         """
-        if not isinstance(max_value, (int, float, complex)):
+        if not isinstance(max_value, (int, float)):
             raise Exception(f"Current value {max_value} isn't valid.")
         if max_value != self.max_value:
             self._max_value = max_value
 
-    def _progress_service(self):
+    def _progress_service(self) -> None:
         last_value = self._current_value
         n_times = 0
         while self._started and not self._iter_finaly:
@@ -1214,27 +1230,35 @@ class Progress:
             time.sleep(0.01)
 
     def _show_progress(self,
-                       for_value=None):
+                       for_value: ProgressNumber | None = None,
+                       force: bool = False) -> None:
         """Mostra progresso atual sem duplicação."""
         if for_value is None:
             for_value = self._current_value
 
-        msg = self._states_view(for_value)
+        with self._lock:
+            msg = self._states_view(for_value)
+            now = time.monotonic()
+            can_render = force or (now - self._last_render_time) >= self._min_render_interval
 
-        # Evita mostrar a mesma mensagem duas vezes
-        if not hasattr(self, '_last_progress_msg') or self._last_progress_msg != msg:
-            self._last_progress_msg = msg
-            self._console.replace_last_msg(msg)
+            # Evita mostrar a mesma mensagem duas vezes e reduz overhead em loops muito rápidos.
+            if can_render and self._last_progress_msg != msg:
+                self._last_progress_msg = msg
+                self._last_render_time = now
+                self._console.replace_last_msg(msg)
 
     def _update_value(self,
-                      value):
-        self._awaiting_update = self._is_generator  # if is generator awaiting state is default.
-        self._show = True
-        self._current_value = value
+                       value: ProgressNumber) -> None:
+        with self._lock:
+            self._awaiting_update = self._is_generator  # if is generator awaiting state is default.
+            self._show = True
+            self._current_value = value
+        if self._started:
+            self._show_progress(value)
 
     def show_progress(self,
-                      for_value,
-                      max_value=None):
+                      for_value: ProgressNumber,
+                      max_value: ProgressNumber | None = None) -> None:
         """
         Build progress by a value.
 
@@ -1248,39 +1272,34 @@ class Progress:
             self.update_max_value(max_value)
         self._update_value(for_value)
 
-    def _reset(self):
+    def _reset(self) -> None:
         self._current_value = 0
         self._n_times = 0
         self._started_time = None
 
-    def start(self):
+    def start(self) -> None:
         self._console.set_prefix(self._name)
         if self._started:
             return
         self._started_time = time.monotonic()
         self._started = True
-        try:
-            self._th_root.start()
-        except RuntimeError:
-            self._th_root.join()
-            self._th_root = self._create_progress_service()
-            self._th_root.start()
         self._console.persist_on_runtime()
         self._n_times = 0
+        self._show_progress(self._current_value, force=True)
 
-    def restart(self):
+    def restart(self) -> None:
         self._reset()
 
     @classmethod
     def prog(
             cls,
-            sequence: Sequence[Any],
-            name: str = None,
-            max_value: int = None,
-            states=("value", "bar", "percent", "time"),
-            custom_state_func=None,
-            custom_state_name=None,
-    ) -> "Progress":
+            sequence: Iterable[Any],
+            name: str | None = None,
+            max_value: ProgressNumber | None = None,
+            states: StateInput | Iterable[StateInput] | None = ("value", "bar", "percent", "time"),
+            custom_state_func: Callable[[], Any] | None = None,
+            custom_state_name: str | None = None,
+    ) -> Iterable[Any]:
         return cls(
                 name=name,
                 max_value=max_value,
@@ -1289,36 +1308,49 @@ class Progress:
                 custom_state_name=custom_state_name,
         )(sequence, name, max_value)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._states)
 
     def __getitem__(self,
-                    slice_):
+                    slice_: int | slice | tuple[int, ...] | str) -> State | tuple[State, ...]:
         if isinstance(slice_, tuple):
             if max(slice_) > len(self):
                 raise IndexError(f"{max(slice_)} isn't in progress")
             return tuple(self._states[idx] for idx in slice_ if idx < len(self))
         if isinstance(slice_, str):
             key = self.__key_map[slice_]
-            if key in self._states:
-                slice_ = self._states.index(key)
-            else:
+            state_index = next(
+                    (idx for idx, state in enumerate(self._states) if isinstance(state, key)),
+                    None,
+            )
+            if state_index is None:
                 raise KeyError(f"Not exists {key}")
+            slice_ = state_index
+        if isinstance(slice_, slice):
+            return self._states[slice_]
         return self._states[slice_]
 
     def __call__(self,
-                 sequence: Sequence,
-                 name=None,
-                 max_value=None) -> "Progress":
+                 sequence: Iterable[Any],
+                 name: str | None = None,
+                 max_value: ProgressNumber | None = None) -> Iterable[Any]:
         if not is_iterable(sequence):
             raise ValueError("Send a sequence.")
-        if has_length(sequence):
+        with self._lock:
+            self._iter_finaly = False
+            self._was_done = False
+            self._err = False
+            self._is_generator = False
+            self._current_value = 0
+            self._n_times = 0
+            self._last_progress_msg = None
+        if isinstance(sequence, Sized):
             self.update_max_value(len(sequence))
         elif max_value is not None:
             self.update_max_value(max_value)
         else:
             self._is_generator = True
-        self.sequence = sequence
+        self.sequence: Iterable[Any] = iter(cast(Iterable[Any], sequence))
         if name is not None:
             self._console.set_prefix(f"{self.name}({name})")
         if self._with_context and name is None:
@@ -1327,7 +1359,7 @@ class Progress:
         self._task_count += 1
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         original_name = self._name
         if not self._with_context:
             self.start()
@@ -1336,28 +1368,29 @@ class Progress:
                 self._update_value(n + 1)
                 yield obj
         except Exception:
-            self._err = True
+            with self._lock:
+                self._err = True
+            raise
         finally:
             if self._is_generator:
                 self.update_max_value(self._current_value)
-            self._was_done = (self._current_value >= self.max_value) and not self._err
+            with self._lock:
+                self._was_done = (self._current_value >= self.max_value) and not self._err
+                self._iter_finaly = True
+            self._show_progress(self._current_value, force=True)
+            print()
             if not self._with_context:
                 self.stop()
-            self._iter_finaly = True
-            self._show_progress(self._current_value)
-            print()
 
         self._console.set_prefix(original_name)
         self.sequence = ()
-        # Force resource cleanup
-        self.cleanup()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         return self.__next__()
 
     def __setitem__(self,
-                    key,
-                    value):
+                    key: int,
+                    value: StateInput) -> None:
         value = self._valid_states(value)[0]
         if isinstance(value, State):
             value = value
@@ -1370,7 +1403,7 @@ class Progress:
 
     def __enter__(self,
                   *args,
-                  **kwargs):
+                  **kwargs) -> "Progress":
         if hasattr(self, "sequence"):
             raise ChildProcessError("Dont use progress instance on with statement.")
         self._with_context = True
@@ -1380,7 +1413,7 @@ class Progress:
     def __exit__(self,
                  exc_type,
                  exc_val,
-                 exc_tb):
+                 exc_tb) -> None:
         if isinstance(exc_val, Exception) and not isinstance(
                 exc_val, DeprecationWarning
         ):
@@ -1393,8 +1426,10 @@ class Progress:
         self._with_context = False
 
 
-if IP:
-    IP.set_custom_exc(
+ip = IP
+if ip is not None:
+    set_custom_exc = getattr(ip, "set_custom_exc")
+    set_custom_exc(
             (Exception, GeneratorExit, SystemExit, KeyboardInterrupt), _Stdout.custom_exc
     )
 else:

--- a/cereja/hashtools/_compress.py
+++ b/cereja/hashtools/_compress.py
@@ -24,9 +24,16 @@ import bz2
 import lzma
 import struct
 import base64
+import logging
 from enum import Enum
-from typing import Union, Tuple, Dict, Any
+from typing import Union, Tuple, Dict, Any, Optional
 from collections import Counter
+
+from cereja.hashtools._crypto import CryptoError
+from cereja.hashtools._crypto import decrypt as _decrypt_data
+from cereja.hashtools._crypto import encrypt as _encrypt_data
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "compress",
@@ -35,6 +42,7 @@ __all__ = [
     "decompress_file",
     "compress_dir",
     "decompress_dir",
+    "is_encrypted_archive",
     "analyze_data",
     "suggest_strategy",
     "get_compression_ratio",
@@ -648,8 +656,37 @@ def decompress(data: bytes) -> bytes:
         raise CompressionError(f"Decompression failed: {str(e)}")
 
 
-def compress_file(file_path: str, output_path: str = None, 
-                  strategy: Union[str, CompressionStrategy] = 'auto') -> Tuple[str, CompressionStats]:
+_ENCRYPTED_ARCHIVE_MAGIC = b"CJZE\x01\n"
+
+
+def _encrypt_archive_payload(data: bytes, password: Union[str, bytes]) -> bytes:
+    return _ENCRYPTED_ARCHIVE_MAGIC + _encrypt_data(data, password).encode('ascii')
+
+
+def _decrypt_archive_payload(data: bytes, password: Optional[Union[str, bytes]]) -> bytes:
+    if not data.startswith(_ENCRYPTED_ARCHIVE_MAGIC):
+        return data
+
+    if password is None:
+        raise CompressionError("Password is required to decompress encrypted archive")
+
+    encrypted_data = data[len(_ENCRYPTED_ARCHIVE_MAGIC):].decode('ascii')
+    try:
+        return _decrypt_data(encrypted_data, password)
+    except CryptoError as exc:
+        raise CompressionError(str(exc)) from exc
+
+
+def is_encrypted_archive(file_path: str) -> bool:
+    """Return True when file starts with the Cereja encrypted archive marker."""
+    with open(file_path, 'rb') as archive:
+        return archive.read(len(_ENCRYPTED_ARCHIVE_MAGIC)) == _ENCRYPTED_ARCHIVE_MAGIC
+
+
+def compress_file(file_path: str, output_path: str = None,
+                  strategy: Union[str, CompressionStrategy] = 'auto',
+                  verbose: bool = False,
+                  password: Optional[Union[str, bytes]] = None) -> Tuple[str, CompressionStats]:
     """
     Compress file contents.
     
@@ -657,6 +694,8 @@ def compress_file(file_path: str, output_path: str = None,
         file_path: Path to file to compress
         output_path: Path for compressed file (if None, uses file_path + '.cjz')
         strategy: Compression strategy (default: 'auto')
+        verbose: Whether to show progress while compressing (default: False)
+        password: Password used to encrypt the compressed archive (default: None)
     
     Returns:
         Tuple of (output_path, compression_stats)
@@ -665,13 +704,22 @@ def compress_file(file_path: str, output_path: str = None,
         CompressionError: If compression fails
         FileNotFoundError: If input file doesn't exist
     """
+    import os
+    from contextlib import nullcontext
+
     try:
-        # Read file
-        with open(file_path, 'rb') as f:
-            data = f.read()
+        progress = _create_progress(verbose, "Compressing file", 1)
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(file_path, 'rb') as f:
+                data = f.read()
+            if active_progress is not None:
+                active_progress.show_progress(1)
         
         # Compress
         compressed, stats = compress(data, strategy=strategy)
+        archive_data = _encrypt_archive_payload(compressed, password) if password is not None else compressed
+        stats = CompressionStats(len(data), len(archive_data), stats.strategy, stats.time_ms)
         
         # Determine output path
         if output_path is None:
@@ -679,7 +727,7 @@ def compress_file(file_path: str, output_path: str = None,
         
         # Write compressed file
         with open(output_path, 'wb') as f:
-            f.write(compressed)
+            f.write(archive_data)
         
         return output_path, stats
     
@@ -689,13 +737,17 @@ def compress_file(file_path: str, output_path: str = None,
         raise CompressionError(f"File compression failed: {str(e)}")
 
 
-def decompress_file(file_path: str, output_path: str = None) -> str:
+def decompress_file(file_path: str, output_path: str = None,
+                    verbose: bool = False,
+                    password: Optional[Union[str, bytes]] = None) -> str:
     """
     Decompress file contents.
     
     Args:
         file_path: Path to compressed file
         output_path: Path for decompressed file (if None, removes '.cjz' extension)
+        verbose: Whether to show progress while decompressing (default: False)
+        password: Password used when archive is encrypted (default: None)
     
     Returns:
         Path to decompressed file
@@ -704,11 +756,20 @@ def decompress_file(file_path: str, output_path: str = None) -> str:
         CompressionError: If decompression fails
         FileNotFoundError: If input file doesn't exist
     """
+    import os
+    from contextlib import nullcontext
+
     try:
-        # Read compressed file
-        with open(file_path, 'rb') as f:
-            compressed_data = f.read()
+        progress = _create_progress(verbose, "Decompressing file", 1)
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(file_path, 'rb') as f:
+                compressed_data = f.read()
+            if active_progress is not None:
+                active_progress.show_progress(1)
         
+        compressed_data = _decrypt_archive_payload(compressed_data, password)
+
         # Decompress
         decompressed = decompress(compressed_data)
         
@@ -751,8 +812,171 @@ def get_compression_ratio(original: Union[str, bytes], compressed: bytes) -> flo
     return len(original) / len(compressed)
 
 
-def compress_dir(dir_path: str, output_path: str = None, 
-                 strategy: Union[str, CompressionStrategy] = 'auto') -> Tuple[str, CompressionStats]:
+_DIR_ARCHIVE_MAGIC = b"CJZD\x02"
+_DIR_RECORD_FILE = b"\x01"
+_DIR_RECORD_END = b"\x00"
+_DIR_CHUNK_SIZE = 1024 * 1024
+_DIR_STREAM_MARKERS = {
+    CompressionStrategy.ZLIB: b'\x10',
+    CompressionStrategy.BZ2: b'\x11',
+    CompressionStrategy.LZMA: b'\x12',
+}
+_DIR_STREAM_STRATEGIES = {marker: strategy for strategy, marker in _DIR_STREAM_MARKERS.items()}
+
+
+def _iter_directory_files(dir_path: str, exclude_path: str = None, exclude_paths=None):
+    import os
+
+    excluded_abs = set()
+    if exclude_path is not None:
+        excluded_abs.add(os.path.abspath(exclude_path))
+    if exclude_paths is not None:
+        excluded_abs.update(os.path.abspath(path) for path in exclude_paths if path is not None)
+
+    for root, dirs, files in os.walk(dir_path):
+        dirs.sort()
+        files.sort()
+
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            if os.path.abspath(file_path) in excluded_abs:
+                continue
+            rel_path = os.path.relpath(file_path, dir_path).replace('\\', '/')
+            yield file_path, rel_path
+
+
+def _get_directory_file_count(dir_path: str, exclude_path: str = None, exclude_paths=None) -> int:
+    return sum(1 for _ in _iter_directory_files(dir_path, exclude_path=exclude_path, exclude_paths=exclude_paths))
+
+
+def _create_progress(enabled: bool, name: str, max_value: Optional[int] = None):
+    if not enabled:
+        return None
+
+    from cereja.display import Progress
+
+    return Progress(name=name, max_value=max_value, states=("value", "bar", "percent", "time"))
+
+
+def _normalize_dir_strategy(strategy: Union[str, CompressionStrategy]) -> CompressionStrategy:
+    if isinstance(strategy, str):
+        if strategy == 'auto':
+            strategy = CompressionStrategy.AUTO
+        else:
+            strategy = CompressionStrategy(strategy)
+
+    if strategy in (CompressionStrategy.BZ2, CompressionStrategy.LZMA):
+        return strategy
+
+    return CompressionStrategy.ZLIB
+
+
+def _create_dir_compressor(strategy: CompressionStrategy, level: int = 6):
+    if strategy == CompressionStrategy.BZ2:
+        return bz2.BZ2Compressor(level)
+    if strategy == CompressionStrategy.LZMA:
+        return lzma.LZMACompressor(preset=level)
+    return zlib.compressobj(level)
+
+
+def _create_dir_decompressor(strategy: CompressionStrategy):
+    if strategy == CompressionStrategy.BZ2:
+        return bz2.BZ2Decompressor()
+    if strategy == CompressionStrategy.LZMA:
+        return lzma.LZMADecompressor()
+    return zlib.decompressobj()
+
+
+def _read_exact(file_obj, size: int) -> bytes:
+    data = file_obj.read(size)
+    if len(data) != size:
+        raise CompressionError("Unexpected end of directory archive")
+    return data
+
+
+def _write_sized_chunk(file_obj, data: bytes) -> None:
+    if data:
+        file_obj.write(struct.pack('>I', len(data)))
+        file_obj.write(data)
+
+
+def _read_uint32(file_obj) -> int:
+    return struct.unpack('>I', _read_exact(file_obj, 4))[0]
+
+
+def _read_uint64(file_obj) -> int:
+    return struct.unpack('>Q', _read_exact(file_obj, 8))[0]
+
+
+def _count_dir_stream_files(archive_path: str) -> int:
+    file_count = 0
+
+    with open(archive_path, 'rb') as archive:
+        _read_exact(archive, len(_DIR_ARCHIVE_MAGIC))
+
+        while True:
+            record_type = _read_exact(archive, 1)
+            if record_type == _DIR_RECORD_END:
+                break
+            if record_type != _DIR_RECORD_FILE:
+                raise CompressionError(f"Invalid directory archive record: {record_type}")
+
+            path_length = _read_uint32(archive)
+            _read_exact(archive, path_length)
+            _read_uint64(archive)
+            marker = _read_exact(archive, 1)
+
+            if marker not in _DIR_STREAM_STRATEGIES:
+                raise CompressionError(f"Unknown directory compression marker: {marker}")
+
+            while True:
+                chunk_size = _read_uint32(archive)
+                if chunk_size == 0:
+                    break
+                _read_exact(archive, chunk_size)
+
+            file_count += 1
+
+    return file_count
+
+
+def _safe_archive_path(output_dir: str, archive_file_path: str) -> str:
+    import os
+
+    normalized_path = archive_file_path.replace('\\', '/')
+    if not normalized_path or normalized_path.startswith('/') or normalized_path.startswith('../'):
+        raise CompressionError(f"Unsafe archive path: {archive_file_path}")
+
+    output_dir_abs = os.path.abspath(output_dir)
+    file_path = os.path.abspath(os.path.join(output_dir_abs, normalized_path.replace('/', os.sep)))
+
+    if os.path.commonpath([output_dir_abs, file_path]) != output_dir_abs:
+        raise CompressionError(f"Unsafe archive path: {archive_file_path}")
+
+    return file_path
+
+
+def _get_default_output_dir(archive_path: str) -> str:
+    if archive_path.endswith('.cjz'):
+        return archive_path[:-4]
+    return archive_path + '_extracted'
+
+
+def _create_temp_archive_path(output_path: str) -> str:
+    import os
+    import tempfile
+
+    output_dir = os.path.dirname(output_path) or os.curdir
+    prefix = os.path.basename(output_path) + '.'
+    fd, temp_path = tempfile.mkstemp(prefix=prefix, suffix='.tmp', dir=output_dir)
+    os.close(fd)
+    return temp_path
+
+
+def compress_dir(dir_path: str, output_path: str = None,
+                 strategy: Union[str, CompressionStrategy] = 'auto',
+                 verbose: bool = False,
+                 password: Optional[Union[str, bytes]] = None) -> Tuple[str, CompressionStats]:
     """
     Compress entire directory recursively.
     
@@ -763,6 +987,8 @@ def compress_dir(dir_path: str, output_path: str = None,
         dir_path: Path to directory to compress
         output_path: Path for compressed archive (if None, uses dir_path + '.cjz')
         strategy: Compression strategy (default: 'auto')
+        verbose: Whether to show progress while compressing (default: False)
+        password: Password used to encrypt the compressed archive (default: None)
     
     Returns:
         Tuple of (output_path, compression_stats)
@@ -779,7 +1005,10 @@ def compress_dir(dir_path: str, output_path: str = None,
         >>> print(f"Compressed to {archive} with {stats.ratio:.2f}x ratio")
     """
     import os
-    import json
+    import time
+    from contextlib import nullcontext
+
+    temp_archive_path = None
     
     try:
         if not os.path.exists(dir_path):
@@ -787,96 +1016,223 @@ def compress_dir(dir_path: str, output_path: str = None,
         
         if not os.path.isdir(dir_path):
             raise NotADirectoryError(f"Path is not a directory: {dir_path}")
-        
-        # Collect all files recursively
-        files_data = []
-        total_size = 0
-        
-        for root, dirs, files in os.walk(dir_path):
-            for filename in files:
-                file_path = os.path.join(root, filename)
-                # Get relative path from base directory
-                rel_path = os.path.relpath(file_path, dir_path)
-                
-                # Read file content
-                try:
-                    with open(file_path, 'rb') as f:
-                        content = f.read()
-                    
-                    files_data.append({
-                        'path': rel_path.replace('\\', '/'),  # Use forward slashes for cross-platform
-                        'size': len(content),
-                        'content': content
-                    })
-                    total_size += len(content)
-                except Exception as e:
-                    # Skip files that can't be read
-                    print(f"Warning: Skipping {file_path}: {str(e)}")
-                    continue
-        
-        if not files_data:
-            raise CompressionError("No files found in directory")
-        
-        # Create archive structure
-        # Format: [metadata_json_length:4bytes][metadata_json][file1_compressed][file2_compressed]...
-        archive = bytearray()
-        
-        # Build metadata
-        metadata = {
-            'version': 1,
-            'file_count': len(files_data),
-            'total_size': total_size,
-            'files': []
-        }
-        
-        # Compress each file
-        compressed_files = []
-        for file_info in files_data:
-            compressed_content, _ = compress(file_info['content'], strategy=strategy)
-            compressed_files.append(compressed_content)
-            
-            metadata['files'].append({
-                'path': file_info['path'],
-                'original_size': file_info['size'],
-                'compressed_size': len(compressed_content)
-            })
-        
-        # Serialize metadata
-        metadata_json = json.dumps(metadata).encode('utf-8')
-        metadata_length = len(metadata_json)
-        
-        # Build archive
-        archive.extend(struct.pack('>I', metadata_length))
-        archive.extend(metadata_json)
-        
-        for compressed_content in compressed_files:
-            archive.extend(compressed_content)
-        
-        # Determine output path
+
         if output_path is None:
             output_path = dir_path.rstrip('/\\') + '.cjz'
-        
-        # Write archive
-        with open(output_path, 'wb') as f:
-            f.write(archive)
-        
-        # Calculate stats
+        output_path_abs = os.path.abspath(output_path)
+        archive_write_path = output_path_abs
+        if password is not None:
+            temp_archive_path = _create_temp_archive_path(output_path_abs)
+            archive_write_path = temp_archive_path
+        excluded_paths = [output_path_abs, temp_archive_path]
+
+        start_time = time.time()
+        total_size = 0
+        file_count = 0
+        effective_strategy = _normalize_dir_strategy(strategy)
+        marker = _DIR_STREAM_MARKERS[effective_strategy]
+        progress_total = max(_get_directory_file_count(dir_path, exclude_paths=excluded_paths), 1) if verbose else None
+        progress = _create_progress(verbose, "Compressing directory", progress_total)
+
+        logger.info(
+            "Starting directory compression: %s",
+            dir_path,
+            extra={
+                "dir_path": dir_path,
+                "output_path": output_path,
+                "strategy": effective_strategy.value,
+            },
+        )
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(archive_write_path, 'wb') as archive:
+                archive.write(_DIR_ARCHIVE_MAGIC)
+
+                for file_path, rel_path in _iter_directory_files(dir_path, exclude_paths=excluded_paths):
+                    try:
+                        original_size = os.path.getsize(file_path)
+                        source = open(file_path, 'rb')
+                    except OSError:
+                        logger.warning("Skipping unreadable file during directory compression: %s", file_path, exc_info=True)
+                        continue
+
+                    with source:
+                        path_bytes = rel_path.encode('utf-8')
+                        compressor = _create_dir_compressor(effective_strategy)
+
+                        archive.write(_DIR_RECORD_FILE)
+                        archive.write(struct.pack('>I', len(path_bytes)))
+                        archive.write(path_bytes)
+                        archive.write(struct.pack('>Q', original_size))
+                        archive.write(marker)
+
+                        while True:
+                            chunk = source.read(_DIR_CHUNK_SIZE)
+                            if not chunk:
+                                break
+                            total_size += len(chunk)
+                            _write_sized_chunk(archive, compressor.compress(chunk))
+
+                        _write_sized_chunk(archive, compressor.flush())
+                        archive.write(struct.pack('>I', 0))
+                        file_count += 1
+                        if active_progress is not None:
+                            active_progress.show_progress(file_count)
+
+                archive.write(_DIR_RECORD_END)
+
+        if file_count == 0:
+            try:
+                os.remove(archive_write_path)
+            except OSError:
+                # Best effort cleanup of an archive created by this failed call.
+                pass
+            raise CompressionError("No files found in directory")
+
+        if password is not None:
+            with open(archive_write_path, 'rb') as archive:
+                archive_data = archive.read()
+            with open(output_path_abs, 'wb') as archive:
+                archive.write(_encrypt_archive_payload(archive_data, password))
+            try:
+                os.remove(archive_write_path)
+            except OSError:
+                pass
+            temp_archive_path = None
+
+        elapsed_ms = (time.time() - start_time) * 1000
+        compressed_size = os.path.getsize(output_path_abs)
         stats = CompressionStats(
             total_size,
-            len(archive),
-            CompressionStrategy.HYBRID,  # Directory uses multiple strategies
-            0
+            compressed_size,
+            effective_strategy,
+            elapsed_ms
         )
-        
+
+        logger.info(
+            "Directory compression finished: %s",
+            output_path,
+            extra={
+                "dir_path": dir_path,
+                "output_path": output_path,
+                "file_count": file_count,
+                "original_size": total_size,
+                "compressed_size": compressed_size,
+                "strategy": effective_strategy.value,
+            },
+        )
+
         return output_path, stats
-    
+
     except (FileNotFoundError, NotADirectoryError):
         raise
     except Exception as e:
-        raise CompressionError(f"Directory compression failed: {str(e)}")
+        if temp_archive_path is not None:
+            try:
+                os.remove(temp_archive_path)
+            except OSError:
+                pass
+        raise CompressionError(f"Directory compression failed: {str(e)}") from e
 
 
-def decompress_dir(archive_path: str, output_dir: str = None) -> str:
+def _decompress_dir_stream(archive_path: str, output_dir: str, verbose: bool = False) -> str:
+    import os
+    from contextlib import nullcontext
+
+    os.makedirs(output_dir, exist_ok=True)
+    file_count = _count_dir_stream_files(archive_path) if verbose else None
+    progress = _create_progress(verbose, "Decompressing directory", max(file_count or 0, 1))
+    extracted_count = 0
+
+    with progress if progress is not None else nullcontext() as active_progress:
+        with open(archive_path, 'rb') as archive:
+            _read_exact(archive, len(_DIR_ARCHIVE_MAGIC))
+
+            while True:
+                record_type = _read_exact(archive, 1)
+                if record_type == _DIR_RECORD_END:
+                    break
+                if record_type != _DIR_RECORD_FILE:
+                    raise CompressionError(f"Invalid directory archive record: {record_type}")
+
+                path_length = _read_uint32(archive)
+                path = _read_exact(archive, path_length).decode('utf-8')
+                _read_uint64(archive)
+                marker = _read_exact(archive, 1)
+
+                if marker not in _DIR_STREAM_STRATEGIES:
+                    raise CompressionError(f"Unknown directory compression marker: {marker}")
+
+                file_path = _safe_archive_path(output_dir, path)
+                parent_dir = os.path.dirname(file_path)
+                if parent_dir:
+                    os.makedirs(parent_dir, exist_ok=True)
+
+                decompressor = _create_dir_decompressor(_DIR_STREAM_STRATEGIES[marker])
+                with open(file_path, 'wb') as output_file:
+                    while True:
+                        chunk_size = _read_uint32(archive)
+                        if chunk_size == 0:
+                            break
+
+                        compressed_chunk = _read_exact(archive, chunk_size)
+                        decompressed_chunk = decompressor.decompress(compressed_chunk)
+                        if decompressed_chunk:
+                            output_file.write(decompressed_chunk)
+
+                    flush = getattr(decompressor, "flush", None)
+                    if flush is not None:
+                        remaining = flush()
+                        if remaining:
+                            output_file.write(remaining)
+
+                extracted_count += 1
+                if active_progress is not None:
+                    active_progress.show_progress(extracted_count)
+
+    return output_dir
+
+
+def _decompress_dir_legacy(archive_path: str, output_dir: str, verbose: bool = False) -> str:
+    import os
+    import json
+    from contextlib import nullcontext
+
+    with open(archive_path, 'rb') as f:
+        archive_data = f.read()
+
+    metadata_length = struct.unpack('>I', archive_data[0:4])[0]
+    metadata_json = archive_data[4:4+metadata_length]
+    metadata = json.loads(metadata_json.decode('utf-8'))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    offset = 4 + metadata_length
+    progress = _create_progress(verbose, "Decompressing directory", max(len(metadata['files']), 1))
+
+    with progress if progress is not None else nullcontext() as active_progress:
+        for index, file_info in enumerate(metadata['files'], start=1):
+            compressed_size = file_info['compressed_size']
+            compressed_content = archive_data[offset:offset+compressed_size]
+            offset += compressed_size
+
+            decompressed_content = decompress(compressed_content)
+            file_path = _safe_archive_path(output_dir, file_info['path'])
+            parent_dir = os.path.dirname(file_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            with open(file_path, 'wb') as f:
+                f.write(decompressed_content)
+            if active_progress is not None:
+                active_progress.show_progress(index)
+
+    return output_dir
+
+
+def decompress_dir(archive_path: str, output_dir: str = None,
+                   verbose: bool = False,
+                   password: Optional[Union[str, bytes]] = None) -> str:
     """
     Decompress directory archive.
     
@@ -885,6 +1241,8 @@ def decompress_dir(archive_path: str, output_dir: str = None) -> str:
     Args:
         archive_path: Path to compressed archive (.cjz)
         output_dir: Path for extracted directory (if None, removes '.cjz' extension)
+        verbose: Whether to show progress while decompressing (default: False)
+        password: Password used when archive is encrypted (default: None)
     
     Returns:
         Path to extracted directory
@@ -900,57 +1258,54 @@ def decompress_dir(archive_path: str, output_dir: str = None) -> str:
         >>> print(f"Extracted to {extracted_dir}")
     """
     import os
-    import json
+
+    temp_archive_path = None
     
     try:
         if not os.path.exists(archive_path):
             raise FileNotFoundError(f"Archive not found: {archive_path}")
-        
-        # Read archive
-        with open(archive_path, 'rb') as f:
-            archive_data = f.read()
-        
-        # Read metadata length
-        metadata_length = struct.unpack('>I', archive_data[0:4])[0]
-        
-        # Read metadata
-        metadata_json = archive_data[4:4+metadata_length]
-        metadata = json.loads(metadata_json.decode('utf-8'))
-        
-        # Determine output directory
+
         if output_dir is None:
-            if archive_path.endswith('.cjz'):
-                output_dir = archive_path[:-4]
-            else:
-                output_dir = archive_path + '_extracted'
-        
-        # Create output directory
-        os.makedirs(output_dir, exist_ok=True)
-        
-        # Decompress files
-        offset = 4 + metadata_length
-        
-        for file_info in metadata['files']:
-            compressed_size = file_info['compressed_size']
-            compressed_content = archive_data[offset:offset+compressed_size]
-            offset += compressed_size
-            
-            # Decompress
-            decompressed_content = decompress(compressed_content)
-            
-            # Create file path
-            file_path = os.path.join(output_dir, file_info['path'].replace('/', os.sep))
-            
-            # Create parent directories if needed
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            
-            # Write file
-            with open(file_path, 'wb') as f:
-                f.write(decompressed_content)
-        
-        return output_dir
+            output_dir = _get_default_output_dir(archive_path)
+
+        logger.info(
+            "Starting directory decompression: %s",
+            archive_path,
+            extra={"archive_path": archive_path, "output_dir": output_dir},
+        )
+
+        archive_read_path = archive_path
+        if is_encrypted_archive(archive_path):
+            with open(archive_path, 'rb') as archive:
+                encrypted_archive = archive.read()
+            decrypted_archive = _decrypt_archive_payload(encrypted_archive, password)
+            temp_archive_path = _create_temp_archive_path(os.path.abspath(archive_path))
+            with open(temp_archive_path, 'wb') as archive:
+                archive.write(decrypted_archive)
+            archive_read_path = temp_archive_path
+
+        with open(archive_read_path, 'rb') as archive:
+            magic = archive.read(len(_DIR_ARCHIVE_MAGIC))
+
+        if magic == _DIR_ARCHIVE_MAGIC:
+            result = _decompress_dir_stream(archive_read_path, output_dir, verbose=verbose)
+        else:
+            result = _decompress_dir_legacy(archive_read_path, output_dir, verbose=verbose)
+
+        logger.info(
+            "Directory decompression finished: %s",
+            output_dir,
+            extra={"archive_path": archive_path, "output_dir": output_dir},
+        )
+        return result
     
     except FileNotFoundError:
         raise
     except Exception as e:
-        raise CompressionError(f"Directory decompression failed: {str(e)}")
+        raise CompressionError(f"Directory decompression failed: {str(e)}") from e
+    finally:
+        if temp_archive_path is not None:
+            try:
+                os.remove(temp_archive_path)
+            except OSError:
+                pass

--- a/cereja/hashtools/_compress.py
+++ b/cereja/hashtools/_compress.py
@@ -24,9 +24,12 @@ import bz2
 import lzma
 import struct
 import base64
+import logging
 from enum import Enum
-from typing import Union, Tuple, Dict, Any
+from typing import Union, Tuple, Dict, Any, Optional
 from collections import Counter
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "compress",
@@ -648,8 +651,9 @@ def decompress(data: bytes) -> bytes:
         raise CompressionError(f"Decompression failed: {str(e)}")
 
 
-def compress_file(file_path: str, output_path: str = None, 
-                  strategy: Union[str, CompressionStrategy] = 'auto') -> Tuple[str, CompressionStats]:
+def compress_file(file_path: str, output_path: str = None,
+                  strategy: Union[str, CompressionStrategy] = 'auto',
+                  verbose: bool = False) -> Tuple[str, CompressionStats]:
     """
     Compress file contents.
     
@@ -657,6 +661,7 @@ def compress_file(file_path: str, output_path: str = None,
         file_path: Path to file to compress
         output_path: Path for compressed file (if None, uses file_path + '.cjz')
         strategy: Compression strategy (default: 'auto')
+        verbose: Whether to show progress while compressing (default: False)
     
     Returns:
         Tuple of (output_path, compression_stats)
@@ -665,10 +670,17 @@ def compress_file(file_path: str, output_path: str = None,
         CompressionError: If compression fails
         FileNotFoundError: If input file doesn't exist
     """
+    import os
+    from contextlib import nullcontext
+
     try:
-        # Read file
-        with open(file_path, 'rb') as f:
-            data = f.read()
+        progress = _create_progress(verbose, "Compressing file", 1)
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(file_path, 'rb') as f:
+                data = f.read()
+            if active_progress is not None:
+                active_progress.show_progress(1)
         
         # Compress
         compressed, stats = compress(data, strategy=strategy)
@@ -689,13 +701,14 @@ def compress_file(file_path: str, output_path: str = None,
         raise CompressionError(f"File compression failed: {str(e)}")
 
 
-def decompress_file(file_path: str, output_path: str = None) -> str:
+def decompress_file(file_path: str, output_path: str = None, verbose: bool = False) -> str:
     """
     Decompress file contents.
     
     Args:
         file_path: Path to compressed file
         output_path: Path for decompressed file (if None, removes '.cjz' extension)
+        verbose: Whether to show progress while decompressing (default: False)
     
     Returns:
         Path to decompressed file
@@ -704,10 +717,17 @@ def decompress_file(file_path: str, output_path: str = None) -> str:
         CompressionError: If decompression fails
         FileNotFoundError: If input file doesn't exist
     """
+    import os
+    from contextlib import nullcontext
+
     try:
-        # Read compressed file
-        with open(file_path, 'rb') as f:
-            compressed_data = f.read()
+        progress = _create_progress(verbose, "Decompressing file", 1)
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(file_path, 'rb') as f:
+                compressed_data = f.read()
+            if active_progress is not None:
+                active_progress.show_progress(1)
         
         # Decompress
         decompressed = decompress(compressed_data)
@@ -751,8 +771,155 @@ def get_compression_ratio(original: Union[str, bytes], compressed: bytes) -> flo
     return len(original) / len(compressed)
 
 
-def compress_dir(dir_path: str, output_path: str = None, 
-                 strategy: Union[str, CompressionStrategy] = 'auto') -> Tuple[str, CompressionStats]:
+_DIR_ARCHIVE_MAGIC = b"CJZD\x02"
+_DIR_RECORD_FILE = b"\x01"
+_DIR_RECORD_END = b"\x00"
+_DIR_CHUNK_SIZE = 1024 * 1024
+_DIR_STREAM_MARKERS = {
+    CompressionStrategy.ZLIB: b'\x10',
+    CompressionStrategy.BZ2: b'\x11',
+    CompressionStrategy.LZMA: b'\x12',
+}
+_DIR_STREAM_STRATEGIES = {marker: strategy for strategy, marker in _DIR_STREAM_MARKERS.items()}
+
+
+def _iter_directory_files(dir_path: str, exclude_path: str = None):
+    import os
+
+    exclude_abs = os.path.abspath(exclude_path) if exclude_path is not None else None
+
+    for root, dirs, files in os.walk(dir_path):
+        dirs.sort()
+        files.sort()
+
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            if exclude_abs is not None and os.path.abspath(file_path) == exclude_abs:
+                continue
+            rel_path = os.path.relpath(file_path, dir_path).replace('\\', '/')
+            yield file_path, rel_path
+
+
+def _get_directory_file_count(dir_path: str, exclude_path: str = None) -> int:
+    return sum(1 for _ in _iter_directory_files(dir_path, exclude_path=exclude_path))
+
+
+def _create_progress(enabled: bool, name: str, max_value: Optional[int] = None):
+    if not enabled:
+        return None
+
+    from cereja.display import Progress
+
+    return Progress(name=name, max_value=max_value, states=("value", "bar", "percent", "time"))
+
+
+def _normalize_dir_strategy(strategy: Union[str, CompressionStrategy]) -> CompressionStrategy:
+    if isinstance(strategy, str):
+        if strategy == 'auto':
+            strategy = CompressionStrategy.AUTO
+        else:
+            strategy = CompressionStrategy(strategy)
+
+    if strategy in (CompressionStrategy.BZ2, CompressionStrategy.LZMA):
+        return strategy
+
+    return CompressionStrategy.ZLIB
+
+
+def _create_dir_compressor(strategy: CompressionStrategy, level: int = 6):
+    if strategy == CompressionStrategy.BZ2:
+        return bz2.BZ2Compressor(level)
+    if strategy == CompressionStrategy.LZMA:
+        return lzma.LZMACompressor(preset=level)
+    return zlib.compressobj(level)
+
+
+def _create_dir_decompressor(strategy: CompressionStrategy):
+    if strategy == CompressionStrategy.BZ2:
+        return bz2.BZ2Decompressor()
+    if strategy == CompressionStrategy.LZMA:
+        return lzma.LZMADecompressor()
+    return zlib.decompressobj()
+
+
+def _read_exact(file_obj, size: int) -> bytes:
+    data = file_obj.read(size)
+    if len(data) != size:
+        raise CompressionError("Unexpected end of directory archive")
+    return data
+
+
+def _write_sized_chunk(file_obj, data: bytes) -> None:
+    if data:
+        file_obj.write(struct.pack('>I', len(data)))
+        file_obj.write(data)
+
+
+def _read_uint32(file_obj) -> int:
+    return struct.unpack('>I', _read_exact(file_obj, 4))[0]
+
+
+def _read_uint64(file_obj) -> int:
+    return struct.unpack('>Q', _read_exact(file_obj, 8))[0]
+
+
+def _count_dir_stream_files(archive_path: str) -> int:
+    file_count = 0
+
+    with open(archive_path, 'rb') as archive:
+        _read_exact(archive, len(_DIR_ARCHIVE_MAGIC))
+
+        while True:
+            record_type = _read_exact(archive, 1)
+            if record_type == _DIR_RECORD_END:
+                break
+            if record_type != _DIR_RECORD_FILE:
+                raise CompressionError(f"Invalid directory archive record: {record_type}")
+
+            path_length = _read_uint32(archive)
+            _read_exact(archive, path_length)
+            _read_uint64(archive)
+            marker = _read_exact(archive, 1)
+
+            if marker not in _DIR_STREAM_STRATEGIES:
+                raise CompressionError(f"Unknown directory compression marker: {marker}")
+
+            while True:
+                chunk_size = _read_uint32(archive)
+                if chunk_size == 0:
+                    break
+                _read_exact(archive, chunk_size)
+
+            file_count += 1
+
+    return file_count
+
+
+def _safe_archive_path(output_dir: str, archive_file_path: str) -> str:
+    import os
+
+    normalized_path = archive_file_path.replace('\\', '/')
+    if not normalized_path or normalized_path.startswith('/') or normalized_path.startswith('../'):
+        raise CompressionError(f"Unsafe archive path: {archive_file_path}")
+
+    output_dir_abs = os.path.abspath(output_dir)
+    file_path = os.path.abspath(os.path.join(output_dir_abs, normalized_path.replace('/', os.sep)))
+
+    if os.path.commonpath([output_dir_abs, file_path]) != output_dir_abs:
+        raise CompressionError(f"Unsafe archive path: {archive_file_path}")
+
+    return file_path
+
+
+def _get_default_output_dir(archive_path: str) -> str:
+    if archive_path.endswith('.cjz'):
+        return archive_path[:-4]
+    return archive_path + '_extracted'
+
+
+def compress_dir(dir_path: str, output_path: str = None,
+                 strategy: Union[str, CompressionStrategy] = 'auto',
+                 verbose: bool = False) -> Tuple[str, CompressionStats]:
     """
     Compress entire directory recursively.
     
@@ -763,6 +930,7 @@ def compress_dir(dir_path: str, output_path: str = None,
         dir_path: Path to directory to compress
         output_path: Path for compressed archive (if None, uses dir_path + '.cjz')
         strategy: Compression strategy (default: 'auto')
+        verbose: Whether to show progress while compressing (default: False)
     
     Returns:
         Tuple of (output_path, compression_stats)
@@ -779,7 +947,8 @@ def compress_dir(dir_path: str, output_path: str = None,
         >>> print(f"Compressed to {archive} with {stats.ratio:.2f}x ratio")
     """
     import os
-    import json
+    import time
+    from contextlib import nullcontext
     
     try:
         if not os.path.exists(dir_path):
@@ -787,96 +956,200 @@ def compress_dir(dir_path: str, output_path: str = None,
         
         if not os.path.isdir(dir_path):
             raise NotADirectoryError(f"Path is not a directory: {dir_path}")
-        
-        # Collect all files recursively
-        files_data = []
-        total_size = 0
-        
-        for root, dirs, files in os.walk(dir_path):
-            for filename in files:
-                file_path = os.path.join(root, filename)
-                # Get relative path from base directory
-                rel_path = os.path.relpath(file_path, dir_path)
-                
-                # Read file content
-                try:
-                    with open(file_path, 'rb') as f:
-                        content = f.read()
-                    
-                    files_data.append({
-                        'path': rel_path.replace('\\', '/'),  # Use forward slashes for cross-platform
-                        'size': len(content),
-                        'content': content
-                    })
-                    total_size += len(content)
-                except Exception as e:
-                    # Skip files that can't be read
-                    print(f"Warning: Skipping {file_path}: {str(e)}")
-                    continue
-        
-        if not files_data:
-            raise CompressionError("No files found in directory")
-        
-        # Create archive structure
-        # Format: [metadata_json_length:4bytes][metadata_json][file1_compressed][file2_compressed]...
-        archive = bytearray()
-        
-        # Build metadata
-        metadata = {
-            'version': 1,
-            'file_count': len(files_data),
-            'total_size': total_size,
-            'files': []
-        }
-        
-        # Compress each file
-        compressed_files = []
-        for file_info in files_data:
-            compressed_content, _ = compress(file_info['content'], strategy=strategy)
-            compressed_files.append(compressed_content)
-            
-            metadata['files'].append({
-                'path': file_info['path'],
-                'original_size': file_info['size'],
-                'compressed_size': len(compressed_content)
-            })
-        
-        # Serialize metadata
-        metadata_json = json.dumps(metadata).encode('utf-8')
-        metadata_length = len(metadata_json)
-        
-        # Build archive
-        archive.extend(struct.pack('>I', metadata_length))
-        archive.extend(metadata_json)
-        
-        for compressed_content in compressed_files:
-            archive.extend(compressed_content)
-        
-        # Determine output path
+
         if output_path is None:
             output_path = dir_path.rstrip('/\\') + '.cjz'
-        
-        # Write archive
-        with open(output_path, 'wb') as f:
-            f.write(archive)
-        
-        # Calculate stats
+        output_path_abs = os.path.abspath(output_path)
+
+        start_time = time.time()
+        total_size = 0
+        file_count = 0
+        effective_strategy = _normalize_dir_strategy(strategy)
+        marker = _DIR_STREAM_MARKERS[effective_strategy]
+        progress_total = max(_get_directory_file_count(dir_path, exclude_path=output_path_abs), 1) if verbose else None
+        progress = _create_progress(verbose, "Compressing directory", progress_total)
+
+        logger.info(
+            "Starting directory compression: %s",
+            dir_path,
+            extra={
+                "dir_path": dir_path,
+                "output_path": output_path,
+                "strategy": effective_strategy.value,
+            },
+        )
+
+        with progress if progress is not None else nullcontext() as active_progress:
+            with open(output_path_abs, 'wb') as archive:
+                archive.write(_DIR_ARCHIVE_MAGIC)
+
+                for file_path, rel_path in _iter_directory_files(dir_path, exclude_path=output_path_abs):
+                    try:
+                        original_size = os.path.getsize(file_path)
+                        source = open(file_path, 'rb')
+                    except OSError:
+                        logger.warning("Skipping unreadable file during directory compression: %s", file_path, exc_info=True)
+                        continue
+
+                    with source:
+                        path_bytes = rel_path.encode('utf-8')
+                        compressor = _create_dir_compressor(effective_strategy)
+
+                        archive.write(_DIR_RECORD_FILE)
+                        archive.write(struct.pack('>I', len(path_bytes)))
+                        archive.write(path_bytes)
+                        archive.write(struct.pack('>Q', original_size))
+                        archive.write(marker)
+
+                        while True:
+                            chunk = source.read(_DIR_CHUNK_SIZE)
+                            if not chunk:
+                                break
+                            total_size += len(chunk)
+                            _write_sized_chunk(archive, compressor.compress(chunk))
+
+                        _write_sized_chunk(archive, compressor.flush())
+                        archive.write(struct.pack('>I', 0))
+                        file_count += 1
+                        if active_progress is not None:
+                            active_progress.show_progress(file_count)
+
+                archive.write(_DIR_RECORD_END)
+
+        if file_count == 0:
+            try:
+                os.remove(output_path_abs)
+            except OSError:
+                # Best effort cleanup of an archive created by this failed call.
+                pass
+            raise CompressionError("No files found in directory")
+
+        elapsed_ms = (time.time() - start_time) * 1000
+        compressed_size = os.path.getsize(output_path_abs)
         stats = CompressionStats(
             total_size,
-            len(archive),
-            CompressionStrategy.HYBRID,  # Directory uses multiple strategies
-            0
+            compressed_size,
+            effective_strategy,
+            elapsed_ms
         )
-        
+
+        logger.info(
+            "Directory compression finished: %s",
+            output_path,
+            extra={
+                "dir_path": dir_path,
+                "output_path": output_path,
+                "file_count": file_count,
+                "original_size": total_size,
+                "compressed_size": compressed_size,
+                "strategy": effective_strategy.value,
+            },
+        )
+
         return output_path, stats
-    
+
     except (FileNotFoundError, NotADirectoryError):
         raise
     except Exception as e:
-        raise CompressionError(f"Directory compression failed: {str(e)}")
+        raise CompressionError(f"Directory compression failed: {str(e)}") from e
 
 
-def decompress_dir(archive_path: str, output_dir: str = None) -> str:
+def _decompress_dir_stream(archive_path: str, output_dir: str, verbose: bool = False) -> str:
+    import os
+    from contextlib import nullcontext
+
+    os.makedirs(output_dir, exist_ok=True)
+    file_count = _count_dir_stream_files(archive_path) if verbose else None
+    progress = _create_progress(verbose, "Decompressing directory", max(file_count or 0, 1))
+    extracted_count = 0
+
+    with progress if progress is not None else nullcontext() as active_progress:
+        with open(archive_path, 'rb') as archive:
+            _read_exact(archive, len(_DIR_ARCHIVE_MAGIC))
+
+            while True:
+                record_type = _read_exact(archive, 1)
+                if record_type == _DIR_RECORD_END:
+                    break
+                if record_type != _DIR_RECORD_FILE:
+                    raise CompressionError(f"Invalid directory archive record: {record_type}")
+
+                path_length = _read_uint32(archive)
+                path = _read_exact(archive, path_length).decode('utf-8')
+                _read_uint64(archive)
+                marker = _read_exact(archive, 1)
+
+                if marker not in _DIR_STREAM_STRATEGIES:
+                    raise CompressionError(f"Unknown directory compression marker: {marker}")
+
+                file_path = _safe_archive_path(output_dir, path)
+                parent_dir = os.path.dirname(file_path)
+                if parent_dir:
+                    os.makedirs(parent_dir, exist_ok=True)
+
+                decompressor = _create_dir_decompressor(_DIR_STREAM_STRATEGIES[marker])
+                with open(file_path, 'wb') as output_file:
+                    while True:
+                        chunk_size = _read_uint32(archive)
+                        if chunk_size == 0:
+                            break
+
+                        compressed_chunk = _read_exact(archive, chunk_size)
+                        decompressed_chunk = decompressor.decompress(compressed_chunk)
+                        if decompressed_chunk:
+                            output_file.write(decompressed_chunk)
+
+                    flush = getattr(decompressor, "flush", None)
+                    if flush is not None:
+                        remaining = flush()
+                        if remaining:
+                            output_file.write(remaining)
+
+                extracted_count += 1
+                if active_progress is not None:
+                    active_progress.show_progress(extracted_count)
+
+    return output_dir
+
+
+def _decompress_dir_legacy(archive_path: str, output_dir: str, verbose: bool = False) -> str:
+    import os
+    import json
+    from contextlib import nullcontext
+
+    with open(archive_path, 'rb') as f:
+        archive_data = f.read()
+
+    metadata_length = struct.unpack('>I', archive_data[0:4])[0]
+    metadata_json = archive_data[4:4+metadata_length]
+    metadata = json.loads(metadata_json.decode('utf-8'))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    offset = 4 + metadata_length
+    progress = _create_progress(verbose, "Decompressing directory", max(len(metadata['files']), 1))
+
+    with progress if progress is not None else nullcontext() as active_progress:
+        for index, file_info in enumerate(metadata['files'], start=1):
+            compressed_size = file_info['compressed_size']
+            compressed_content = archive_data[offset:offset+compressed_size]
+            offset += compressed_size
+
+            decompressed_content = decompress(compressed_content)
+            file_path = _safe_archive_path(output_dir, file_info['path'])
+            parent_dir = os.path.dirname(file_path)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+
+            with open(file_path, 'wb') as f:
+                f.write(decompressed_content)
+            if active_progress is not None:
+                active_progress.show_progress(index)
+
+    return output_dir
+
+
+def decompress_dir(archive_path: str, output_dir: str = None, verbose: bool = False) -> str:
     """
     Decompress directory archive.
     
@@ -885,6 +1158,7 @@ def decompress_dir(archive_path: str, output_dir: str = None) -> str:
     Args:
         archive_path: Path to compressed archive (.cjz)
         output_dir: Path for extracted directory (if None, removes '.cjz' extension)
+        verbose: Whether to show progress while decompressing (default: False)
     
     Returns:
         Path to extracted directory
@@ -900,57 +1174,36 @@ def decompress_dir(archive_path: str, output_dir: str = None) -> str:
         >>> print(f"Extracted to {extracted_dir}")
     """
     import os
-    import json
     
     try:
         if not os.path.exists(archive_path):
             raise FileNotFoundError(f"Archive not found: {archive_path}")
-        
-        # Read archive
-        with open(archive_path, 'rb') as f:
-            archive_data = f.read()
-        
-        # Read metadata length
-        metadata_length = struct.unpack('>I', archive_data[0:4])[0]
-        
-        # Read metadata
-        metadata_json = archive_data[4:4+metadata_length]
-        metadata = json.loads(metadata_json.decode('utf-8'))
-        
-        # Determine output directory
+
         if output_dir is None:
-            if archive_path.endswith('.cjz'):
-                output_dir = archive_path[:-4]
-            else:
-                output_dir = archive_path + '_extracted'
-        
-        # Create output directory
-        os.makedirs(output_dir, exist_ok=True)
-        
-        # Decompress files
-        offset = 4 + metadata_length
-        
-        for file_info in metadata['files']:
-            compressed_size = file_info['compressed_size']
-            compressed_content = archive_data[offset:offset+compressed_size]
-            offset += compressed_size
-            
-            # Decompress
-            decompressed_content = decompress(compressed_content)
-            
-            # Create file path
-            file_path = os.path.join(output_dir, file_info['path'].replace('/', os.sep))
-            
-            # Create parent directories if needed
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            
-            # Write file
-            with open(file_path, 'wb') as f:
-                f.write(decompressed_content)
-        
-        return output_dir
+            output_dir = _get_default_output_dir(archive_path)
+
+        logger.info(
+            "Starting directory decompression: %s",
+            archive_path,
+            extra={"archive_path": archive_path, "output_dir": output_dir},
+        )
+
+        with open(archive_path, 'rb') as archive:
+            magic = archive.read(len(_DIR_ARCHIVE_MAGIC))
+
+        if magic == _DIR_ARCHIVE_MAGIC:
+            result = _decompress_dir_stream(archive_path, output_dir, verbose=verbose)
+        else:
+            result = _decompress_dir_legacy(archive_path, output_dir, verbose=verbose)
+
+        logger.info(
+            "Directory decompression finished: %s",
+            output_dir,
+            extra={"archive_path": archive_path, "output_dir": output_dir},
+        )
+        return result
     
     except FileNotFoundError:
         raise
     except Exception as e:
-        raise CompressionError(f"Directory decompression failed: {str(e)}")
+        raise CompressionError(f"Directory decompression failed: {str(e)}") from e

--- a/cereja/hashtools/_crypto.py
+++ b/cereja/hashtools/_crypto.py
@@ -70,16 +70,19 @@ def _generate_keystream(key: bytes, iv: bytes, length: int) -> bytes:
     Generate keystream using HMAC-based key expansion.
     This creates a cryptographically secure stream cipher.
     """
-    keystream = b''
+    chunks = []
     counter = 0
+    remaining = length
     
-    while len(keystream) < length:
+    while remaining > 0:
         # Use HMAC with counter for key expansion
         h = hmac.new(key, iv + counter.to_bytes(4, 'big'), hashlib.sha256)
-        keystream += h.digest()
+        digest = h.digest()
+        chunks.append(digest)
+        remaining -= len(digest)
         counter += 1
     
-    return keystream[:length]
+    return b''.join(chunks)[:length]
 
 
 def generate_key(password: Union[str, bytes], salt: bytes = None, iterations: int = 100000) -> Tuple[bytes, bytes]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ classifiers = [
 [tool.setuptools.dynamic]
 version = {attr = "cereja.__version__"}
 
+[project.scripts]
+cereja = "cereja.cli:main"
+
 [project.urls]
 "Homepage" = "https://github.com/cereja-project/cereja"
 "Bug Tracker" = "https://github.com/cereja-project/cereja/issues/new/choose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ description = "Cereja is a bundle of useful functions that I don't want to rewri
 readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["progress bar", "utils", "array", "pln", "file utils"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,135 @@
+import io
+import shutil
+import subprocess
+import sys
+import unittest
+import uuid
+from contextlib import contextmanager
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from cereja.cli import main
+
+
+@contextmanager
+def temporary_workspace_directory():
+    temp_dir = Path.cwd() / f"test_cli_{uuid.uuid4().hex}"
+    temp_dir.mkdir()
+    try:
+        yield str(temp_dir)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+class CliTest(unittest.TestCase):
+    """Test suite for the Cereja command-line interface."""
+
+    def test_module_help_returns_success(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "cereja", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Cereja Tools.", result.stdout)
+        self.assertIn("compress", result.stdout)
+
+    def test_module_version_returns_success(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "cereja", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(result.stdout.strip())
+
+    def test_compress_and_decompress_file_restore_original_bytes(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            compressed_path = Path(temp_dir) / "source.txt.cjz"
+            restored_path = Path(temp_dir) / "restored.txt"
+            source_path.write_bytes(b"Cereja CLI compression test.\n" * 50)
+
+            with redirect_stdout(io.StringIO()):
+                compress_code = main(["compress", str(source_path), "-o", str(compressed_path)])
+                decompress_code = main(["decompress", str(compressed_path), "-o", str(restored_path)])
+
+            self.assertEqual(compress_code, 0)
+            self.assertEqual(decompress_code, 0)
+            self.assertEqual(restored_path.read_bytes(), source_path.read_bytes())
+
+    def test_compress_and_decompress_directory_restore_files(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            nested_dir = source_dir / "nested"
+            nested_dir.mkdir(parents=True)
+            (source_dir / "root.txt").write_bytes(b"root content")
+            (nested_dir / "child.txt").write_bytes(b"child content")
+            archive_path = Path(temp_dir) / "source.cjz"
+            restored_dir = Path(temp_dir) / "restored"
+
+            with redirect_stdout(io.StringIO()):
+                compress_code = main(["compress", str(source_dir), "-o", str(archive_path)])
+                decompress_code = main(
+                    ["decompress", str(archive_path), "-o", str(restored_dir), "--archive-type", "dir"]
+                )
+
+            self.assertEqual(compress_code, 0)
+            self.assertEqual(decompress_code, 0)
+            self.assertEqual((restored_dir / "root.txt").read_bytes(), b"root content")
+            self.assertEqual((restored_dir / "nested" / "child.txt").read_bytes(), b"child content")
+
+    def test_encrypt_and_decrypt_file_restore_original_bytes(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "secret.bin"
+            encrypted_path = Path(temp_dir) / "secret.enc"
+            restored_path = Path(temp_dir) / "secret.restored"
+            source_path.write_bytes(b"secret bytes\x00\x01\x02")
+
+            with patch("getpass.getpass", side_effect=["password", "password"]), redirect_stdout(io.StringIO()):
+                encrypt_code = main(["encrypt", str(source_path), "-o", str(encrypted_path)])
+            with patch("getpass.getpass", return_value="password"), redirect_stdout(io.StringIO()):
+                decrypt_code = main(["decrypt", str(encrypted_path), "-o", str(restored_path)])
+
+            self.assertEqual(encrypt_code, 0)
+            self.assertEqual(decrypt_code, 0)
+            self.assertEqual(restored_path.read_bytes(), source_path.read_bytes())
+
+    def test_encrypt_fails_when_password_confirmation_differs(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "secret.txt"
+            encrypted_path = Path(temp_dir) / "secret.enc"
+            source_path.write_text("secret", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with patch("getpass.getpass", side_effect=["password", "different"]):
+                with redirect_stderr(stderr):
+                    exit_code = main(["encrypt", str(source_path), "-o", str(encrypted_path)])
+
+            self.assertEqual(exit_code, 1)
+            self.assertFalse(encrypted_path.exists())
+            self.assertIn("Password confirmation does not match", stderr.getvalue())
+
+    def test_existing_output_fails_without_force(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            output_path = Path(temp_dir) / "source.cjz"
+            source_path.write_text("content", encoding="utf-8")
+            output_path.write_bytes(b"existing")
+            stderr = io.StringIO()
+
+            with redirect_stderr(stderr), redirect_stdout(io.StringIO()):
+                exit_code = main(["compress", str(source_path), "-o", str(output_path)])
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(output_path.read_bytes(), b"existing")
+            self.assertIn("Output already exists", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import io
+import os
 import shutil
 import subprocess
 import sys
@@ -7,9 +8,20 @@ import uuid
 from contextlib import contextmanager
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from cereja.cli import main
+
+
+def compression_stats():
+    return SimpleNamespace(
+        strategy=SimpleNamespace(value="zlib"),
+        original_size=10,
+        compressed_size=5,
+        ratio=2.0,
+        savings_percent=50.0,
+    )
 
 
 @contextmanager
@@ -20,6 +32,16 @@ def temporary_workspace_directory():
         yield str(temp_dir)
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@contextmanager
+def working_directory(path):
+    original_dir = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original_dir)
 
 
 class CliTest(unittest.TestCase):
@@ -83,6 +105,178 @@ class CliTest(unittest.TestCase):
             self.assertEqual(decompress_code, 0)
             self.assertEqual((restored_dir / "root.txt").read_bytes(), b"root content")
             self.assertEqual((restored_dir / "nested" / "child.txt").read_bytes(), b"child content")
+
+    def test_compress_directory_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            archive_path = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(archive_path), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(archive_path)])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(archive_path),
+                strategy="auto",
+                verbose=True,
+            )
+
+    def test_compress_directory_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            archive_path = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(archive_path), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(archive_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(archive_path),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_current_directory_uses_resolved_directory_name(self):
+        with temporary_workspace_directory() as temp_dir:
+            workspace = Path(temp_dir)
+            expected_archive = Path(workspace.name + ".cjz")
+
+            with working_directory(workspace):
+                with patch(
+                    "cereja.cli.compress_dir",
+                    return_value=(str(expected_archive), compression_stats()),
+                ) as compress_dir:
+                    with redirect_stdout(io.StringIO()):
+                        exit_code = main(["compress", ".", "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                ".",
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_directory_output_without_suffix_adds_cjz(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            output_path = Path(temp_dir) / "archive"
+            expected_archive = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(expected_archive), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(output_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_file_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            archive_path = Path(temp_dir) / "source.txt.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch("cereja.cli.compress_file", return_value=(str(archive_path), compression_stats())) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(archive_path)])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(archive_path),
+                strategy="auto",
+                verbose=True,
+            )
+
+    def test_compress_file_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            archive_path = Path(temp_dir) / "source.txt.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch("cereja.cli.compress_file", return_value=(str(archive_path), compression_stats())) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(archive_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(archive_path),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_file_output_without_suffix_adds_cjz(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            output_path = Path(temp_dir) / "archive"
+            expected_archive = Path(temp_dir) / "archive.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch(
+                "cereja.cli.compress_file",
+                return_value=(str(expected_archive), compression_stats()),
+            ) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(output_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_decompress_directory_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            archive_path = Path(temp_dir) / "archive.cjz"
+            output_dir = Path(temp_dir) / "output"
+            archive_path.write_bytes(b"archive")
+
+            with patch("cereja.cli.decompress_dir", return_value=str(output_dir)) as decompress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(
+                        ["decompress", str(archive_path), "-o", str(output_dir), "--archive-type", "dir"]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            decompress_dir.assert_called_once_with(str(archive_path), str(output_dir), verbose=True)
+
+    def test_decompress_directory_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            archive_path = Path(temp_dir) / "archive.cjz"
+            output_dir = Path(temp_dir) / "output"
+            archive_path.write_bytes(b"archive")
+
+            with patch("cereja.cli.decompress_dir", return_value=str(output_dir)) as decompress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(
+                        [
+                            "decompress",
+                            str(archive_path),
+                            "-o",
+                            str(output_dir),
+                            "--archive-type",
+                            "dir",
+                            "--quiet",
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            decompress_dir.assert_called_once_with(str(archive_path), str(output_dir), verbose=False)
 
     def test_encrypt_and_decrypt_file_restore_original_bytes(self):
         with temporary_workspace_directory() as temp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import io
+import os
 import shutil
 import subprocess
 import sys
@@ -7,9 +8,20 @@ import uuid
 from contextlib import contextmanager
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from cereja.cli import main
+
+
+def compression_stats():
+    return SimpleNamespace(
+        strategy=SimpleNamespace(value="zlib"),
+        original_size=10,
+        compressed_size=5,
+        ratio=2.0,
+        savings_percent=50.0,
+    )
 
 
 @contextmanager
@@ -20,6 +32,16 @@ def temporary_workspace_directory():
         yield str(temp_dir)
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@contextmanager
+def working_directory(path):
+    original_dir = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original_dir)
 
 
 class CliTest(unittest.TestCase):
@@ -63,6 +85,22 @@ class CliTest(unittest.TestCase):
             self.assertEqual(decompress_code, 0)
             self.assertEqual(restored_path.read_bytes(), source_path.read_bytes())
 
+    def test_compress_encrypt_and_decompress_file_restore_original_bytes(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            compressed_path = Path(temp_dir) / "source.txt.cjz"
+            restored_path = Path(temp_dir) / "restored.txt"
+            source_path.write_bytes(b"Cereja encrypted compression test.\n" * 50)
+
+            with patch("getpass.getpass", side_effect=["password", "password", "password"]):
+                with redirect_stdout(io.StringIO()):
+                    compress_code = main(["compress", str(source_path), "-o", str(compressed_path), "--encrypt"])
+                    decompress_code = main(["decompress", str(compressed_path), "-o", str(restored_path)])
+
+            self.assertEqual(compress_code, 0)
+            self.assertEqual(decompress_code, 0)
+            self.assertEqual(restored_path.read_bytes(), source_path.read_bytes())
+
     def test_compress_and_decompress_directory_restore_files(self):
         with temporary_workspace_directory() as temp_dir:
             source_dir = Path(temp_dir) / "source"
@@ -83,6 +121,178 @@ class CliTest(unittest.TestCase):
             self.assertEqual(decompress_code, 0)
             self.assertEqual((restored_dir / "root.txt").read_bytes(), b"root content")
             self.assertEqual((restored_dir / "nested" / "child.txt").read_bytes(), b"child content")
+
+    def test_compress_directory_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            archive_path = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(archive_path), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(archive_path)])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(archive_path),
+                strategy="auto",
+                verbose=True,
+            )
+
+    def test_compress_directory_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            archive_path = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(archive_path), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(archive_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(archive_path),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_current_directory_uses_resolved_directory_name(self):
+        with temporary_workspace_directory() as temp_dir:
+            workspace = Path(temp_dir)
+            expected_archive = Path(workspace.name + ".cjz")
+
+            with working_directory(workspace):
+                with patch(
+                    "cereja.cli.compress_dir",
+                    return_value=(str(expected_archive), compression_stats()),
+                ) as compress_dir:
+                    with redirect_stdout(io.StringIO()):
+                        exit_code = main(["compress", ".", "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                ".",
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_directory_output_without_suffix_adds_cjz(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_dir = Path(temp_dir) / "source"
+            source_dir.mkdir()
+            output_path = Path(temp_dir) / "archive"
+            expected_archive = Path(temp_dir) / "archive.cjz"
+
+            with patch("cereja.cli.compress_dir", return_value=(str(expected_archive), compression_stats())) as compress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_dir), "-o", str(output_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_dir.assert_called_once_with(
+                str(source_dir),
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_file_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            archive_path = Path(temp_dir) / "source.txt.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch("cereja.cli.compress_file", return_value=(str(archive_path), compression_stats())) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(archive_path)])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(archive_path),
+                strategy="auto",
+                verbose=True,
+            )
+
+    def test_compress_file_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            archive_path = Path(temp_dir) / "source.txt.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch("cereja.cli.compress_file", return_value=(str(archive_path), compression_stats())) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(archive_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(archive_path),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_compress_file_output_without_suffix_adds_cjz(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            output_path = Path(temp_dir) / "archive"
+            expected_archive = Path(temp_dir) / "archive.cjz"
+            source_path.write_text("content", encoding="utf-8")
+
+            with patch(
+                "cereja.cli.compress_file",
+                return_value=(str(expected_archive), compression_stats()),
+            ) as compress_file:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(["compress", str(source_path), "-o", str(output_path), "--quiet"])
+
+            self.assertEqual(exit_code, 0)
+            compress_file.assert_called_once_with(
+                str(source_path),
+                str(expected_archive),
+                strategy="auto",
+                verbose=False,
+            )
+
+    def test_decompress_directory_enables_progress_by_default(self):
+        with temporary_workspace_directory() as temp_dir:
+            archive_path = Path(temp_dir) / "archive.cjz"
+            output_dir = Path(temp_dir) / "output"
+            archive_path.write_bytes(b"archive")
+
+            with patch("cereja.cli.decompress_dir", return_value=str(output_dir)) as decompress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(
+                        ["decompress", str(archive_path), "-o", str(output_dir), "--archive-type", "dir"]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            decompress_dir.assert_called_once_with(str(archive_path), str(output_dir), verbose=True)
+
+    def test_decompress_directory_quiet_disables_progress(self):
+        with temporary_workspace_directory() as temp_dir:
+            archive_path = Path(temp_dir) / "archive.cjz"
+            output_dir = Path(temp_dir) / "output"
+            archive_path.write_bytes(b"archive")
+
+            with patch("cereja.cli.decompress_dir", return_value=str(output_dir)) as decompress_dir:
+                with redirect_stdout(io.StringIO()):
+                    exit_code = main(
+                        [
+                            "decompress",
+                            str(archive_path),
+                            "-o",
+                            str(output_dir),
+                            "--archive-type",
+                            "dir",
+                            "--quiet",
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0)
+            decompress_dir.assert_called_once_with(str(archive_path), str(output_dir), verbose=False)
 
     def test_encrypt_and_decrypt_file_restore_original_bytes(self):
         with temporary_workspace_directory() as temp_dir:
@@ -113,6 +323,21 @@ class CliTest(unittest.TestCase):
 
             self.assertEqual(exit_code, 1)
             self.assertFalse(encrypted_path.exists())
+            self.assertIn("Password confirmation does not match", stderr.getvalue())
+
+    def test_compress_encrypt_fails_when_password_confirmation_differs(self):
+        with temporary_workspace_directory() as temp_dir:
+            source_path = Path(temp_dir) / "source.txt"
+            archive_path = Path(temp_dir) / "source.cjz"
+            source_path.write_text("secret", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with patch("getpass.getpass", side_effect=["password", "different"]):
+                with redirect_stderr(stderr):
+                    exit_code = main(["compress", str(source_path), "-o", str(archive_path), "--encrypt"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertFalse(archive_path.exists())
             self.assertIn("Password confirmation does not match", stderr.getvalue())
 
     def test_existing_output_fails_without_force(self):

--- a/tests/testcompress.py
+++ b/tests/testcompress.py
@@ -1,7 +1,9 @@
 import unittest
 import os
 import tempfile
+from unittest import mock
 from cereja import hashtools
+from cereja.hashtools import _compress
 
 
 class CompressTest(unittest.TestCase):
@@ -357,6 +359,251 @@ class CompressTest(unittest.TestCase):
         # Both should decompress correctly
         self.assertEqual(hashtools.decompress(compressed_low).decode('utf-8'), original)
         self.assertEqual(hashtools.decompress(compressed_high).decode('utf-8'), original)
+
+    def test_compress_dir_decompress_dir_preserves_nested_files(self):
+        """Test directory compression and decompression with nested files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            os.makedirs(os.path.join(source_dir, 'nested'))
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+
+            with open(os.path.join(source_dir, 'root.txt'), 'wb') as f:
+                f.write(b'root data\n' * 50)
+            with open(os.path.join(source_dir, 'nested', 'child.bin'), 'wb') as f:
+                f.write(bytes(range(256)) * 4)
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            extracted_dir = hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(extracted_dir, output_dir)
+            self.assertEqual(stats.original_size, (len(b'root data\n') * 50) + (256 * 4))
+            with open(os.path.join(output_dir, 'root.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'root data\n' * 50)
+            with open(os.path.join(output_dir, 'nested', 'child.bin'), 'rb') as f:
+                self.assertEqual(f.read(), bytes(range(256)) * 4)
+
+    def test_compress_dir_supports_streaming_and_mapped_strategies(self):
+        """Test directory compression with streaming-compatible strategy mapping."""
+        strategies = ('auto', 'zlib', 'bz2', 'lzma', 'rle')
+
+        for strategy in strategies:
+            with self.subTest(strategy=strategy):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    source_dir = os.path.join(temp_dir, 'source')
+                    output_dir = os.path.join(temp_dir, 'output')
+                    archive_path = os.path.join(temp_dir, f'{strategy}.cjz')
+                    os.makedirs(source_dir)
+                    with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                        f.write(b'streaming directory compression\n' * 100)
+
+                    compressed_file, stats = hashtools.compress_dir(source_dir, archive_path, strategy=strategy)
+                    hashtools.decompress_dir(compressed_file, output_dir)
+
+                    with open(os.path.join(output_dir, 'data.txt'), 'rb') as f:
+                        self.assertEqual(f.read(), b'streaming directory compression\n' * 100)
+                    self.assertIn(
+                        stats.strategy,
+                        {
+                            hashtools.CompressionStrategy.ZLIB,
+                            hashtools.CompressionStrategy.BZ2,
+                            hashtools.CompressionStrategy.LZMA,
+                        },
+                    )
+
+    def test_decompress_dir_supports_legacy_archive_format(self):
+        """Test decompression of directory archives created by the legacy format."""
+        import json
+        import struct
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = os.path.join(temp_dir, 'legacy.cjz')
+            output_dir = os.path.join(temp_dir, 'output')
+            file_content = b'legacy format data' * 20
+            compressed_content, _ = hashtools.compress(file_content, strategy='zlib')
+            metadata = {
+                'version': 1,
+                'file_count': 1,
+                'total_size': len(file_content),
+                'files': [
+                    {
+                        'path': 'nested/legacy.txt',
+                        'original_size': len(file_content),
+                        'compressed_size': len(compressed_content),
+                    }
+                ],
+            }
+            metadata_json = json.dumps(metadata).encode('utf-8')
+            with open(archive_path, 'wb') as f:
+                f.write(struct.pack('>I', len(metadata_json)))
+                f.write(metadata_json)
+                f.write(compressed_content)
+
+            hashtools.decompress_dir(archive_path, output_dir)
+
+            with open(os.path.join(output_dir, 'nested', 'legacy.txt'), 'rb') as f:
+                self.assertEqual(f.read(), file_content)
+
+    def test_compress_dir_handles_large_file_without_api_changes(self):
+        """Test directory compression round-trip with a larger file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(temp_dir, 'large.cjz')
+            os.makedirs(source_dir)
+            chunk = b'large file compression data\n' * 1024
+            with open(os.path.join(source_dir, 'large.bin'), 'wb') as f:
+                for _ in range(128):
+                    f.write(chunk)
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(stats.original_size, len(chunk) * 128)
+            with open(os.path.join(output_dir, 'large.bin'), 'rb') as f:
+                self.assertEqual(f.read(), chunk * 128)
+
+    def test_compress_dir_does_not_include_output_archive_inside_source_dir(self):
+        """Test directory compression excludes the archive being written."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(source_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'archive self exclusion data')
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(stats.original_size, len(b'archive self exclusion data'))
+            self.assertEqual(os.listdir(output_dir), ['data.txt'])
+            with open(os.path.join(output_dir, 'data.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'archive self exclusion data')
+
+    def test_decompress_dir_rejects_streaming_archive_path_traversal(self):
+        """Test path traversal protection for streaming directory archives."""
+        import struct
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = os.path.join(temp_dir, 'unsafe.cjz')
+            unsafe_path = b'../escape.txt'
+            with open(archive_path, 'wb') as f:
+                f.write(b"CJZD\x02")
+                f.write(b'\x01')
+                f.write(struct.pack('>I', len(unsafe_path)))
+                f.write(unsafe_path)
+                f.write(struct.pack('>Q', 0))
+                f.write(b'\x10')
+
+            with self.assertRaises(hashtools.CompressionError):
+                hashtools.decompress_dir(archive_path, os.path.join(temp_dir, 'output'))
+
+    def test_compress_dir_emits_info_logs(self):
+        """Test directory compression logs start and finish events."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'logged compression data' * 10)
+
+            with self.assertLogs('cereja.hashtools._compress', level='INFO') as logs:
+                hashtools.compress_dir(source_dir, archive_path)
+
+            self.assertTrue(any('Starting directory compression' in message for message in logs.output))
+            self.assertTrue(any('Directory compression finished' in message for message in logs.output))
+
+    def test_compress_dir_verbose_updates_progress(self):
+        """Test directory compression updates progress when verbose is enabled."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            data = b'progress compression data' * 100
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(data)
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress) as create_progress:
+                hashtools.compress_dir(source_dir, archive_path, verbose=True)
+
+            create_progress.assert_called_once()
+            self.assertEqual(progress.values[-1], 1)
+
+    def test_compress_dir_verbose_tracks_completed_file_count(self):
+        """Test directory compression progress advances by completed files."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'first.txt'), 'wb') as f:
+                f.write(b'first file')
+            with open(os.path.join(source_dir, 'second.txt'), 'wb') as f:
+                f.write(b'second file')
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress):
+                hashtools.compress_dir(source_dir, archive_path, verbose=True)
+
+            self.assertEqual(progress.values, [1, 2])
+
+    def test_decompress_dir_verbose_updates_progress(self):
+        """Test directory decompression updates progress when verbose is enabled."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'progress decompression data' * 100)
+            hashtools.compress_dir(source_dir, archive_path)
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress) as create_progress:
+                hashtools.decompress_dir(archive_path, output_dir, verbose=True)
+
+            create_progress.assert_called_once()
+            self.assertEqual(progress.values[-1], 1)
 
 
 if __name__ == "__main__":

--- a/tests/testcompress.py
+++ b/tests/testcompress.py
@@ -1,7 +1,9 @@
 import unittest
 import os
 import tempfile
+from unittest import mock
 from cereja import hashtools
+from cereja.hashtools import _compress
 
 
 class CompressTest(unittest.TestCase):
@@ -327,6 +329,32 @@ class CompressTest(unittest.TestCase):
         finally:
             if os.path.exists(temp_file):
                 os.remove(temp_file)
+
+    def test_compress_file_with_password_requires_password_to_decompress(self):
+        """Test encrypted file archive requires the password to decompress."""
+        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as f:
+            temp_file = f.name
+            f.write(b'secret compressed file data' * 20)
+
+        try:
+            compressed_file, stats = hashtools.compress_file(temp_file, password='password')
+            restored_file = temp_file + '.restored'
+
+            self.assertTrue(hashtools.is_encrypted_archive(compressed_file))
+            self.assertGreater(stats.compressed_size, 0)
+            with self.assertRaises(hashtools.CompressionError):
+                hashtools.decompress_file(compressed_file, output_path=restored_file)
+
+            hashtools.decompress_file(compressed_file, output_path=restored_file, password='password')
+
+            with open(temp_file, 'rb') as original, open(restored_file, 'rb') as restored:
+                self.assertEqual(restored.read(), original.read())
+
+            os.remove(compressed_file)
+            os.remove(restored_file)
+        finally:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
     
     def test_compress_nonexistent_file(self):
         """Test compression of non-existent file."""
@@ -357,6 +385,278 @@ class CompressTest(unittest.TestCase):
         # Both should decompress correctly
         self.assertEqual(hashtools.decompress(compressed_low).decode('utf-8'), original)
         self.assertEqual(hashtools.decompress(compressed_high).decode('utf-8'), original)
+
+    def test_compress_dir_decompress_dir_preserves_nested_files(self):
+        """Test directory compression and decompression with nested files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            os.makedirs(os.path.join(source_dir, 'nested'))
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+
+            with open(os.path.join(source_dir, 'root.txt'), 'wb') as f:
+                f.write(b'root data\n' * 50)
+            with open(os.path.join(source_dir, 'nested', 'child.bin'), 'wb') as f:
+                f.write(bytes(range(256)) * 4)
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            extracted_dir = hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(extracted_dir, output_dir)
+            self.assertEqual(stats.original_size, (len(b'root data\n') * 50) + (256 * 4))
+            with open(os.path.join(output_dir, 'root.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'root data\n' * 50)
+            with open(os.path.join(output_dir, 'nested', 'child.bin'), 'rb') as f:
+                self.assertEqual(f.read(), bytes(range(256)) * 4)
+
+    def test_compress_dir_with_password_restores_nested_files(self):
+        """Test encrypted directory archive round-trip with nested files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            os.makedirs(os.path.join(source_dir, 'nested'))
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+
+            with open(os.path.join(source_dir, 'root.txt'), 'wb') as f:
+                f.write(b'encrypted root data')
+            with open(os.path.join(source_dir, 'nested', 'child.txt'), 'wb') as f:
+                f.write(b'encrypted child data')
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path, password='password')
+
+            self.assertTrue(hashtools.is_encrypted_archive(compressed_file))
+            self.assertGreater(stats.compressed_size, 0)
+            with self.assertRaises(hashtools.CompressionError):
+                hashtools.decompress_dir(compressed_file, output_dir)
+
+            hashtools.decompress_dir(compressed_file, output_dir, password='password')
+
+            with open(os.path.join(output_dir, 'root.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'encrypted root data')
+            with open(os.path.join(output_dir, 'nested', 'child.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'encrypted child data')
+
+    def test_compress_dir_supports_streaming_and_mapped_strategies(self):
+        """Test directory compression with streaming-compatible strategy mapping."""
+        strategies = ('auto', 'zlib', 'bz2', 'lzma', 'rle')
+
+        for strategy in strategies:
+            with self.subTest(strategy=strategy):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    source_dir = os.path.join(temp_dir, 'source')
+                    output_dir = os.path.join(temp_dir, 'output')
+                    archive_path = os.path.join(temp_dir, f'{strategy}.cjz')
+                    os.makedirs(source_dir)
+                    with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                        f.write(b'streaming directory compression\n' * 100)
+
+                    compressed_file, stats = hashtools.compress_dir(source_dir, archive_path, strategy=strategy)
+                    hashtools.decompress_dir(compressed_file, output_dir)
+
+                    with open(os.path.join(output_dir, 'data.txt'), 'rb') as f:
+                        self.assertEqual(f.read(), b'streaming directory compression\n' * 100)
+                    self.assertIn(
+                        stats.strategy,
+                        {
+                            hashtools.CompressionStrategy.ZLIB,
+                            hashtools.CompressionStrategy.BZ2,
+                            hashtools.CompressionStrategy.LZMA,
+                        },
+                    )
+
+    def test_decompress_dir_supports_legacy_archive_format(self):
+        """Test decompression of directory archives created by the legacy format."""
+        import json
+        import struct
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = os.path.join(temp_dir, 'legacy.cjz')
+            output_dir = os.path.join(temp_dir, 'output')
+            file_content = b'legacy format data' * 20
+            compressed_content, _ = hashtools.compress(file_content, strategy='zlib')
+            metadata = {
+                'version': 1,
+                'file_count': 1,
+                'total_size': len(file_content),
+                'files': [
+                    {
+                        'path': 'nested/legacy.txt',
+                        'original_size': len(file_content),
+                        'compressed_size': len(compressed_content),
+                    }
+                ],
+            }
+            metadata_json = json.dumps(metadata).encode('utf-8')
+            with open(archive_path, 'wb') as f:
+                f.write(struct.pack('>I', len(metadata_json)))
+                f.write(metadata_json)
+                f.write(compressed_content)
+
+            hashtools.decompress_dir(archive_path, output_dir)
+
+            with open(os.path.join(output_dir, 'nested', 'legacy.txt'), 'rb') as f:
+                self.assertEqual(f.read(), file_content)
+
+    def test_compress_dir_handles_large_file_without_api_changes(self):
+        """Test directory compression round-trip with a larger file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(temp_dir, 'large.cjz')
+            os.makedirs(source_dir)
+            chunk = b'large file compression data\n' * 1024
+            with open(os.path.join(source_dir, 'large.bin'), 'wb') as f:
+                for _ in range(128):
+                    f.write(chunk)
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(stats.original_size, len(chunk) * 128)
+            with open(os.path.join(output_dir, 'large.bin'), 'rb') as f:
+                self.assertEqual(f.read(), chunk * 128)
+
+    def test_compress_dir_does_not_include_output_archive_inside_source_dir(self):
+        """Test directory compression excludes the archive being written."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(source_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'archive self exclusion data')
+
+            compressed_file, stats = hashtools.compress_dir(source_dir, archive_path)
+            hashtools.decompress_dir(compressed_file, output_dir)
+
+            self.assertEqual(stats.original_size, len(b'archive self exclusion data'))
+            self.assertEqual(os.listdir(output_dir), ['data.txt'])
+            with open(os.path.join(output_dir, 'data.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'archive self exclusion data')
+
+    def test_decompress_dir_rejects_streaming_archive_path_traversal(self):
+        """Test path traversal protection for streaming directory archives."""
+        import struct
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = os.path.join(temp_dir, 'unsafe.cjz')
+            unsafe_path = b'../escape.txt'
+            with open(archive_path, 'wb') as f:
+                f.write(b"CJZD\x02")
+                f.write(b'\x01')
+                f.write(struct.pack('>I', len(unsafe_path)))
+                f.write(unsafe_path)
+                f.write(struct.pack('>Q', 0))
+                f.write(b'\x10')
+
+            with self.assertRaises(hashtools.CompressionError):
+                hashtools.decompress_dir(archive_path, os.path.join(temp_dir, 'output'))
+
+    def test_compress_dir_emits_info_logs(self):
+        """Test directory compression logs start and finish events."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'logged compression data' * 10)
+
+            with self.assertLogs('cereja.hashtools._compress', level='INFO') as logs:
+                hashtools.compress_dir(source_dir, archive_path)
+
+            self.assertTrue(any('Starting directory compression' in message for message in logs.output))
+            self.assertTrue(any('Directory compression finished' in message for message in logs.output))
+
+    def test_compress_dir_verbose_updates_progress(self):
+        """Test directory compression updates progress when verbose is enabled."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            data = b'progress compression data' * 100
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(data)
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress) as create_progress:
+                hashtools.compress_dir(source_dir, archive_path, verbose=True)
+
+            create_progress.assert_called_once()
+            self.assertEqual(progress.values[-1], 1)
+
+    def test_compress_dir_verbose_tracks_completed_file_count(self):
+        """Test directory compression progress advances by completed files."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'first.txt'), 'wb') as f:
+                f.write(b'first file')
+            with open(os.path.join(source_dir, 'second.txt'), 'wb') as f:
+                f.write(b'second file')
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress):
+                hashtools.compress_dir(source_dir, archive_path, verbose=True)
+
+            self.assertEqual(progress.values, [1, 2])
+
+    def test_decompress_dir_verbose_updates_progress(self):
+        """Test directory decompression updates progress when verbose is enabled."""
+        class FakeProgress:
+            def __init__(self):
+                self.values = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def show_progress(self, value):
+                self.values.append(value)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_dir = os.path.join(temp_dir, 'source')
+            output_dir = os.path.join(temp_dir, 'output')
+            archive_path = os.path.join(temp_dir, 'archive.cjz')
+            os.makedirs(source_dir)
+            with open(os.path.join(source_dir, 'data.txt'), 'wb') as f:
+                f.write(b'progress decompression data' * 100)
+            hashtools.compress_dir(source_dir, archive_path)
+            progress = FakeProgress()
+
+            with mock.patch.object(_compress, '_create_progress', return_value=progress) as create_progress:
+                hashtools.decompress_dir(archive_path, output_dir, verbose=True)
+
+            create_progress.assert_called_once()
+            self.assertEqual(progress.values[-1], 1)
 
 
 if __name__ == "__main__":

--- a/tests/testcrypto.py
+++ b/tests/testcrypto.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import tempfile
 from cereja import hashtools
+from cereja.hashtools import _crypto
 
 
 class CryptoTest(unittest.TestCase):
@@ -84,6 +85,29 @@ class CryptoTest(unittest.TestCase):
         decrypted = hashtools.decrypt(encrypted, password)
         
         self.assertEqual(decrypted.decode('utf-8'), original)
+
+    def test_large_binary_data(self):
+        """Test encryption and decryption of larger binary data."""
+        original = bytes(range(256)) * 4096
+        password = "large_binary_password"
+
+        encrypted = hashtools.encrypt(original, password)
+        decrypted = hashtools.decrypt(encrypted, password)
+
+        self.assertEqual(decrypted, original)
+
+    def test_generate_keystream_sizes_and_determinism(self):
+        """Test keystream generation preserves requested size and deterministic output."""
+        key = b"k" * 16
+        iv = b"i" * 16
+
+        for size in (0, 1, 31, 32, 33, 100):
+            with self.subTest(size=size):
+                first = _crypto._generate_keystream(key, iv, size)
+                second = _crypto._generate_keystream(key, iv, size)
+
+                self.assertEqual(len(first), size)
+                self.assertEqual(first, second)
     
     def test_special_characters(self):
         """Test encryption with special characters."""

--- a/tests/testsdisplay.py
+++ b/tests/testsdisplay.py
@@ -85,6 +85,17 @@ class TestConsoleBase(unittest.TestCase):
 class TestProgress(unittest.TestCase):
     """Tests for Progress class."""
 
+    def setUp(self):
+        self.default_stdout = sys.stdout
+        self.default_stderr = sys.stderr
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+
+    def tearDown(self):
+        console.disable()
+        sys.stdout = self.default_stdout
+        sys.stderr = self.default_stderr
+
     def test_progress_with_sequence(self):
         """Progress.prog should iterate over a sequence."""
         items = list(range(10))
@@ -119,6 +130,119 @@ class TestProgress(unittest.TestCase):
             self.assertIs(sys.stdout, runtime_stdout)
             self.assertIs(sys.stderr, runtime_stderr)
         finally:
+            sys.stdout = default_stdout
+            sys.stderr = default_stderr
+
+    def test_progress_flushes_prints_while_active(self):
+        """Progress should keep user prints visible while stdout is managed."""
+        default_stdout = sys.stdout
+        default_stderr = sys.stderr
+        runtime_stdout = io.StringIO()
+        runtime_stderr = io.StringIO()
+        try:
+            sys.stdout = runtime_stdout
+            sys.stderr = runtime_stderr
+
+            for item in Progress.prog([1], name="flush_prints"):
+                print(f"current: {item}")
+
+            output = runtime_stdout.getvalue()
+            self.assertIn("current: 1", output)
+            self.assertIn("flush_prints", output)
+            self.assertIs(sys.stdout, runtime_stdout)
+            self.assertIs(sys.stderr, runtime_stderr)
+        finally:
+            console.disable()
+            sys.stdout = default_stdout
+            sys.stderr = default_stderr
+
+    def test_progress_propagates_iteration_errors(self):
+        """Progress should not swallow exceptions raised by the iterable."""
+        def failing_sequence():
+            yield 1
+            raise RuntimeError("boom")
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            list(Progress.prog(failing_sequence(), name="failing"))
+
+    def test_progress_does_not_start_background_thread(self):
+        """Progress rendering should not create a background progress thread."""
+        progress = Progress(name="no_thread", max_value=1)
+        try:
+            with progress:
+                progress.show_progress(1)
+
+            self.assertIsNone(progress._th_root)
+        finally:
+            console.disable()
+
+    def test_show_progress_from_threads_finishes(self):
+        """Concurrent show_progress calls should finish without deadlock."""
+        progress = Progress(name="threaded_updates", max_value=30)
+        workers = [
+            threading.Thread(target=progress.show_progress, args=(value,))
+            for value in range(1, 6)
+        ]
+
+        try:
+            with progress:
+                for worker in workers:
+                    worker.start()
+                for worker in workers:
+                    worker.join(timeout=1)
+
+            self.assertTrue(all(not worker.is_alive() for worker in workers))
+        finally:
+            console.disable()
+
+    def test_nested_progress_keeps_outer_stream_capture(self):
+        """Disabling an inner progress should not restore streams for the outer one."""
+        default_stdout = sys.stdout
+        default_stderr = sys.stderr
+        runtime_stdout = io.StringIO()
+        runtime_stderr = io.StringIO()
+        try:
+            sys.stdout = runtime_stdout
+            sys.stderr = runtime_stderr
+
+            with Progress(name="outer", max_value=2) as outer:
+                print("outer-start")
+                with Progress(name="inner", max_value=1) as inner:
+                    inner.show_progress(1)
+                print("outer-after-inner")
+                outer.show_progress(2)
+
+            output = runtime_stdout.getvalue()
+            self.assertIn("outer-start", output)
+            self.assertIn("outer-after-inner", output)
+            self.assertIs(sys.stdout, runtime_stdout)
+            self.assertIs(sys.stderr, runtime_stderr)
+        finally:
+            console.disable()
+            sys.stdout = default_stdout
+            sys.stderr = default_stderr
+
+    def test_context_progress_reuses_instance_for_multiple_sequences(self):
+        """A context-managed Progress should reset counters between sequences."""
+        default_stdout = sys.stdout
+        default_stderr = sys.stderr
+        runtime_stdout = io.StringIO()
+        runtime_stderr = io.StringIO()
+        try:
+            sys.stdout = runtime_stdout
+            sys.stderr = runtime_stderr
+
+            with Progress(name="reuse", max_value=2) as progress:
+                first = list(progress([1, 2]))
+                second = list(progress([3]))
+
+            self.assertEqual(first, [1, 2])
+            self.assertEqual(second, [3])
+            self.assertIn("reuse", runtime_stdout.getvalue())
+            self.assertIs(sys.stdout, runtime_stdout)
+            self.assertIs(sys.stderr, runtime_stderr)
+        finally:
+            console.disable()
             sys.stdout = default_stdout
             sys.stderr = default_stderr
 


### PR DESCRIPTION
This pull request introduces several significant improvements and updates to the Cereja project, focusing on modernizing Python version support, refactoring and enhancing the command-line interface (CLI), improving error handling and logging, and updating documentation and packaging. The CLI logic has been moved into a new, dedicated module with expanded features, and the codebase now consistently uses Python 3.11+ across all workflows and documentation.

**CLI Refactor and Enhancement:**

* Refactored the CLI logic from `cereja/__main__.py` into a new, dedicated `cereja/cli.py` module, providing a more robust, extensible, and testable command-line interface with subcommands for compression, decompression, encryption, and decryption. The CLI now includes improved argument parsing, error handling, and user prompts. Also, added an entry point in `pyproject.toml` for the `cereja` CLI. [[1]](diffhunk://#diff-9ba1fd4efbe393fa16163e9409933206207a8e92192dbae11f9563efd79c3e3bL1-R6) [[2]](diffhunk://#diff-90f3e9df2af2aafadb0d4afba9ae6d41cc4a665f8a3ccb0015152f30839c48a1R1-R320) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R37-R39)

**Python Version and Packaging Updates:**

* Updated minimum required Python version to 3.11 across documentation (`README.md`), packaging (`pyproject.toml`), and GitHub Actions workflows. Dropped support for Python 3.9 and 3.10, and added support for Python 3.14. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-R28) [[3]](diffhunk://#diff-ee68bef8369ed7bc5460a288e72d62152784762ef66851e07bf134c4075a08f0L14-R14) [[4]](diffhunk://#diff-a59524abd7f2742db7365aa7ccecc939b56b227b92b77b33882978ebe8b228edL19-R19)

**Logging and Error Handling Improvements:**

* Replaced print statements with structured logging in `cereja/concurrently/process.py` for better error reporting and debugging. Also, replaced assertions with explicit exceptions for clearer runtime error handling. [[1]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bR32-R33) [[2]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL143-R145) [[3]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL166-R168) [[4]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL226-R229) [[5]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL236-R240) [[6]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL261-R265) [[7]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL400-R405) [[8]](diffhunk://#diff-507e559d76394db146a7b92a99d20229c1e2e373a43fc12c6f07b5fbdfd3d09bL416-R421)

**Internal Improvements:**

* Optimized the keystream generation logic in `cereja/hashtools/_crypto.py` to use a list of chunks instead of repeated string concatenation, improving performance and memory efficiency.

**Version Bump:**

* Updated the package version to `2.1.4.final.0` in `cereja/__init__.py`.