### PR TITLE
Fix bounded context search output

### DIFF
--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -89,7 +89,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         FileNotFoundError,
         NotADirectoryError,
         PermissionError,
-        ValueError,
     ) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -287,26 +286,32 @@ def _add_context_common_options(parser: argparse.ArgumentParser) -> None:
 
 
 def _handle_context_search(args: argparse.Namespace) -> int:
-    response = search_text_context(
-        args.root,
-        args.query,
-        extensions=args.extension,
-        max_results=args.max_results,
-        max_snippets=args.max_snippets,
-        max_snippet_chars=args.max_snippet_chars,
-        max_file_bytes=args.max_file_bytes,
-    )
+    try:
+        response = search_text_context(
+            args.root,
+            args.query,
+            extensions=args.extension,
+            max_results=args.max_results,
+            max_snippets=args.max_snippets,
+            max_snippet_chars=args.max_snippet_chars,
+            max_file_bytes=args.max_file_bytes,
+        )
+    except ValueError as exc:
+        raise CliError(str(exc)) from exc
     _print_context_response(response, args.format)
     return 0
 
 
 def _handle_context_list(args: argparse.Namespace) -> int:
-    response = list_text_context(
-        args.root,
-        extensions=args.extension,
-        max_results=args.max_results,
-        max_file_bytes=args.max_file_bytes,
-    )
+    try:
+        response = list_text_context(
+            args.root,
+            extensions=args.extension,
+            max_results=args.max_results,
+            max_file_bytes=args.max_file_bytes,
+        )
+    except ValueError as exc:
+        raise CliError(str(exc)) from exc
     _print_context_response(response, args.format)
     return 0
 

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -191,25 +191,52 @@ def _collect_context(
         results.sort(key=lambda item: (-item.score, item.path.casefold(), item.path))
     else:
         results.sort(key=lambda item: (item.path.casefold(), item.path))
+    sorted_skipped = tuple(
+        sorted(skipped, key=lambda item: (item.path.casefold(), item.path))
+    )
     results_truncated = len(results) > max_results
+    skipped_truncated = len(sorted_skipped) > max_results
     return ContextResponse(
         schema_version=1,
         mode=mode,
         query=query,
         roots=normalized_roots,
         results=tuple(results[:max_results]),
-        skipped=tuple(sorted(skipped, key=lambda item: (item.path.casefold(), item.path))),
-        truncated=results_truncated or snippets_truncated,
+        skipped=sorted_skipped[:max_results],
+        truncated=results_truncated or skipped_truncated or snippets_truncated,
     )
 
 
 def _extract_snippets(text, terms, max_snippets, max_snippet_chars):
     matching = []
+    characters_truncated = False
     for line_number, line in enumerate(text.splitlines(), start=1):
         folded_line = line.casefold()
         if any(term in folded_line for term in terms):
-            matching.append(ContextSnippet(line_number, line[:max_snippet_chars]))
-    return tuple(matching[:max_snippets]), len(matching) > max_snippets
+            matching.append(ContextSnippet(
+                line_number,
+                _snippet_window(line, folded_line, terms, max_snippet_chars),
+            ))
+            characters_truncated = characters_truncated or len(line) > max_snippet_chars
+    return (
+        tuple(matching[:max_snippets]),
+        len(matching) > max_snippets or characters_truncated,
+    )
+
+
+def _snippet_window(line, folded_line, terms, max_snippet_chars):
+    if len(line) <= max_snippet_chars:
+        return line
+    occurrences = [
+        (folded_line.find(term), term)
+        for term in terms
+        if folded_line.find(term) >= 0
+    ]
+    first_match, term = min(occurrences, key=lambda item: item[0])
+    leading_context = max(0, max_snippet_chars - len(term)) // 2
+    start = max(0, first_match - leading_context)
+    start = min(start, len(line) - max_snippet_chars)
+    return line[start:start + max_snippet_chars]
 
 
 def _normalized_path(value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -495,6 +495,24 @@ class CliTest(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "")
         self.assertIn("Path not found", stderr.getvalue())
 
+    def test_context_translates_api_value_error_to_cli_error(self):
+        stderr = io.StringIO()
+
+        with patch(
+            "cereja.cli.search_text_context", side_effect=ValueError("invalid context")
+        ), redirect_stderr(stderr):
+            exit_code = main([
+                "context", "search", "--root", ".", "--query", "needle"
+            ])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("invalid context", stderr.getvalue())
+
+    def test_non_context_value_error_is_not_translated(self):
+        with patch("cereja.cli._handle_tree", side_effect=ValueError("unrelated")):
+            with self.assertRaisesRegex(ValueError, "unrelated"):
+                main(["tree", "."])
+
     def test_context_rejects_zero_limit(self):
         result = subprocess.run(
             [

--- a/tests/test_context_search.py
+++ b/tests/test_context_search.py
@@ -67,6 +67,34 @@ class ContextSearchTest(unittest.TestCase):
             self.assertLessEqual(len(response.results[0].snippets[0].text), 12)
             self.assertTrue(response.truncated)
 
+    def test_snippet_window_contains_first_match_on_long_line(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "long.txt").write_text(
+                "x" * 500 + "NEEDLE tail", encoding="utf-8"
+            )
+
+            response = search_text_context(
+                [root], "needle", max_snippet_chars=40
+            )
+
+            snippet = response.results[0].snippets[0]
+            self.assertLessEqual(len(snippet.text), 40)
+            self.assertIn("needle", snippet.text.casefold())
+
+    def test_snippet_character_cut_marks_response_truncated(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "long.txt").write_text(
+                "x" * 500 + "NEEDLE tail", encoding="utf-8"
+            )
+
+            response = search_text_context(
+                [root], "needle", max_snippet_chars=40
+            )
+
+            self.assertTrue(response.truncated)
+
     def test_reports_large_binary_and_invalid_utf8_files(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -85,6 +113,18 @@ class ContextSearchTest(unittest.TestCase):
                     "large.txt": "file_too_large",
                 },
             )
+
+    def test_limits_skipped_files_deterministically(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for index in range(25):
+                (root / f"{index:02}.bin").write_bytes(b"\x00binary")
+
+            response = search_text_context([root], "needle", max_results=1)
+
+            self.assertEqual(len(response.skipped), 1)
+            self.assertEqual(Path(response.skipped[0].path).name, "00.bin")
+            self.assertTrue(response.truncated)
 
     def test_list_returns_only_text_metadata_and_serializes_schema_v1(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Fixes mandatory follow-up findings from PR #265: snippet windows now include the first match when possible and flag character truncation; skipped files are deterministically bounded by max_results and set truncated on overflow; ValueError translation is restricted to context handlers so unrelated commands preserve prior behavior. Verification: 59 focused tests, 374 full tests with 3 Windows symlink skips, blocking flake8 check with 0 errors, and clean diff.