### PR TITLE
Add limited context search CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ cereja decompress archive.cjz
 
 Progress is enabled by default for CLI compression and decompression. Use `--quiet` for script-friendly output.
 
+### Bounded context search
+
+Search for all whitespace-separated terms in UTF-8 text under one or more
+explicit roots:
+
+```bash
+cereja context search --root docs --query "context search" --extension md
+cereja context search --root docs --root cereja --query "Path FileIO" --format json
+```
+
+Inventory text files without returning their content:
+
+```bash
+cereja context list --root docs --max-results 20
+```
+
+Use `--max-file-bytes`, `--max-results`, `--max-snippets`, and
+`--max-snippet-chars` to bound search output. The commands are read-only,
+decode only UTF-8 text, skip binary files, and do not follow symbolic links.
+
 ## Development
 
 ```bash

--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -24,6 +24,7 @@ SOFTWARE.
 
 import argparse
 import getpass
+import json
 import sys
 from pathlib import Path
 from typing import Optional, Sequence
@@ -42,7 +43,12 @@ from cereja.hashtools import (
     encrypt_file,
     is_encrypted_archive,
 )
-from cereja.system import render_repository_tree
+from cereja.system import (
+    context_response_to_dict,
+    list_text_context,
+    render_repository_tree,
+    search_text_context,
+)
 
 COMPRESSION_STRATEGIES = (
     "auto",
@@ -83,6 +89,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         FileNotFoundError,
         NotADirectoryError,
         PermissionError,
+        ValueError,
     ) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -139,6 +146,33 @@ def create_parser() -> argparse.ArgumentParser:
     tree_parser.add_argument("path", nargs="?", default=".", help="Root directory.")
     tree_parser.add_argument("--depth", type=_non_negative_int, help="Maximum depth.")
     tree_parser.set_defaults(handler=_handle_tree)
+
+    context_parser = subparsers.add_parser(
+        "context", help="Search or list bounded textual context."
+    )
+    context_subparsers = context_parser.add_subparsers(
+        dest="context_command", required=True
+    )
+    context_search_parser = context_subparsers.add_parser(
+        "search", help="Search textual context."
+    )
+    _add_context_common_options(context_search_parser)
+    context_search_parser.add_argument("--query", required=True, help="Search terms.")
+    context_search_parser.add_argument(
+        "--max-snippets", type=_positive_int, default=2,
+        help="Maximum snippets per result."
+    )
+    context_search_parser.add_argument(
+        "--max-snippet-chars", type=_positive_int, default=240,
+        help="Maximum characters per snippet."
+    )
+    context_search_parser.set_defaults(handler=_handle_context_search)
+
+    context_list_parser = context_subparsers.add_parser(
+        "list", help="List textual file metadata."
+    )
+    _add_context_common_options(context_list_parser)
+    context_list_parser.set_defaults(handler=_handle_context_list)
 
     return parser
 
@@ -232,6 +266,71 @@ def _handle_tree(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_context_common_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--root", action="append", required=True, help="Explicit root directory."
+    )
+    parser.add_argument(
+        "--extension", action="append", help="File suffix to include; repeatable."
+    )
+    parser.add_argument(
+        "--format", choices=("text", "json"), default="text", help="Output format."
+    )
+    parser.add_argument(
+        "--max-results", type=_positive_int, default=10,
+        help="Maximum returned files."
+    )
+    parser.add_argument(
+        "--max-file-bytes", type=_positive_int, default=1_048_576,
+        help="Maximum bytes read from each file."
+    )
+
+
+def _handle_context_search(args: argparse.Namespace) -> int:
+    response = search_text_context(
+        args.root,
+        args.query,
+        extensions=args.extension,
+        max_results=args.max_results,
+        max_snippets=args.max_snippets,
+        max_snippet_chars=args.max_snippet_chars,
+        max_file_bytes=args.max_file_bytes,
+    )
+    _print_context_response(response, args.format)
+    return 0
+
+
+def _handle_context_list(args: argparse.Namespace) -> int:
+    response = list_text_context(
+        args.root,
+        extensions=args.extension,
+        max_results=args.max_results,
+        max_file_bytes=args.max_file_bytes,
+    )
+    _print_context_response(response, args.format)
+    return 0
+
+
+def _print_context_response(response, output_format: str) -> None:
+    if output_format == "json":
+        print(json.dumps(context_response_to_dict(response), ensure_ascii=False, indent=2))
+        return
+    for result in response.results:
+        if response.mode == "search":
+            print(
+                f"{result.path} ({result.size_bytes} bytes, score={result.score}, "
+                f"matches={result.match_count})"
+            )
+            for snippet in result.snippets:
+                print(f"  {snippet.line}: {snippet.text}")
+        else:
+            print(f"{result.path} ({result.size_bytes} bytes)")
+    for skipped in response.skipped:
+        print(f"Skipped: {skipped.path} ({skipped.reason})")
+    if response.truncated:
+        print("Results truncated.")
+
+
 def _print_tree(tree: str) -> None:
     reconfigure = getattr(sys.stdout, "reconfigure", None)
     if reconfigure is not None:
@@ -273,6 +372,13 @@ def _non_negative_int(value: str) -> int:
     parsed = int(value)
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
     return parsed
 
 

--- a/cereja/system/__init__.py
+++ b/cereja/system/__init__.py
@@ -24,6 +24,7 @@ from ._path import *
 from ..system.commons import *
 from ._repository_tree import *
 from ._repository_files import *
+from ._context_search import *
 
 try:
     from ._win32 import Window, Keyboard, Mouse, play_alert_sound

--- a/cereja/system/__init__.py
+++ b/cereja/system/__init__.py
@@ -23,6 +23,7 @@ SOFTWARE.
 from ._path import *
 from ..system.commons import *
 from ._repository_tree import *
+from ._repository_files import *
 
 try:
     from ._win32 import Window, Keyboard, Mouse, play_alert_sound

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -1,0 +1,246 @@
+"""Bounded textual context search for explicit repository roots."""
+
+from dataclasses import dataclass
+import os
+from pathlib import Path as NativePath
+
+from cereja.system._repository_files import iter_repository_files
+
+__all__ = [
+    "ContextSnippet",
+    "ContextResult",
+    "SkippedFile",
+    "ContextResponse",
+    "search_text_context",
+    "list_text_context",
+    "context_response_to_dict",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSnippet:
+    line: int
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextResult:
+    path: str
+    root: str
+    relative_path: str
+    size_bytes: int
+    score: int
+    match_count: int
+    snippets: tuple[ContextSnippet, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedFile:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextResponse:
+    schema_version: int
+    mode: str
+    query: str | None
+    roots: tuple[str, ...]
+    results: tuple[ContextResult, ...]
+    skipped: tuple[SkippedFile, ...]
+    truncated: bool
+
+
+def search_text_context(
+        roots,
+        query,
+        *,
+        extensions=None,
+        max_results=10,
+        max_snippets=2,
+        max_snippet_chars=240,
+        max_file_bytes=1_048_576,
+):
+    """Search UTF-8 text using AND terms and bounded result snippets."""
+    terms = tuple(str(query).split())
+    if not terms:
+        raise ValueError("query must not be empty")
+    _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes)
+    normalized_terms = tuple(term.casefold() for term in terms)
+    return _collect_context(
+        roots,
+        mode="search",
+        query=str(query),
+        terms=normalized_terms,
+        extensions=extensions,
+        max_results=max_results,
+        max_snippets=max_snippets,
+        max_snippet_chars=max_snippet_chars,
+        max_file_bytes=max_file_bytes,
+    )
+
+
+def list_text_context(
+        roots,
+        *,
+        extensions=None,
+        max_results=10,
+        max_file_bytes=1_048_576,
+):
+    """List bounded metadata for UTF-8 text files without returning content."""
+    _validate_limits(max_results, 1, 1, max_file_bytes)
+    return _collect_context(
+        roots,
+        mode="list",
+        query=None,
+        terms=(),
+        extensions=extensions,
+        max_results=max_results,
+        max_snippets=1,
+        max_snippet_chars=1,
+        max_file_bytes=max_file_bytes,
+    )
+
+
+def _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes):
+    values = {
+        "max_results": max_results,
+        "max_snippets": max_snippets,
+        "max_snippet_chars": max_snippet_chars,
+        "max_file_bytes": max_file_bytes,
+    }
+    for name, value in values.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+
+
+def _collect_context(
+        roots,
+        *,
+        mode,
+        query,
+        terms,
+        extensions,
+        max_results,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+):
+    root_values = tuple(roots)
+    normalized_roots = tuple(_normalized_path(root) for root in root_values)
+    results = []
+    skipped = []
+    snippets_truncated = False
+    for repository_file in iter_repository_files(root_values, extensions=extensions):
+        path = repository_file.path.path
+        normalized_path = _normalized_path(path)
+        try:
+            size_bytes = os.path.getsize(path)
+            if size_bytes > max_file_bytes:
+                skipped.append(SkippedFile(normalized_path, "file_too_large"))
+                continue
+            with open(path, "rb") as file:
+                data = file.read(max_file_bytes + 1)
+        except PermissionError:
+            skipped.append(SkippedFile(normalized_path, "permission_denied"))
+            continue
+        except FileNotFoundError:
+            skipped.append(SkippedFile(normalized_path, "disappeared"))
+            continue
+        if len(data) > max_file_bytes:
+            skipped.append(SkippedFile(normalized_path, "file_too_large"))
+            continue
+        if b"\x00" in data:
+            skipped.append(SkippedFile(normalized_path, "binary_file"))
+            continue
+        try:
+            text = data.decode("utf-8-sig", errors="strict")
+        except UnicodeDecodeError:
+            skipped.append(SkippedFile(normalized_path, "invalid_utf8"))
+            continue
+
+        if mode == "search":
+            folded_text = text.casefold()
+            counts = tuple(folded_text.count(term) for term in terms)
+            if not all(counts):
+                continue
+            match_count = sum(counts)
+            filename = repository_file.path.name.casefold()
+            filename_hits = sum(term in filename for term in terms)
+            score = filename_hits * 1000 + match_count
+            snippets, omitted = _extract_snippets(
+                text, terms, max_snippets, max_snippet_chars
+            )
+            snippets_truncated = snippets_truncated or omitted
+        else:
+            match_count = 0
+            score = 0
+            snippets = ()
+
+        results.append(ContextResult(
+            path=normalized_path,
+            root=_normalized_path(repository_file.root.path),
+            relative_path=repository_file.relative_path,
+            size_bytes=size_bytes,
+            score=score,
+            match_count=match_count,
+            snippets=snippets,
+        ))
+
+    if mode == "search":
+        results.sort(key=lambda item: (-item.score, item.path.casefold(), item.path))
+    else:
+        results.sort(key=lambda item: (item.path.casefold(), item.path))
+    results_truncated = len(results) > max_results
+    return ContextResponse(
+        schema_version=1,
+        mode=mode,
+        query=query,
+        roots=normalized_roots,
+        results=tuple(results[:max_results]),
+        skipped=tuple(sorted(skipped, key=lambda item: (item.path.casefold(), item.path))),
+        truncated=results_truncated or snippets_truncated,
+    )
+
+
+def _extract_snippets(text, terms, max_snippets, max_snippet_chars):
+    matching = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        folded_line = line.casefold()
+        if any(term in folded_line for term in terms):
+            matching.append(ContextSnippet(line_number, line[:max_snippet_chars]))
+    return tuple(matching[:max_snippets]), len(matching) > max_snippets
+
+
+def _normalized_path(value):
+    return NativePath(os.fspath(value)).absolute().as_posix()
+
+
+def context_response_to_dict(response):
+    """Convert a context response into the stable JSON schema version 1."""
+    return {
+        "schema_version": response.schema_version,
+        "mode": response.mode,
+        "query": response.query,
+        "roots": list(response.roots),
+        "results": [
+            {
+                "path": item.path,
+                "root": item.root,
+                "relative_path": item.relative_path,
+                "size_bytes": item.size_bytes,
+                "score": item.score,
+                "match_count": item.match_count,
+                "snippets": [
+                    {"line": snippet.line, "text": snippet.text}
+                    for snippet in item.snippets
+                ],
+            }
+            for item in response.results
+        ],
+        "skipped": [
+            {"path": item.path, "reason": item.reason}
+            for item in response.skipped
+        ],
+        "truncated": response.truncated,
+    }

--- a/cereja/system/_repository_files.py
+++ b/cereja/system/_repository_files.py
@@ -1,0 +1,189 @@
+"""Deterministic repository file traversal with ``.gitignore`` support."""
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+import os
+from pathlib import Path as NativePath
+
+from cereja.system._path import Path
+
+__all__ = ["RepositoryFile", "iter_repository_files"]
+
+BUILTIN_IGNORED_DIRS = frozenset(
+    {".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", ".tox", ".nox"}
+)
+BUILTIN_IGNORED_SUFFIXES = frozenset({".pyc", ".pyo"})
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryFile:
+    root: Path
+    path: Path
+    relative_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class _IgnoreRule:
+    pattern: str
+    negated: bool
+    directory_only: bool
+    anchored: bool
+    base_path: str
+
+
+def iter_repository_files(roots, *, extensions=None):
+    """Yield filtered files from explicit roots in deterministic order."""
+    normalized_extensions = _normalize_extensions(extensions)
+    seen = set()
+    for root_value in roots:
+        root = root_value if isinstance(root_value, Path) else Path(root_value)
+        _validate_root(root)
+        inherited = _ancestor_ignore_rules(root)
+        for file_path in _walk_files(root, inherited):
+            canonical = os.path.normcase(os.path.realpath(file_path.path))
+            if canonical in seen:
+                continue
+            if normalized_extensions is not None:
+                if file_path.suffix.casefold() not in normalized_extensions:
+                    continue
+            seen.add(canonical)
+            relative = NativePath(file_path.path).relative_to(NativePath(root.path)).as_posix()
+            yield RepositoryFile(root=root, path=file_path, relative_path=relative)
+
+
+def _validate_root(root):
+    if not root.exists:
+        raise FileNotFoundError(f"Path not found: {root.path}")
+    if not root.is_dir or root.is_link:
+        raise NotADirectoryError(f"Path is not a directory: {root.path}")
+
+
+def _normalize_extensions(extensions):
+    if extensions is None:
+        return None
+    normalized = set()
+    for extension in extensions:
+        value = str(extension).strip().casefold()
+        if not value:
+            raise ValueError("extensions must not contain empty values")
+        normalized.add(value if value.startswith(".") else f".{value}")
+    return frozenset(normalized)
+
+
+def _ancestor_ignore_rules(root):
+    native_root = NativePath(root.path).absolute()
+    repository_root = None
+    for candidate in (native_root, *native_root.parents):
+        if (candidate / ".git").exists():
+            repository_root = candidate
+            break
+    start = repository_root or native_root
+    directories = [start]
+    if start != native_root:
+        current = start
+        for part in native_root.relative_to(start).parts:
+            current = current / part
+            directories.append(current)
+    rules = ()
+    for directory in directories[:-1]:
+        rules += _load_ignore_rules(Path(directory))
+    return rules
+
+
+def _walk_files(root, inherited_rules):
+    found = []
+
+    def visit(directory, rules):
+        active_rules = rules + _load_ignore_rules(directory)
+        entries = directory.list_dir(include_hidden=True, raise_errors=True)
+        entries.sort(key=lambda entry: (entry.name.casefold(), entry.name))
+        for entry in entries:
+            is_directory = entry.is_dir and not entry.is_link
+            if entry.is_link or _is_builtin_ignored(entry, is_directory):
+                continue
+            if _is_ignored(entry, is_directory, active_rules):
+                continue
+            if is_directory:
+                visit(entry, active_rules)
+            else:
+                found.append(entry)
+
+    visit(root, inherited_rules)
+    found.sort(key=lambda item: NativePath(item.path).relative_to(NativePath(root.path)).as_posix())
+    return found
+
+
+def _load_ignore_rules(directory, root=None):
+    ignore_file = directory.join(".gitignore")
+    if not ignore_file.exists:
+        return ()
+    rules = []
+    with open(ignore_file.path, encoding="utf-8", errors="replace") as file:
+        for line in file:
+            rule = _parse_ignore_rule(line, directory.path)
+            if rule is not None:
+                rules.append(rule)
+    return tuple(rules)
+
+
+def _parse_ignore_rule(line, base_path):
+    pattern = line.strip()
+    if not pattern or pattern.startswith("#"):
+        return None
+    negated = pattern.startswith("!")
+    if negated:
+        pattern = pattern[1:]
+    directory_only = pattern.endswith("/")
+    pattern = pattern.rstrip("/")
+    anchored = pattern.startswith("/")
+    if anchored:
+        pattern = pattern[1:]
+    if not pattern:
+        return None
+    return _IgnoreRule(pattern, negated, directory_only, anchored, base_path)
+
+
+def _is_builtin_ignored(entry, is_directory):
+    if is_directory:
+        return entry.name in BUILTIN_IGNORED_DIRS
+    return entry.name.lower().endswith(tuple(BUILTIN_IGNORED_SUFFIXES))
+
+
+def _relative_parts(entry, root):
+    if entry == root:
+        return ()
+    return NativePath(entry.path).relative_to(NativePath(root.path)).parts
+
+
+def _is_ignored(entry, is_directory, rules):
+    ignored = False
+    entry_path = NativePath(entry.path).absolute()
+    for rule in rules:
+        try:
+            candidate = entry_path.relative_to(NativePath(rule.base_path).absolute()).parts
+        except ValueError:
+            continue
+        if _rule_matches(rule, candidate, is_directory):
+            ignored = not rule.negated
+    return ignored
+
+
+def _rule_matches(rule, candidate, is_directory):
+    if rule.directory_only and not is_directory:
+        return False
+    pattern_parts = tuple(part for part in rule.pattern.split("/") if part)
+    if "/" not in rule.pattern and not rule.anchored:
+        return bool(candidate) and _match_segments(pattern_parts, (candidate[-1],))
+    return _match_segments(pattern_parts, candidate)
+
+
+def _match_segments(pattern, candidate):
+    if not pattern:
+        return not candidate
+    if pattern[0] == "**":
+        return _match_segments(pattern[1:], candidate) or (
+            bool(candidate) and _match_segments(pattern, candidate[1:])
+        )
+    return bool(candidate) and fnmatchcase(candidate[0], pattern[0]) and _match_segments(
+        pattern[1:], candidate[1:]
+    )

--- a/cereja/system/_repository_tree.py
+++ b/cereja/system/_repository_tree.py
@@ -62,4 +62,3 @@ def _render_directory(
         if is_directory and can_descend:
             child_prefix = prefix + ("    " if is_last else "│   ")
             _render_directory(entry, root, rules, level + 1, depth, child_prefix, lines)
-

--- a/cereja/system/_repository_tree.py
+++ b/cereja/system/_repository_tree.py
@@ -1,36 +1,16 @@
 """Render filesystem trees while honoring common ``.gitignore`` rules."""
 
-from dataclasses import dataclass
-from fnmatch import fnmatchcase
 import os
-from pathlib import Path as NativePath
 
 from cereja.system._path import Path
+from cereja.system._repository_files import (
+    _IgnoreRule,
+    _is_builtin_ignored,
+    _is_ignored,
+    _load_ignore_rules,
+)
 
 __all__ = ["render_repository_tree"]
-
-BUILTIN_IGNORED_DIRS = frozenset(
-    {
-        ".git",
-        "__pycache__",
-        ".pytest_cache",
-        ".mypy_cache",
-        ".ruff_cache",
-        ".tox",
-        ".nox",
-    }
-)
-BUILTIN_IGNORED_SUFFIXES = frozenset({".pyc", ".pyo"})
-
-
-@dataclass(frozen=True, slots=True)
-class _IgnoreRule:
-    pattern: str
-    negated: bool
-    directory_only: bool
-    anchored: bool
-    base_parts: tuple[str, ...]
-
 
 def render_repository_tree(
         path: str | os.PathLike[str] | Path = ".",
@@ -68,8 +48,7 @@ def _render_directory(
         is_directory = entry.is_dir and not entry.is_link
         if _is_builtin_ignored(entry, is_directory):
             continue
-        relative_parts = _relative_parts(entry, root)
-        if _is_ignored(relative_parts, is_directory, rules):
+        if _is_ignored(entry, is_directory, rules):
             continue
         entries.append((entry, is_directory))
 
@@ -84,88 +63,3 @@ def _render_directory(
             child_prefix = prefix + ("    " if is_last else "│   ")
             _render_directory(entry, root, rules, level + 1, depth, child_prefix, lines)
 
-
-def _load_ignore_rules(directory: Path, root: Path) -> tuple[_IgnoreRule, ...]:
-    ignore_file = directory.join(".gitignore")
-    if not ignore_file.exists:
-        return ()
-
-    base_parts = _relative_parts(directory, root)
-    rules = []
-    with open(ignore_file.path, encoding="utf-8", errors="replace") as file:
-        for line in file:
-            rule = _parse_ignore_rule(line, base_parts)
-            if rule is not None:
-                rules.append(rule)
-    return tuple(rules)
-
-
-def _parse_ignore_rule(line: str, base_parts: tuple[str, ...]) -> _IgnoreRule | None:
-    pattern = line.strip()
-    if not pattern or pattern.startswith("#"):
-        return None
-
-    negated = pattern.startswith("!")
-    if negated:
-        pattern = pattern[1:]
-    directory_only = pattern.endswith("/")
-    pattern = pattern.rstrip("/")
-    anchored = pattern.startswith("/")
-    if anchored:
-        pattern = pattern[1:]
-    if not pattern:
-        return None
-    return _IgnoreRule(pattern, negated, directory_only, anchored, base_parts)
-
-
-def _is_builtin_ignored(entry: Path, is_directory: bool) -> bool:
-    if is_directory:
-        return entry.name in BUILTIN_IGNORED_DIRS
-    return entry.name.lower().endswith(tuple(BUILTIN_IGNORED_SUFFIXES))
-
-
-def _relative_parts(entry: Path, root: Path) -> tuple[str, ...]:
-    if entry == root:
-        return ()
-    relative = NativePath(entry.path).relative_to(NativePath(root.path))
-    return relative.parts
-
-
-def _is_ignored(
-        relative_parts: tuple[str, ...],
-        is_directory: bool,
-        rules: tuple[_IgnoreRule, ...],
-) -> bool:
-    ignored = False
-    for rule in rules:
-        if _rule_matches(rule, relative_parts, is_directory):
-            ignored = not rule.negated
-    return ignored
-
-
-def _rule_matches(
-        rule: _IgnoreRule,
-        relative_parts: tuple[str, ...],
-        is_directory: bool,
-) -> bool:
-    if rule.directory_only and not is_directory:
-        return False
-    if rule.base_parts and relative_parts[:len(rule.base_parts)] != rule.base_parts:
-        return False
-    candidate = relative_parts[len(rule.base_parts):]
-    pattern_parts = tuple(part for part in rule.pattern.split("/") if part)
-    if "/" not in rule.pattern and not rule.anchored:
-        return bool(candidate) and _match_segments(pattern_parts, (candidate[-1],))
-    return _match_segments(pattern_parts, candidate)
-
-
-def _match_segments(pattern: tuple[str, ...], candidate: tuple[str, ...]) -> bool:
-    if not pattern:
-        return not candidate
-    if pattern[0] == "**":
-        return _match_segments(pattern[1:], candidate) or (
-            bool(candidate) and _match_segments(pattern, candidate[1:])
-        )
-    return bool(candidate) and fnmatchcase(candidate[0], pattern[0]) and _match_segments(
-        pattern[1:], candidate[1:]
-    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -419,6 +420,105 @@ class CliTest(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             output = buffer.getvalue().decode("utf-8").replace("\r\n", "\n")
             self.assertEqual(output, "project/\n└── README.md\n")
+
+    def test_context_search_emits_stable_json(self):
+        with temporary_workspace_directory() as temp_dir:
+            root = Path(temp_dir) / "docs"
+            root.mkdir()
+            (root / "guide.md").write_text("auth cache", encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main([
+                    "context", "search", "--root", str(root),
+                    "--query", "auth cache", "--format", "json",
+                ])
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["mode"], "search")
+            self.assertEqual(payload["results"][0]["relative_path"], "guide.md")
+
+    def test_context_search_supports_multiple_roots_and_extensions(self):
+        with temporary_workspace_directory() as temp_dir:
+            first = Path(temp_dir) / "first"
+            second = Path(temp_dir) / "second"
+            first.mkdir()
+            second.mkdir()
+            (first / "one.md").write_text("needle", encoding="utf-8")
+            (second / "two.TXT").write_text("needle", encoding="utf-8")
+            (second / "ignored.py").write_text("needle", encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main([
+                    "context", "search", "--root", str(first),
+                    "--root", str(second), "--query", "needle",
+                    "--extension", "md", "--extension", ".txt",
+                    "--format", "json",
+                ])
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(
+                [item["relative_path"] for item in payload["results"]],
+                ["one.md", "two.TXT"],
+            )
+
+    def test_context_list_emits_text_metadata_without_content(self):
+        with temporary_workspace_directory() as temp_dir:
+            root = Path(temp_dir) / "docs"
+            root.mkdir()
+            (root / "guide.md").write_text("private full content", encoding="utf-8")
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(["context", "list", "--root", str(root)])
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("guide.md", stdout.getvalue())
+            self.assertIn("bytes", stdout.getvalue())
+            self.assertNotIn("private full content", stdout.getvalue())
+
+    def test_context_reports_missing_root_only_to_stderr(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = main([
+                "context", "list", "--root", "missing-context-root",
+                "--format", "json",
+            ])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Path not found", stderr.getvalue())
+
+    def test_context_rejects_zero_limit(self):
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "cereja", "context", "search",
+                "--root", ".", "--query", "needle", "--max-results", "0",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must be greater than zero", result.stderr)
+
+    def test_context_search_requires_query(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "cereja", "context", "search", "--root", "."],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--query", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_context_search.py
+++ b/tests/test_context_search.py
@@ -1,0 +1,148 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cereja.system import (
+    context_response_to_dict,
+    list_text_context,
+    search_text_context,
+)
+
+
+class ContextSearchTest(unittest.TestCase):
+    def test_requires_all_terms_and_limits_snippets(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "auth-guide.md").write_text(
+                "Auth cache\nother\nCACHE auth again\n", encoding="utf-8"
+            )
+            (root / "auth-only.md").write_text(
+                "auth without second term", encoding="utf-8"
+            )
+
+            response = search_text_context(
+                [root],
+                "AUTH cache",
+                max_results=10,
+                max_snippets=1,
+                max_snippet_chars=40,
+            )
+
+            self.assertEqual(
+                [item.relative_path for item in response.results],
+                ["auth-guide.md"],
+            )
+            self.assertEqual(response.results[0].match_count, 4)
+            self.assertEqual(len(response.results[0].snippets), 1)
+            self.assertEqual(response.results[0].snippets[0].line, 1)
+            self.assertTrue(response.truncated)
+
+    def test_scores_filename_hits_then_occurrences_and_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "z-auth.md").write_text("auth cache", encoding="utf-8")
+            (root / "a-auth.md").write_text("auth cache", encoding="utf-8")
+            (root / "many.md").write_text("auth auth cache cache cache", encoding="utf-8")
+
+            response = search_text_context([root], "auth cache")
+
+            self.assertEqual(
+                [item.relative_path for item in response.results],
+                ["a-auth.md", "z-auth.md", "many.md"],
+            )
+            self.assertEqual([item.score for item in response.results], [1002, 1002, 5])
+
+    def test_limits_results_and_snippet_characters(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for name in ("a.txt", "b.txt"):
+                (root / name).write_text("needle " + "x" * 80, encoding="utf-8")
+
+            response = search_text_context(
+                [root], "needle", max_results=1, max_snippet_chars=12
+            )
+
+            self.assertEqual(len(response.results), 1)
+            self.assertLessEqual(len(response.results[0].snippets[0].text), 12)
+            self.assertTrue(response.truncated)
+
+    def test_reports_large_binary_and_invalid_utf8_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "large.txt").write_bytes(b"needle-too-large")
+            (root / "binary.txt").write_bytes(b"needle\x00binary")
+            (root / "invalid.txt").write_bytes(b"needle\xff")
+
+            response = search_text_context([root], "needle", max_file_bytes=13)
+
+            reasons = {Path(item.path).name: item.reason for item in response.skipped}
+            self.assertEqual(
+                reasons,
+                {
+                    "binary.txt": "binary_file",
+                    "invalid.txt": "invalid_utf8",
+                    "large.txt": "file_too_large",
+                },
+            )
+
+    def test_list_returns_only_text_metadata_and_serializes_schema_v1(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.md").write_text("guide", encoding="utf-8-sig")
+            (root / "data.bin").write_bytes(b"binary\x00data")
+
+            response = list_text_context([root], extensions=["md"])
+            payload = context_response_to_dict(response)
+
+            self.assertIsNone(response.query)
+            self.assertEqual(response.results[0].score, 0)
+            self.assertEqual(response.results[0].match_count, 0)
+            self.assertEqual(response.results[0].snippets, ())
+            self.assertEqual(list(payload), [
+                "schema_version", "mode", "query", "roots", "results", "skipped", "truncated"
+            ])
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["mode"], "list")
+            self.assertEqual(payload["results"][0]["relative_path"], "guide.md")
+
+    def test_rejects_empty_query_and_non_positive_limits(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for query in ("", "   "):
+                with self.assertRaises(ValueError):
+                    search_text_context([root], query)
+            for keyword in (
+                "max_results", "max_snippets", "max_snippet_chars", "max_file_bytes"
+            ):
+                with self.subTest(keyword=keyword):
+                    with self.assertRaises(ValueError):
+                        search_text_context([root], "query", **{keyword: 0})
+
+    def test_reports_file_that_disappears_during_read(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "vanished.txt"
+            path.write_text("needle", encoding="utf-8")
+
+            with patch("cereja.system._context_search.open", side_effect=FileNotFoundError):
+                response = search_text_context([root], "needle")
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(response.skipped[0].reason, "disappeared")
+
+    def test_reports_file_permission_denied_during_read(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "private.txt"
+            path.write_text("needle", encoding="utf-8")
+
+            with patch("cereja.system._context_search.open", side_effect=PermissionError):
+                response = search_text_context([root], "needle")
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(response.skipped[0].reason, "permission_denied")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_files.py
+++ b/tests/test_repository_files.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from cereja.system import iter_repository_files
+
+
+class RepositoryFilesTest(unittest.TestCase):
+    def test_is_ordered_and_honors_parent_gitignore(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            root = repo / "docs" / "project"
+            (repo / ".git").mkdir(parents=True)
+            (repo / ".gitignore").write_text("*.secret\n", encoding="utf-8")
+            root.mkdir(parents=True)
+            (root / "z.md").write_text("z", encoding="utf-8")
+            (root / "a.md").write_text("a", encoding="utf-8")
+            (root / "hidden.secret").write_text("secret", encoding="utf-8")
+
+            files = list(iter_repository_files([root]))
+
+            self.assertEqual([item.relative_path for item in files], ["a.md", "z.md"])
+
+    def test_deduplicates_overlapping_roots_by_input_order(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "outer"
+            inner = outer / "inner"
+            inner.mkdir(parents=True)
+            (inner / "note.md").write_text("note", encoding="utf-8")
+
+            files = list(iter_repository_files([outer, inner]))
+
+            self.assertEqual(len(files), 1)
+            self.assertEqual(Path(files[0].root.path), outer)
+            self.assertEqual(files[0].relative_path, "inner/note.md")
+
+    def test_filters_extensions_case_insensitively(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.MD").write_text("guide", encoding="utf-8")
+            (root / "notes.txt").write_text("notes", encoding="utf-8")
+
+            files = list(iter_repository_files([root], extensions=["md"]))
+
+            self.assertEqual([item.relative_path for item in files], ["guide.MD"])
+
+    def test_rejects_missing_root_and_file_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            file_path = root / "file.txt"
+            file_path.write_text("file", encoding="utf-8")
+
+            with self.assertRaises(FileNotFoundError):
+                list(iter_repository_files([root / "missing"]))
+            with self.assertRaises(NotADirectoryError):
+                list(iter_repository_files([file_path]))
+
+    def test_does_not_follow_file_or_directory_symlinks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "root"
+            root.mkdir()
+            target_file = root / "target.txt"
+            target_file.write_text("target", encoding="utf-8")
+            real_dir = root / "real"
+            real_dir.mkdir()
+            (real_dir / "inside.txt").write_text("inside", encoding="utf-8")
+            try:
+                os.symlink(target_file, root / "linked.txt")
+                os.symlink(real_dir, root / "linked-dir", target_is_directory=True)
+            except (OSError, NotImplementedError) as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+
+            files = list(iter_repository_files([root]))
+
+            self.assertEqual(
+                [item.relative_path for item in files],
+                ["real/inside.txt", "target.txt"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds deterministic gitignore-aware traversal, bounded UTF-8 context search/list APIs, JSON schema v1 output, nested CLI commands, tests, and README usage. Verification: full unittest suite (369 tests, 3 Windows symlink skips), both CI flake8 commands, CLI JSON smoke test, and git diff check.