### PR TITLE
feat: add persistent cache for context search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ MANIFEST.in
 .ai
 .aiassistant
 AGENTS.md
+.worktrees/
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ Use `--max-file-bytes`, `--max-results`, `--max-snippets`, and
 `--max-snippet-chars` to bound search output. The commands are read-only,
 decode only UTF-8 text, skip binary files, and do not follow symbolic links.
 
+The persistent cache is opt-in. Use `--cache` to populate or reuse it and
+`--refresh-cache` with `--cache` to force file content to be reprocessed:
+
+```bash
+cereja context search --root docs --query "context search" --cache
+cereja context search --root docs --query "context search" --cache --refresh-cache
+```
+
+Inspect cache metadata or clear the context-cache namespace with:
+
+```bash
+cereja context cache info --format json
+cereja context cache clear
+```
+
+If the optional cache is unavailable, context search emits a
+`ContextCacheWarning` and continues with a direct filesystem search.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ cereja context list --root docs --max-results 20
 ```
 
 Use `--max-file-bytes`, `--max-results`, `--max-snippets`, and
-`--max-snippet-chars` to bound search output. The commands are read-only,
-decode only UTF-8 text, skip binary files, and do not follow symbolic links.
+`--max-snippet-chars` to bound search output. Searched source files are opened
+read-only and are never modified. The commands decode only UTF-8 text, skip
+binary files, and do not follow symbolic links.
 
-The persistent cache is opt-in. Use `--cache` to populate or reuse it and
-`--refresh-cache` with `--cache` to force file content to be reprocessed:
+The persistent cache is opt-in. When `--cache` is enabled, Cereja writes a
+global per-user cache outside the searched roots. Use `--cache` to populate or
+reuse it and `--refresh-cache` with `--cache` to force file content to be
+reprocessed:
 
 ```bash
 cereja context search --root docs --query "context search" --cache

--- a/benchmarks/context_cache.py
+++ b/benchmarks/context_cache.py
@@ -1,0 +1,117 @@
+"""Benchmark direct, cold, warm, and refreshed context searches."""
+
+import argparse
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from cereja.system import search_text_context  # noqa: E402
+
+
+def build_fixture(root, *, files=2_000, lines=200):
+    """Create a repeatable collection of UTF-8 text files."""
+    for index in range(files):
+        text = "\n".join(
+            f"line {line} auth cache payload {index}" if line % 50 == 0
+            else f"line {line} payload {index}"
+            for line in range(lines)
+        )
+        (root / f"file-{index:05}.txt").write_text(text, encoding="utf-8")
+
+
+def _positive_int(value):
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _timed_search(root, *, files, cache, refresh_cache=False):
+    started = time.perf_counter()
+    response = search_text_context(
+        [root],
+        "auth cache",
+        max_results=files,
+        cache=cache,
+        refresh_cache=refresh_cache,
+    )
+    return response, time.perf_counter() - started
+
+
+def run_benchmark(*, files, lines):
+    """Run the benchmark in isolated fixture and cache directories."""
+    with tempfile.TemporaryDirectory(prefix="cereja-context-benchmark-") as temp:
+        temp_root = Path(temp)
+        fixture_root = temp_root / "fixture"
+        fixture_root.mkdir()
+        build_fixture(fixture_root, files=files, lines=lines)
+        cache_path = temp_root / "cache" / "context.sqlite3"
+
+        with patch(
+            "cereja.system._context.cache.default_cache_path",
+            return_value=cache_path,
+        ):
+            direct, direct_seconds = _timed_search(
+                fixture_root, files=files, cache=False
+            )
+            cold, cold_seconds = _timed_search(
+                fixture_root, files=files, cache=True
+            )
+            warm, warm_seconds = _timed_search(
+                fixture_root, files=files, cache=True
+            )
+            refreshed, refresh_seconds = _timed_search(
+                fixture_root, files=files, cache=True, refresh_cache=True
+            )
+
+        responses = {
+            "direct": direct,
+            "cold_cache": cold,
+            "warm_cache": warm,
+            "refresh_cache": refreshed,
+        }
+        equalities = {
+            "cold_equals_direct": cold == direct,
+            "warm_equals_direct": warm == direct,
+            "refresh_equals_direct": refreshed == direct,
+        }
+        equalities["all_equal"] = all(equalities.values())
+        return {
+            "fixture": {
+                "files": files,
+                "lines_per_file": lines,
+                "bytes": sum(path.stat().st_size for path in fixture_root.iterdir()),
+            },
+            "durations_seconds": {
+                "direct": direct_seconds,
+                "cold_cache": cold_seconds,
+                "warm_cache": warm_seconds,
+                "refresh_cache": refresh_seconds,
+            },
+            "result_counts": {
+                name: len(response.results) for name, response in responses.items()
+            },
+            "equalities": equalities,
+        }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", type=_positive_int, default=2_000)
+    parser.add_argument("--lines", type=_positive_int, default=200)
+    args = parser.parse_args(argv)
+    payload = run_benchmark(files=args.files, lines=args.lines)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["equalities"]["all_equal"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -44,11 +44,14 @@ from cereja.hashtools import (
     is_encrypted_archive,
 )
 from cereja.system import (
+    clear_context_cache,
     context_response_to_dict,
+    get_context_cache_info,
     list_text_context,
     render_repository_tree,
     search_text_context,
 )
+from cereja.system._context.cache_db import CacheDatabaseError
 
 COMPRESSION_STRATEGIES = (
     "auto",
@@ -173,6 +176,24 @@ def create_parser() -> argparse.ArgumentParser:
     _add_context_common_options(context_list_parser)
     context_list_parser.set_defaults(handler=_handle_context_list)
 
+    context_cache_parser = context_subparsers.add_parser(
+        "cache", help="Manage the textual context cache."
+    )
+    context_cache_subparsers = context_cache_parser.add_subparsers(
+        dest="context_cache_command", required=True
+    )
+    context_cache_info_parser = context_cache_subparsers.add_parser(
+        "info", help="Show textual context cache information."
+    )
+    _add_context_cache_format_option(context_cache_info_parser)
+    context_cache_info_parser.set_defaults(handler=_handle_context_cache_info)
+
+    context_cache_clear_parser = context_cache_subparsers.add_parser(
+        "clear", help="Clear the textual context cache."
+    )
+    _add_context_cache_format_option(context_cache_clear_parser)
+    context_cache_clear_parser.set_defaults(handler=_handle_context_cache_clear)
+
     return parser
 
 
@@ -283,6 +304,19 @@ def _add_context_common_options(parser: argparse.ArgumentParser) -> None:
         "--max-file-bytes", type=_positive_int, default=1_048_576,
         help="Maximum bytes read from each file."
     )
+    parser.add_argument(
+        "--cache", action="store_true", help="Use the persistent context cache."
+    )
+    parser.add_argument(
+        "--refresh-cache", action="store_true",
+        help="Refresh cached file content before querying."
+    )
+
+
+def _add_context_cache_format_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--format", choices=("text", "json"), default="text", help="Output format."
+    )
 
 
 def _handle_context_search(args: argparse.Namespace) -> int:
@@ -295,8 +329,10 @@ def _handle_context_search(args: argparse.Namespace) -> int:
             max_snippets=args.max_snippets,
             max_snippet_chars=args.max_snippet_chars,
             max_file_bytes=args.max_file_bytes,
+            cache=args.cache,
+            refresh_cache=args.refresh_cache,
         )
-    except ValueError as exc:
+    except (ValueError, CacheDatabaseError) as exc:
         raise CliError(str(exc)) from exc
     _print_context_response(response, args.format)
     return 0
@@ -309,10 +345,30 @@ def _handle_context_list(args: argparse.Namespace) -> int:
             extensions=args.extension,
             max_results=args.max_results,
             max_file_bytes=args.max_file_bytes,
+            cache=args.cache,
+            refresh_cache=args.refresh_cache,
         )
-    except ValueError as exc:
+    except (ValueError, CacheDatabaseError) as exc:
         raise CliError(str(exc)) from exc
     _print_context_response(response, args.format)
+    return 0
+
+
+def _handle_context_cache_info(args: argparse.Namespace) -> int:
+    try:
+        info = get_context_cache_info()
+    except (ValueError, CacheDatabaseError) as exc:
+        raise CliError(str(exc)) from exc
+    _print_context_cache_info(info, args.format)
+    return 0
+
+
+def _handle_context_cache_clear(args: argparse.Namespace) -> int:
+    try:
+        report = clear_context_cache()
+    except (ValueError, CacheDatabaseError) as exc:
+        raise CliError(str(exc)) from exc
+    _print_context_cache_clear_report(report, args.format)
     return 0
 
 
@@ -334,6 +390,50 @@ def _print_context_response(response, output_format: str) -> None:
         print(f"Skipped: {skipped.path} ({skipped.reason})")
     if response.truncated:
         print("Results truncated.")
+
+
+def _print_context_cache_info(info, output_format: str) -> None:
+    payload = _context_cache_info_to_dict(info)
+    if output_format == "json":
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    for key, value in payload.items():
+        print(f"{key}: {value}")
+
+
+def _print_context_cache_clear_report(report, output_format: str) -> None:
+    payload = _context_cache_clear_report_to_dict(report)
+    if output_format == "json":
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    for key, value in payload.items():
+        print(f"{key}: {value}")
+
+
+def _context_cache_info_to_dict(info) -> dict:
+    return {
+        "path": info.path,
+        "schema_version": info.schema_version,
+        "namespace": info.namespace,
+        "database_bytes": info.database_bytes,
+        "wal_bytes": info.wal_bytes,
+        "shm_bytes": info.shm_bytes,
+        "roots": info.roots,
+        "files": info.files,
+        "text_files": info.text_files,
+        "skipped_files": info.skipped_files,
+        "last_access_ns": info.last_access_ns,
+    }
+
+
+def _context_cache_clear_report_to_dict(report) -> dict:
+    return {
+        "associations_removed": report.associations_removed,
+        "roots_removed": report.roots_removed,
+        "files_removed": report.files_removed,
+        "before_bytes": report.before_bytes,
+        "after_bytes": report.after_bytes,
+    }
 
 
 def _print_tree(tree: str) -> None:

--- a/cereja/system/_context/__init__.py
+++ b/cereja/system/_context/__init__.py
@@ -1,11 +1,32 @@
 """Private components for bounded textual context search."""
 
 from .models import (
+    ContextCacheClearReport,
+    ContextCacheInfo,
     ContextCacheWarning,
     ContextResponse,
     ContextResult,
     ContextSnippet,
     SkippedFile,
 )
+from .cache import clear_context_cache, get_context_cache_info
+from .cache_db import CacheDatabaseUnavailable
 from .query import context_response_to_dict
 from .search import list_text_context, search_text_context
+
+
+__all__ = [
+    "ContextCacheInfo",
+    "ContextCacheClearReport",
+    "ContextCacheWarning",
+    "CacheDatabaseUnavailable",
+    "ContextSnippet",
+    "ContextResult",
+    "SkippedFile",
+    "ContextResponse",
+    "search_text_context",
+    "list_text_context",
+    "context_response_to_dict",
+    "get_context_cache_info",
+    "clear_context_cache",
+]

--- a/cereja/system/_context/__init__.py
+++ b/cereja/system/_context/__init__.py
@@ -1,1 +1,5 @@
 """Private components for bounded textual context search."""
+
+from .models import ContextResponse, ContextResult, ContextSnippet, SkippedFile
+from .query import context_response_to_dict
+from .search import list_text_context, search_text_context

--- a/cereja/system/_context/__init__.py
+++ b/cereja/system/_context/__init__.py
@@ -1,5 +1,11 @@
 """Private components for bounded textual context search."""
 
-from .models import ContextResponse, ContextResult, ContextSnippet, SkippedFile
+from .models import (
+    ContextCacheWarning,
+    ContextResponse,
+    ContextResult,
+    ContextSnippet,
+    SkippedFile,
+)
 from .query import context_response_to_dict
 from .search import list_text_context, search_text_context

--- a/cereja/system/_context/__init__.py
+++ b/cereja/system/_context/__init__.py
@@ -1,0 +1,1 @@
+"""Private components for bounded textual context search."""

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -104,12 +104,18 @@ def _collect_cached_context(
 
     try:
         with ContextCacheDatabase(default_cache_path()) as database:
+            _database_call(
+                database.enforce_quota,
+                canonical_roots,
+                max_bytes=DEFAULT_MAX_BYTES,
+            )
             prepared, transient_skips = _synchronize_inventory(
                 database,
                 inventory,
                 canonical_roots,
                 max_file_bytes,
                 refresh_cache,
+                DEFAULT_MAX_BYTES,
             )
             _database_call(
                 database.enforce_quota,
@@ -140,6 +146,7 @@ def _synchronize_inventory(
         canonical_roots,
         max_file_bytes,
         refresh_cache,
+        max_cache_bytes,
 ):
     by_root = {root: [] for root in canonical_roots}
     prepared = []
@@ -192,11 +199,19 @@ def _synchronize_inventory(
             cached=cached,
         ))
 
-    for canonical_root, cached_files in by_root.items():
-        scan_token = _database_call(
+    scans = [
+        (canonical_root, cached_files, _database_call(
             database.begin_scan, DEFAULT_NAMESPACE, canonical_root
+        ))
+        for canonical_root, cached_files in by_root.items()
+    ]
+    for canonical_root, cached_files, scan_token in scans:
+        _database_call(
+            database.commit_scan,
+            scan_token,
+            cached_files,
+            max_bytes=max_cache_bytes,
         )
-        _database_call(database.commit_scan, scan_token, cached_files)
     return prepared, skipped
 
 

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -1,0 +1,334 @@
+"""Filesystem-backed cache orchestration for textual context search."""
+
+import hashlib
+import os
+import sqlite3
+from dataclasses import dataclass
+
+from cereja.system._repository_files import iter_repository_files
+
+from .cache_db import (
+    DEFAULT_MAX_BYTES,
+    DEFAULT_NAMESPACE,
+    CacheDatabaseUnavailable,
+    CachedFile,
+    ContextCacheDatabase,
+    FileSignature,
+    default_cache_path,
+)
+from .models import ContextResult, SkippedFile
+from .query import build_search_result, finalize_response
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedFile:
+    path: str
+    root: str
+    cached: CachedFile
+
+
+def _canonical_path(path):
+    return os.path.normcase(os.path.realpath(os.fspath(path)))
+
+
+def _file_signature(path):
+    stat_result = os.stat(path, follow_symlinks=False)
+    return FileSignature(
+        _sqlite_identifier(getattr(stat_result, "st_dev", None)),
+        _sqlite_identifier(getattr(stat_result, "st_ino", None)),
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
+
+
+def _sqlite_identifier(value):
+    if value is None or -(2 ** 63) <= value < 2 ** 63:
+        return value
+    if 0 <= value < 2 ** 64:
+        return value - 2 ** 64
+    return None
+
+
+def _read_cacheable_file(path, signature, max_file_bytes):
+    """Return persistent state, folded text, and digest for one file."""
+    if signature.size_bytes > max_file_bytes:
+        return "file_too_large", None, None
+    with open(path, "rb") as file:
+        data = file.read(max_file_bytes + 1)
+    if len(data) > max_file_bytes:
+        return "file_too_large", None, None
+    digest = hashlib.sha256(data).hexdigest()
+    state, text = _decode_file_data(data)
+    return state, None if text is None else text.casefold(), digest
+
+
+def _read_original_text(path, max_file_bytes):
+    with open(path, "rb") as file:
+        data = file.read(max_file_bytes + 1)
+    if len(data) > max_file_bytes:
+        return "file_too_large", None
+    return _decode_file_data(data)
+
+
+def _decode_file_data(data):
+    if b"\x00" in data:
+        return "binary_file", None
+    try:
+        return "text", data.decode("utf-8-sig", errors="strict")
+    except UnicodeDecodeError:
+        return "invalid_utf8", None
+
+
+def _collect_cached_context(
+        roots,
+        *,
+        mode,
+        query,
+        terms,
+        extensions,
+        max_results,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+        refresh_cache,
+):
+    """Collect context using signature-validated persistent file content."""
+    root_values = tuple(roots)
+    normalized_roots = tuple(_normalized_path(root) for root in root_values)
+    canonical_roots = tuple(dict.fromkeys(_canonical_path(root) for root in root_values))
+
+    # Traversal can fail for invalid roots and must complete before any scan can
+    # remove stale associations.
+    inventory = tuple(iter_repository_files(root_values, extensions=extensions))
+
+    try:
+        with ContextCacheDatabase(default_cache_path()) as database:
+            prepared, transient_skips = _synchronize_inventory(
+                database,
+                inventory,
+                canonical_roots,
+                max_file_bytes,
+                refresh_cache,
+            )
+            _database_call(
+                database.enforce_quota,
+                canonical_roots,
+                max_bytes=DEFAULT_MAX_BYTES,
+            )
+            return _query_prepared_files(
+                prepared,
+                transient_skips,
+                mode=mode,
+                query=query,
+                terms=terms,
+                roots=normalized_roots,
+                max_results=max_results,
+                max_snippets=max_snippets,
+                max_snippet_chars=max_snippet_chars,
+                max_file_bytes=max_file_bytes,
+            )
+    except sqlite3.Error as error:
+        raise CacheDatabaseUnavailable(
+            "context cache database is unavailable"
+        ) from error
+
+
+def _synchronize_inventory(
+        database,
+        inventory,
+        canonical_roots,
+        max_file_bytes,
+        refresh_cache,
+):
+    by_root = {root: [] for root in canonical_roots}
+    prepared = []
+    skipped = []
+    for repository_file in inventory:
+        path = repository_file.path.path
+        normalized_path = _normalized_path(path)
+        canonical_path = _canonical_path(path)
+        canonical_root = _canonical_path(repository_file.root.path)
+        try:
+            signature = _file_signature(path)
+            cached = None if refresh_cache else _database_call(
+                database.get_cached_content,
+                canonical_path,
+                signature,
+                max_file_bytes,
+            )
+            if cached is None:
+                state, folded_text, digest = _read_cacheable_file(
+                    path, signature, max_file_bytes
+                )
+                cached = CachedFile(
+                    canonical_path=canonical_path,
+                    relative_path=repository_file.relative_path,
+                    signature=signature,
+                    state=state,
+                    folded_text=folded_text,
+                    content_sha256=digest,
+                )
+            else:
+                cached = CachedFile(
+                    canonical_path=canonical_path,
+                    relative_path=repository_file.relative_path,
+                    signature=cached.signature,
+                    state=cached.state,
+                    folded_text=cached.folded_text,
+                    content_sha256=cached.content_sha256,
+                )
+        except PermissionError:
+            skipped.append(SkippedFile(normalized_path, "permission_denied"))
+            continue
+        except FileNotFoundError:
+            skipped.append(SkippedFile(normalized_path, "disappeared"))
+            continue
+
+        by_root[canonical_root].append(cached)
+        prepared.append(_PreparedFile(
+            path=normalized_path,
+            root=_normalized_path(repository_file.root.path),
+            cached=cached,
+        ))
+
+    for canonical_root, cached_files in by_root.items():
+        scan_token = _database_call(
+            database.begin_scan, DEFAULT_NAMESPACE, canonical_root
+        )
+        _database_call(database.commit_scan, scan_token, cached_files)
+    return prepared, skipped
+
+
+def _query_prepared_files(
+        prepared,
+        transient_skips,
+        *,
+        mode,
+        query,
+        terms,
+        roots,
+        max_results,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+):
+    candidates = []
+    skipped = list(transient_skips)
+    snippets_truncated = False
+    for item in prepared:
+        cached = item.cached
+        if cached.state != "text":
+            skipped.append(SkippedFile(item.path, cached.state))
+            continue
+        if mode == "list":
+            candidates.append(ContextResult(
+                path=item.path,
+                root=item.root,
+                relative_path=cached.relative_path,
+                size_bytes=cached.signature.size_bytes,
+                score=0,
+                match_count=0,
+                snippets=(),
+            ))
+            continue
+
+        folded_text = cached.folded_text or ""
+        counts = tuple(folded_text.count(term) for term in terms)
+        if not all(counts):
+            continue
+        filename = cached.relative_path.rsplit("/", 1)[-1].casefold()
+        candidates.append(ContextResult(
+            path=item.path,
+            root=item.root,
+            relative_path=cached.relative_path,
+            size_bytes=cached.signature.size_bytes,
+            score=sum(term in filename for term in terms) * 1000 + sum(counts),
+            match_count=sum(counts),
+            snippets=(),
+        ))
+
+    candidates.sort(key=(
+        (lambda result: (-result.score, result.path.casefold(), result.path))
+        if mode == "search"
+        else (lambda result: (result.path.casefold(), result.path))
+    ))
+    selected = candidates[:max_results]
+    if mode == "search":
+        selected, reopen_skips, reopened_truncated = _reopen_winners(
+            candidates,
+            terms,
+            max_snippets,
+            max_snippet_chars,
+            max_file_bytes,
+            max_results,
+        )
+        skipped.extend(reopen_skips)
+        snippets_truncated = snippets_truncated or reopened_truncated
+
+    return finalize_response(
+        mode=mode,
+        query=query,
+        roots=roots,
+        results=list(selected),
+        skipped=skipped,
+        max_results=max_results,
+        snippets_truncated=(
+            snippets_truncated or len(candidates) > max_results
+        ),
+    )
+
+
+def _reopen_winners(
+        candidates,
+        terms,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+        max_results,
+):
+    results = []
+    skipped = []
+    snippets_truncated = False
+    for winner in candidates:
+        if len(results) == max_results:
+            break
+        try:
+            signature = _file_signature(winner.path)
+            state, text = _read_original_text(winner.path, max_file_bytes)
+            if state != "text":
+                skipped.append(SkippedFile(winner.path, state))
+                continue
+        except PermissionError:
+            skipped.append(SkippedFile(winner.path, "permission_denied"))
+            continue
+        except FileNotFoundError:
+            skipped.append(SkippedFile(winner.path, "disappeared"))
+            continue
+        result, omitted = build_search_result(
+            path=winner.path,
+            root=winner.root,
+            relative_path=winner.relative_path,
+            size_bytes=signature.size_bytes,
+            text=text,
+            terms=terms,
+            max_snippets=max_snippets,
+            max_snippet_chars=max_snippet_chars,
+        )
+        if result is not None:
+            results.append(result)
+            snippets_truncated = snippets_truncated or omitted
+    return results, skipped, snippets_truncated
+
+
+def _database_call(operation, *args, **kwargs):
+    try:
+        return operation(*args, **kwargs)
+    except (OSError, sqlite3.Error) as error:
+        raise CacheDatabaseUnavailable(
+            "context cache database is unavailable"
+        ) from error
+
+
+def _normalized_path(value):
+    return os.path.abspath(os.fspath(value)).replace(os.sep, "/")

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -37,6 +37,7 @@ def get_context_cache_info() -> ContextCacheInfo:
     """Return metadata for the default cache without exposing cached text."""
     path = default_cache_path()
     if not path.exists() and not ContextCacheDatabase._is_link(path):
+        ContextCacheDatabase(path)._reject_orphan_sidecars()
         return ContextCacheInfo(
             path=path.absolute().as_posix(),
             schema_version=SCHEMA_VERSION,
@@ -57,6 +58,7 @@ def clear_context_cache() -> ContextCacheClearReport:
     """Clear only the default context-cache namespace."""
     path = default_cache_path()
     if not path.exists() and not ContextCacheDatabase._is_link(path):
+        ContextCacheDatabase(path)._reject_orphan_sidecars()
         return ContextCacheClearReport(0, 0, 0, 0, 0)
     try:
         with ContextCacheDatabase(path) as database:

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -23,7 +23,13 @@ from .models import (
     ContextResult,
     SkippedFile,
 )
-from .query import build_search_result, finalize_response
+from .query import (
+    build_search_candidate,
+    build_search_result,
+    finalize_response,
+    order_context_results,
+    select_context_results,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +79,14 @@ def clear_context_cache() -> ContextCacheClearReport:
 
 def _canonical_path(path):
     return os.path.normcase(os.path.realpath(os.fspath(path)))
+
+
+def _path_is_within_root(path, canonical_root):
+    canonical_path = _canonical_path(path)
+    try:
+        return os.path.commonpath((canonical_path, canonical_root)) == canonical_root
+    except ValueError:
+        return False
 
 
 def _file_signature(path):
@@ -141,13 +155,29 @@ def _collect_cached_context(
     root_values = tuple(roots)
     normalized_roots = tuple(_normalized_path(root) for root in root_values)
     canonical_roots = tuple(dict.fromkeys(_canonical_path(root) for root in root_values))
+    cache_path = default_cache_path()
+    if any(
+            _path_is_within_root(cache_path, canonical_root)
+            for canonical_root in canonical_roots
+    ):
+        raise CacheDatabaseUnavailable(
+            "context cache path is inside a searched root"
+        )
 
     # Traversal can fail for invalid roots and must complete before any scan can
     # remove stale associations.
     inventory = tuple(iter_repository_files(root_values, extensions=extensions))
 
     try:
-        with ContextCacheDatabase(default_cache_path()) as database:
+        with ContextCacheDatabase(cache_path) as database:
+            if _database_call(
+                    database.aggregate_size_bytes
+            ) > DEFAULT_MAX_BYTES:
+                _database_call(
+                    database.enforce_quota,
+                    canonical_roots,
+                    DEFAULT_MAX_BYTES,
+                )
             inventory_roots = {root: False for root in canonical_roots}
             for repository_file in inventory:
                 inventory_roots[_canonical_path(repository_file.root.path)] = True
@@ -170,6 +200,11 @@ def _collect_cached_context(
                 refresh_cache,
                 DEFAULT_MAX_BYTES,
                 scan_tokens,
+            )
+            _database_call(
+                database.enforce_quota,
+                canonical_roots,
+                DEFAULT_MAX_BYTES,
             )
             return _query_prepared_files(
                 prepared,
@@ -298,30 +333,22 @@ def _query_prepared_files(
             ))
             continue
 
-        folded_text = cached.folded_text or ""
-        counts = tuple(folded_text.count(term) for term in terms)
-        if not all(counts):
-            continue
-        filename = cached.relative_path.rsplit("/", 1)[-1].casefold()
-        candidates.append(ContextResult(
+        candidate = build_search_candidate(
             path=item.path,
             root=item.root,
             relative_path=cached.relative_path,
             size_bytes=cached.signature.size_bytes,
-            score=sum(term in filename for term in terms) * 1000 + sum(counts),
-            match_count=sum(counts),
-            snippets=(),
-        ))
+            folded_text=cached.folded_text or "",
+            terms=terms,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
 
-    candidates.sort(key=(
-        (lambda result: (-result.score, result.path.casefold(), result.path))
-        if mode == "search"
-        else (lambda result: (result.path.casefold(), result.path))
-    ))
-    selected = candidates[:max_results]
+    ordered_candidates = order_context_results(candidates, mode)
+    selected = select_context_results(candidates, mode, max_results)
     if mode == "search":
         selected, reopen_skips, reopened_truncated = _reopen_winners(
-            candidates,
+            ordered_candidates,
             terms,
             max_snippets,
             max_snippet_chars,

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -104,10 +104,19 @@ def _collect_cached_context(
 
     try:
         with ContextCacheDatabase(default_cache_path()) as database:
-            _database_call(
-                database.enforce_quota,
-                canonical_roots,
-                max_bytes=DEFAULT_MAX_BYTES,
+            inventory_roots = {root: False for root in canonical_roots}
+            for repository_file in inventory:
+                inventory_roots[_canonical_path(repository_file.root.path)] = True
+            roots_to_sync = _database_call(
+                database.roots_requiring_scan,
+                DEFAULT_NAMESPACE,
+                inventory_roots.items(),
+            )
+            scan_tokens = _database_call(
+                database.begin_scans_if_admitted,
+                DEFAULT_NAMESPACE,
+                roots_to_sync,
+                DEFAULT_MAX_BYTES,
             )
             prepared, transient_skips = _synchronize_inventory(
                 database,
@@ -116,11 +125,7 @@ def _collect_cached_context(
                 max_file_bytes,
                 refresh_cache,
                 DEFAULT_MAX_BYTES,
-            )
-            _database_call(
-                database.enforce_quota,
-                canonical_roots,
-                max_bytes=DEFAULT_MAX_BYTES,
+                scan_tokens,
             )
             return _query_prepared_files(
                 prepared,
@@ -147,6 +152,7 @@ def _synchronize_inventory(
         max_file_bytes,
         refresh_cache,
         max_cache_bytes,
+        scan_tokens,
 ):
     by_root = {root: [] for root in canonical_roots}
     prepared = []
@@ -199,19 +205,19 @@ def _synchronize_inventory(
             cached=cached,
         ))
 
-    scans = [
-        (canonical_root, cached_files, _database_call(
-            database.begin_scan, DEFAULT_NAMESPACE, canonical_root
-        ))
-        for canonical_root, cached_files in by_root.items()
-    ]
-    for canonical_root, cached_files, scan_token in scans:
-        _database_call(
+    if scan_tokens is None:
+        return prepared, skipped
+    for canonical_root, cached_files in by_root.items():
+        if canonical_root not in scan_tokens:
+            continue
+        admitted = _database_call(
             database.commit_scan,
-            scan_token,
+            scan_tokens[canonical_root],
             cached_files,
             max_bytes=max_cache_bytes,
         )
+        if admitted is None:
+            break
     return prepared, skipped
 
 

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from cereja.system._repository_files import iter_repository_files
 
 from .cache_db import (
+    SCHEMA_VERSION,
     DEFAULT_MAX_BYTES,
     DEFAULT_NAMESPACE,
     CacheDatabaseUnavailable,
@@ -16,7 +17,12 @@ from .cache_db import (
     FileSignature,
     default_cache_path,
 )
-from .models import ContextResult, SkippedFile
+from .models import (
+    ContextCacheClearReport,
+    ContextCacheInfo,
+    ContextResult,
+    SkippedFile,
+)
 from .query import build_search_result, finalize_response
 
 
@@ -25,6 +31,42 @@ class _PreparedFile:
     path: str
     root: str
     cached: CachedFile
+
+
+def get_context_cache_info() -> ContextCacheInfo:
+    """Return metadata for the default cache without exposing cached text."""
+    path = default_cache_path()
+    if not path.exists() and not ContextCacheDatabase._is_link(path):
+        return ContextCacheInfo(
+            path=path.absolute().as_posix(),
+            schema_version=SCHEMA_VERSION,
+            namespace=DEFAULT_NAMESPACE,
+            database_bytes=0,
+            wal_bytes=0,
+            shm_bytes=0,
+            roots=0,
+            files=0,
+            text_files=0,
+            skipped_files=0,
+            last_access_ns=None,
+        )
+    return ContextCacheDatabase.read_info(path)
+
+
+def clear_context_cache() -> ContextCacheClearReport:
+    """Clear only the default context-cache namespace."""
+    path = default_cache_path()
+    if not path.exists() and not ContextCacheDatabase._is_link(path):
+        return ContextCacheClearReport(0, 0, 0, 0, 0)
+    try:
+        with ContextCacheDatabase(path) as database:
+            return database.clear_default_namespace()
+    except CacheDatabaseUnavailable:
+        raise
+    except (OSError, sqlite3.Error) as error:
+        raise CacheDatabaseUnavailable(
+            "context cache database is unavailable"
+        ) from error
 
 
 def _canonical_path(path):

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -6,8 +6,10 @@ import sqlite3
 import stat
 import sys
 import time
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Iterable, Iterator, Optional, Union
 
 
 APPLICATION_ID = 0x434A4358  # "CJCX"
@@ -121,6 +123,40 @@ class CacheDatabaseUnavailable(CacheDatabaseError):
     """Raised when the cache database cannot be opened."""
 
 
+@dataclass(frozen=True, slots=True)
+class FileSignature:
+    """Filesystem identity fields used to validate a cached file."""
+
+    device: int | None
+    inode: int | None
+    size_bytes: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class CachedFile:
+    """Cached text state and its association-relative path."""
+
+    canonical_path: str
+    relative_path: str
+    signature: FileSignature
+    state: str
+    folded_text: str | None
+    content_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CacheMaintenanceReport:
+    """Internal accounting for one quota-maintenance pass."""
+
+    associations_removed: int
+    roots_removed: int
+    files_removed: int
+    before_bytes: int
+    after_bytes: int
+
+
 def default_cache_path() -> Path:
     """Return the platform-specific location for Cereja's context cache."""
     if os.name == "nt":
@@ -146,6 +182,8 @@ class ContextCacheDatabase:
     def __init__(self, path: Union[Path, str]):
         self.path = Path(path)
         self._connection: Optional[sqlite3.Connection] = None
+        self._scans: dict[str, tuple[str, str]] = {}
+        self._active_scans: dict[tuple[str, str], str] = {}
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -185,6 +223,294 @@ class ContextCacheDatabase:
             if not row[0].startswith("sqlite_")
         }
 
+    def begin_scan(self, namespace: str, canonical_root: str) -> str:
+        """Return an opaque scan token without changing persisted state."""
+        self.connection
+        scan_token = str(uuid.uuid4())
+        scan_key = namespace, canonical_root
+        previous_token = self._active_scans.get(scan_key)
+        if previous_token is not None:
+            self._scans.pop(previous_token, None)
+        self._scans[scan_token] = scan_key
+        self._active_scans[scan_key] = scan_token
+        return scan_token
+
+    def commit_scan(
+        self, scan_token: str, files: Iterable[CachedFile]
+    ) -> None:
+        """Atomically publish one completed root scan."""
+        try:
+            namespace, canonical_root = self._scans[scan_token]
+        except KeyError as error:
+            raise CacheDatabaseError("context cache scan token is unknown") from error
+
+        cached_files = tuple(files)
+        connection = self.connection
+        timestamp = time.time_ns()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """INSERT INTO namespaces (name, last_access_ns)
+                   VALUES (?, ?)
+                   ON CONFLICT(name) DO UPDATE SET
+                       last_access_ns = excluded.last_access_ns""",
+                (namespace, timestamp),
+            )
+            namespace_id = connection.execute(
+                "SELECT id FROM namespaces WHERE name = ?", (namespace,)
+            ).fetchone()[0]
+            connection.execute(
+                """INSERT INTO roots (canonical_path, last_access_ns)
+                   VALUES (?, ?)
+                   ON CONFLICT(canonical_path) DO UPDATE SET
+                       last_access_ns = excluded.last_access_ns""",
+                (canonical_root, timestamp),
+            )
+            root_id = connection.execute(
+                "SELECT id FROM roots WHERE canonical_path = ?", (canonical_root,)
+            ).fetchone()[0]
+            connection.execute(
+                """INSERT INTO namespace_roots (namespace_id, root_id)
+                   VALUES (?, ?)
+                   ON CONFLICT(namespace_id, root_id) DO NOTHING""",
+                (namespace_id, root_id),
+            )
+
+            for cached_file in cached_files:
+                signature = cached_file.signature
+                connection.execute(
+                    """INSERT INTO files (
+                           canonical_path, device, inode, size_bytes,
+                           mtime_ns, ctime_ns, state, content_sha256,
+                           folded_text, created_ns, validated_ns, last_access_ns
+                       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(canonical_path) DO UPDATE SET
+                           device = excluded.device,
+                           inode = excluded.inode,
+                           size_bytes = excluded.size_bytes,
+                           mtime_ns = excluded.mtime_ns,
+                           ctime_ns = excluded.ctime_ns,
+                           state = excluded.state,
+                           content_sha256 = excluded.content_sha256,
+                           folded_text = excluded.folded_text,
+                           validated_ns = excluded.validated_ns,
+                           last_access_ns = excluded.last_access_ns""",
+                    (
+                        cached_file.canonical_path,
+                        signature.device,
+                        signature.inode,
+                        signature.size_bytes,
+                        signature.mtime_ns,
+                        signature.ctime_ns,
+                        cached_file.state,
+                        cached_file.content_sha256,
+                        cached_file.folded_text,
+                        timestamp,
+                        timestamp,
+                        timestamp,
+                    ),
+                )
+                file_id = connection.execute(
+                    "SELECT id FROM files WHERE canonical_path = ?",
+                    (cached_file.canonical_path,),
+                ).fetchone()[0]
+                connection.execute(
+                    """INSERT INTO root_files (
+                           root_id, file_id, relative_path, last_seen_scan
+                       ) VALUES (?, ?, ?, ?)
+                       ON CONFLICT(root_id, file_id) DO UPDATE SET
+                           relative_path = excluded.relative_path,
+                           last_seen_scan = excluded.last_seen_scan""",
+                    (root_id, file_id, cached_file.relative_path, scan_token),
+                )
+
+            connection.execute(
+                """DELETE FROM root_files
+                   WHERE root_id = ? AND last_seen_scan <> ?""",
+                (root_id, scan_token),
+            )
+            connection.commit()
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        else:
+            del self._scans[scan_token]
+            self._active_scans.pop((namespace, canonical_root), None)
+
+    def iter_root_files(
+        self, namespace: str, canonical_root: str
+    ) -> Iterator[CachedFile]:
+        """Iterate cached files associated with a namespace root."""
+        timestamp = time.time_ns()
+        self.connection.execute(
+            """UPDATE roots SET last_access_ns = ?
+               WHERE canonical_path = ?
+                 AND EXISTS (
+                     SELECT 1 FROM namespace_roots AS nr
+                     JOIN namespaces AS n ON n.id = nr.namespace_id
+                     WHERE nr.root_id = roots.id AND n.name = ?
+                 )""",
+            (timestamp, canonical_root, namespace),
+        )
+        self.connection.commit()
+        rows = self.connection.execute(
+            """SELECT f.canonical_path, rf.relative_path,
+                      f.device, f.inode, f.size_bytes, f.mtime_ns, f.ctime_ns,
+                      f.state, f.folded_text, f.content_sha256
+               FROM namespace_roots AS nr
+               JOIN namespaces AS n ON n.id = nr.namespace_id
+               JOIN roots AS r ON r.id = nr.root_id
+               JOIN root_files AS rf ON rf.root_id = r.id
+               JOIN files AS f ON f.id = rf.file_id
+               WHERE n.name = ? AND r.canonical_path = ?
+               ORDER BY rf.relative_path, f.canonical_path""",
+            (namespace, canonical_root),
+        ).fetchall()
+        for row in rows:
+            yield _cached_file_from_row(row)
+
+    def get_cached_file(
+        self,
+        canonical_path: str,
+        signature: FileSignature,
+        max_file_bytes: int,
+    ) -> CachedFile | None:
+        """Return a reusable cached file with an identical signature."""
+        rows = self.connection.execute(
+            """SELECT f.canonical_path, rf.relative_path,
+                      f.device, f.inode, f.size_bytes, f.mtime_ns, f.ctime_ns,
+                      f.state, f.folded_text, f.content_sha256, f.id
+               FROM files AS f
+               LEFT JOIN root_files AS rf ON rf.file_id = f.id
+               WHERE f.canonical_path = ?
+                 AND f.device IS ?
+                 AND f.inode IS ?
+                 AND f.size_bytes = ?
+                 AND f.mtime_ns = ?
+                 AND f.ctime_ns = ?
+               ORDER BY rf.root_id""",
+            (
+                canonical_path,
+                signature.device,
+                signature.inode,
+                signature.size_bytes,
+                signature.mtime_ns,
+                signature.ctime_ns,
+            ),
+        ).fetchall()
+        if len(rows) != 1 or rows[0][1] is None:
+            return None
+        row = rows[0]
+        if signature.size_bytes > max_file_bytes and row[7] != "file_too_large":
+            return None
+        if row[7] == "file_too_large" and signature.size_bytes <= max_file_bytes:
+            return None
+        self.connection.execute(
+            "UPDATE files SET last_access_ns = ? WHERE id = ?",
+            (time.time_ns(), row[10]),
+        )
+        self.connection.execute(
+            """UPDATE roots SET last_access_ns = ?
+               WHERE id = (
+                   SELECT root_id FROM root_files WHERE file_id = ?
+               )""",
+            (time.time_ns(), row[10]),
+        )
+        self.connection.commit()
+        normalized = tuple(row[:10])
+        return _cached_file_from_row(normalized)
+
+    def aggregate_size_bytes(self) -> int:
+        """Return the current byte size of the database and WAL sidecars."""
+        total = 0
+        for path in (self.path, *self._sidecar_paths()):
+            try:
+                total += path.stat(follow_symlinks=False).st_size
+            except FileNotFoundError:
+                continue
+        return total
+
+    def enforce_quota(
+        self,
+        protected_root: str,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+    ) -> CacheMaintenanceReport:
+        """Evict unprotected roots in LRU order until quota or candidates end."""
+        if max_bytes < 0:
+            raise ValueError("max_bytes must not be negative")
+        before_bytes = self.aggregate_size_bytes()
+        associations_removed = 0
+        roots_removed = 0
+        files_removed = self._collect_orphan_files()
+        self._run_bounded_maintenance()
+
+        candidates = self.connection.execute(
+            """SELECT id FROM roots
+               WHERE canonical_path <> ?
+               ORDER BY last_access_ns, id""",
+            (protected_root,),
+        ).fetchall()
+        for (root_id,) in candidates:
+            if self.aggregate_size_bytes() <= max_bytes:
+                break
+            connection = self.connection
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                association_count = connection.execute(
+                    "SELECT COUNT(*) FROM root_files WHERE root_id = ?",
+                    (root_id,),
+                ).fetchone()[0]
+                root_count = connection.execute(
+                    "DELETE FROM roots WHERE id = ?", (root_id,)
+                ).rowcount
+                file_count = connection.execute(
+                    """DELETE FROM files
+                       WHERE NOT EXISTS (
+                           SELECT 1 FROM root_files WHERE root_files.file_id = files.id
+                       )"""
+                ).rowcount
+                connection.commit()
+            except BaseException:
+                if connection.in_transaction:
+                    connection.rollback()
+                raise
+            associations_removed += association_count
+            roots_removed += root_count
+            files_removed += file_count
+            self._run_bounded_maintenance()
+
+        self._run_bounded_maintenance()
+        return CacheMaintenanceReport(
+            associations_removed=associations_removed,
+            roots_removed=roots_removed,
+            files_removed=files_removed,
+            before_bytes=before_bytes,
+            after_bytes=self.aggregate_size_bytes(),
+        )
+
+    def _collect_orphan_files(self) -> int:
+        connection = self.connection
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            removed = connection.execute(
+                """DELETE FROM files
+                   WHERE NOT EXISTS (
+                       SELECT 1 FROM root_files WHERE root_files.file_id = files.id
+                   )"""
+            ).rowcount
+            connection.commit()
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        return removed
+
+    def _run_bounded_maintenance(self) -> None:
+        """Checkpoint WAL and reclaim at most a bounded number of pages."""
+        self.connection.execute("PRAGMA incremental_vacuum(128)")
+        self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+
     @staticmethod
     def _identity(path: Path) -> tuple[int, int]:
         result = path.stat(follow_symlinks=False)
@@ -193,7 +519,7 @@ class ContextCacheDatabase:
     @staticmethod
     def _is_link(path: Path) -> bool:
         try:
-            attributes = getattr(path.lstat(), "st_file_attributes", 0)
+            attributes = getattr(path.lstat(), "st_file_attributes", 0) or 0
         except FileNotFoundError:
             attributes = 0
         reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
@@ -429,6 +755,8 @@ class ContextCacheDatabase:
         if self._connection is not None:
             self._connection.close()
             self._connection = None
+        self._scans.clear()
+        self._active_scans.clear()
 
 
 def _uses_posix_permissions() -> bool:
@@ -437,3 +765,20 @@ def _uses_posix_permissions() -> bool:
 
 def _canonical_ddl(ddl: str) -> str:
     return re.sub(r"\s+", "", ddl).rstrip(";").casefold()
+
+
+def _cached_file_from_row(row: tuple[object, ...]) -> CachedFile:
+    return CachedFile(
+        canonical_path=str(row[0]),
+        relative_path=str(row[1]),
+        signature=FileSignature(
+            device=row[2],
+            inode=row[3],
+            size_bytes=int(row[4]),
+            mtime_ns=int(row[5]),
+            ctime_ns=int(row[6]),
+        ),
+        state=str(row[7]),
+        folded_text=None if row[8] is None else str(row[8]),
+        content_sha256=None if row[9] is None else str(row[9]),
+    )

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -2,9 +2,12 @@
 
 import os
 import re
+import shutil
 import sqlite3
 import stat
+import struct
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -12,12 +15,30 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, Union
 
+from .models import ContextCacheClearReport, ContextCacheInfo
+
 
 APPLICATION_ID = 0x434A4358  # "CJCX"
 SCHEMA_VERSION = 1
 DEFAULT_NAMESPACE = "default"
 DEFAULT_MAX_BYTES = 256 * 1024 * 1024
 BUSY_TIMEOUT_MS = 500
+
+_SQLITE_HEADER = b"SQLite format 3\x00"
+_SQLITE_USER_VERSION_OFFSET = 60
+_SQLITE_APPLICATION_ID_OFFSET = 68
+_SQLITE_IDENTITY_BYTES = 72
+_WAL_HEADER_BYTES = 32
+_WAL_FRAME_HEADER_BYTES = 24
+_WAL_FORMAT_VERSION = 3_007_000
+_WAL_CHECKSUM_BYTE_ORDERS = {
+    0x377F0682: "<",
+    0x377F0683: ">",
+}
+
+_PreparedPath = tuple[
+    bool, tuple[int, int], tuple[int, int], dict[Path, tuple[int, int]]
+]
 
 _SCAN_TOKEN_LOCK = threading.Lock()
 _LAST_SCAN_STARTED_NS = 0
@@ -147,6 +168,86 @@ class CacheDatabaseUnavailable(CacheDatabaseError):
     """Raised when the cache database cannot be opened."""
 
 
+class _RecognizedCacheCorruption(CacheDatabaseUnavailable):
+    """Signal corruption only after the main file proves cache ownership."""
+
+
+class _ReplacementPublicationError(CacheDatabaseUnavailable):
+    """Keep recovery inputs when a no-clobber publication cannot complete."""
+
+
+class _CachePathLock:
+    """Shared/exclusive advisory lock coordinated by every cache opener."""
+
+    def __init__(self, database_path: Path):
+        self.path = Path(f"{database_path}.lock")
+        self._descriptor: int | None = None
+        self._platform_state = None
+        self.exclusive = False
+
+    def acquire(self, exclusive: bool, *, create: bool = True) -> None:
+        if self._descriptor is not None:
+            raise CacheDatabaseError("context cache lock is already held")
+        if ContextCacheDatabase._is_link(self.path):
+            raise CacheDatabaseError("context cache lock file is unsafe")
+        flags = os.O_RDWR | getattr(os, "O_BINARY", 0)
+        if create:
+            flags |= os.O_CREAT
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(self.path, flags, 0o600)
+        try:
+            result = os.fstat(descriptor)
+            if not stat.S_ISREG(result.st_mode):
+                raise CacheDatabaseError(
+                    "context cache lock must be a regular file"
+                )
+            if _uses_posix_permissions() and stat.S_IMODE(result.st_mode) & 0o077:
+                raise CacheDatabaseError(
+                    "context cache lock permissions are unsafe"
+                )
+            if (ContextCacheDatabase._is_link(self.path)
+                    or ContextCacheDatabase._identity(self.path)
+                    != (result.st_dev, result.st_ino)):
+                raise CacheDatabaseError("context cache lock identity changed")
+            self._platform_state = _acquire_descriptor_lock(
+                descriptor, exclusive
+            )
+        except BaseException:
+            os.close(descriptor)
+            raise
+        self._descriptor = descriptor
+        self.exclusive = exclusive
+
+    def change(self, exclusive: bool) -> None:
+        if self._descriptor is None:
+            raise CacheDatabaseError("context cache lock is not held")
+        if self.exclusive == exclusive:
+            return
+        descriptor = self._descriptor
+        _release_descriptor_lock(descriptor, self._platform_state)
+        self._platform_state = None
+        try:
+            self._platform_state = _acquire_descriptor_lock(
+                descriptor, exclusive
+            )
+        except BaseException:
+            os.close(descriptor)
+            self._descriptor = None
+            raise
+        self.exclusive = exclusive
+
+    def release(self) -> None:
+        if self._descriptor is None:
+            return
+        descriptor = self._descriptor
+        self._descriptor = None
+        try:
+            _release_descriptor_lock(descriptor, self._platform_state)
+        finally:
+            self._platform_state = None
+            os.close(descriptor)
+
+
 @dataclass(frozen=True, slots=True)
 class ScanToken:
     """Scan identity with a process-monotonic start timestamp."""
@@ -216,6 +317,7 @@ class ContextCacheDatabase:
     def __init__(self, path: Union[Path, str]):
         self.path = Path(path)
         self._connection: Optional[sqlite3.Connection] = None
+        self._cache_lock: _CachePathLock | None = None
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -228,22 +330,460 @@ class ContextCacheDatabase:
         try:
             prepared = self._prepare_path()
             database_is_empty, directory_identity, file_identity, sidecars = prepared
-            self._connection = sqlite3.connect(str(self.path), timeout=0.5)
-            self._validate_identity(directory_identity, file_identity)
-            self._configure_connection(database_is_empty)
-            self._secure_new_sidecars(sidecars)
-            self._verify_or_create_schema()
-            self._secure_new_sidecars(sidecars)
+            recovery_required = False
+            schema_version = SCHEMA_VERSION
+            if not database_is_empty:
+                try:
+                    schema_version = self._read_header_identity(
+                        file_identity, sidecars
+                    )
+                except _RecognizedCacheCorruption:
+                    recovery_required = True
+            self._acquire_cache_lock(
+                database_is_empty or recovery_required or schema_version == 0
+            )
+            locked_prepared = self._prepare_path()
+            if locked_prepared[1] != directory_identity:
+                raise CacheDatabaseError(
+                    "context cache directory identity changed"
+                )
+            if locked_prepared[2] != file_identity:
+                raise CacheDatabaseError(
+                    "context cache database identity changed"
+                )
+            self._open_locked(locked_prepared)
         except CacheDatabaseError:
             self._close_connection()
+            self._release_cache_lock()
             raise
         except (OSError, sqlite3.Error) as error:
             self._close_connection()
+            self._release_cache_lock()
             raise CacheDatabaseUnavailable("context cache database is unavailable") from error
         return self
 
+    def _open_locked(self, prepared: _PreparedPath) -> None:
+        database_is_empty, _, file_identity, sidecars = prepared
+        if database_is_empty:
+            self._require_exclusive_lock()
+            self._open_prepared(prepared)
+            self._cache_lock.change(False)
+            return
+
+        try:
+            schema_version = self._read_header_identity(
+                file_identity, sidecars
+            )
+        except _RecognizedCacheCorruption:
+            self._require_exclusive_lock()
+            prepared = self._prepare_path()
+            try:
+                self._read_header_identity(prepared[2], prepared[3])
+            except _RecognizedCacheCorruption:
+                self._recover_database(prepared)
+                self._cache_lock.change(False)
+                return
+            return self._open_locked(prepared)
+        if schema_version == 0:
+            self._require_exclusive_lock()
+            prepared = self._prepare_path()
+            schema_version = self._read_header_identity(
+                prepared[2], prepared[3]
+            )
+            if schema_version == 0:
+                self._recover_database(prepared)
+                self._cache_lock.change(False)
+                return
+            return self._open_locked(prepared)
+
+        try:
+            self._open_prepared(prepared)
+        except sqlite3.DatabaseError as error:
+            self._close_connection()
+            if not self._is_corruption_error(error):
+                raise
+            self._require_exclusive_lock()
+            prepared = self._prepare_path()
+            try:
+                schema_version = self._read_header_identity(
+                    prepared[2], prepared[3]
+                )
+            except _RecognizedCacheCorruption:
+                self._recover_database(prepared)
+                self._cache_lock.change(False)
+                return
+            if schema_version == 0:
+                self._recover_database(prepared)
+                self._cache_lock.change(False)
+                return
+            try:
+                self._open_prepared(prepared)
+            except sqlite3.DatabaseError as retry_error:
+                self._close_connection()
+                if not self._is_corruption_error(retry_error):
+                    raise
+                self._recover_database(prepared)
+        if self._cache_lock.exclusive:
+            self._cache_lock.change(False)
+
+    def _acquire_cache_lock(self, exclusive: bool) -> None:
+        lock = _CachePathLock(self.path)
+        lock.acquire(exclusive)
+        self._cache_lock = lock
+
+    def _require_exclusive_lock(self) -> None:
+        if self._cache_lock is None:
+            raise CacheDatabaseError("context cache lock is not held")
+        self._cache_lock.change(True)
+
+    def _release_cache_lock(self) -> None:
+        if self._cache_lock is not None:
+            self._cache_lock.release()
+            self._cache_lock = None
+
+    def _open_prepared(
+        self,
+        prepared: _PreparedPath,
+    ) -> None:
+        database_is_empty, directory_identity, file_identity, sidecars = prepared
+        self._connection = sqlite3.connect(
+            str(self.path), timeout=BUSY_TIMEOUT_MS / 1000
+        )
+        self._validate_identity(directory_identity, file_identity)
+        self._configure_connection(database_is_empty)
+        self._secure_new_sidecars(sidecars)
+        self._verify_or_create_schema()
+        self._secure_new_sidecars(sidecars)
+
+    def _read_header_identity(
+        self,
+        file_identity: tuple[int, int],
+        sidecars: dict[Path, tuple[int, int]],
+    ) -> int:
+        """Return a recognized schema version without opening SQLite."""
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(self.path, flags)
+        try:
+            result = os.fstat(descriptor)
+            if (result.st_dev, result.st_ino) != file_identity:
+                raise CacheDatabaseError(
+                    "context cache database identity changed"
+                )
+            header = os.read(descriptor, _SQLITE_IDENTITY_BYTES)
+        finally:
+            os.close(descriptor)
+        self._validate_secure_file(self.path)
+        if (len(header) < _SQLITE_IDENTITY_BYTES
+                or header[:len(_SQLITE_HEADER)] != _SQLITE_HEADER):
+            raise CacheDatabaseUnavailable(
+                "context cache database identity is not recognized"
+            )
+        application_id, schema_version = _database_header_identity(header)
+        self._validate_header_values(application_id, schema_version)
+        write_ahead_log, _ = self._sidecar_paths()
+        if (write_ahead_log in sidecars
+                and write_ahead_log.stat(follow_symlinks=False).st_size > 32):
+            try:
+                application_id, schema_version = self._read_wal_identity(
+                    file_identity,
+                    sidecars,
+                    application_id,
+                    schema_version,
+                )
+            except CacheDatabaseUnavailable as error:
+                raise _RecognizedCacheCorruption(
+                    "recognized context cache WAL is corrupt"
+                ) from error
+        self._validate_header_values(application_id, schema_version)
+        return schema_version
+
+    def _read_wal_identity(
+        self,
+        file_identity: tuple[int, int],
+        sidecars: dict[Path, tuple[int, int]],
+        application_id: int,
+        schema_version: int,
+    ) -> tuple[int, int]:
+        write_ahead_log, _ = self._sidecar_paths()
+        descriptor = self._open_validated_wal(write_ahead_log, sidecars)
+        try:
+            page_one = _last_committed_wal_page_one(descriptor)
+        finally:
+            os.close(descriptor)
+        if self._identity(self.path) != file_identity:
+            raise CacheDatabaseError(
+                "context cache database identity changed"
+            )
+        for sidecar, identity in sidecars.items():
+            if self._identity(sidecar) != identity:
+                raise CacheDatabaseError(
+                    "context cache sidecar identity changed"
+                )
+        if page_one is not None:
+            application_id, schema_version = _database_header_identity(page_one)
+        return int(application_id), int(schema_version)
+
+    def _open_validated_wal(
+        self,
+        write_ahead_log: Path,
+        sidecars: dict[Path, tuple[int, int]],
+    ) -> int:
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(write_ahead_log, flags)
+        result = os.fstat(descriptor)
+        if (result.st_dev, result.st_ino) != sidecars[write_ahead_log]:
+            os.close(descriptor)
+            raise CacheDatabaseError(
+                "context cache WAL identity changed"
+            )
+        return descriptor
+
+    @staticmethod
+    def _validate_header_values(application_id: int, schema_version: int) -> None:
+        if application_id != APPLICATION_ID:
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unknown application id"
+            )
+        if schema_version > SCHEMA_VERSION:
+            raise CacheDatabaseUnavailable(
+                "context cache database has a newer schema version"
+            )
+        if schema_version not in (0, SCHEMA_VERSION):
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unsupported schema version"
+            )
+
+    @staticmethod
+    def _is_corruption_error(error: sqlite3.DatabaseError) -> bool:
+        message = str(error).casefold()
+        if "malformed database schema" in message:
+            return False
+        code = getattr(error, "sqlite_errorcode", None)
+        if code is not None:
+            primary_code = code & 0xFF
+            corruption_codes = {
+                value for value in (
+                    getattr(sqlite3, "SQLITE_CORRUPT", None),
+                    getattr(sqlite3, "SQLITE_NOTADB", None),
+                    getattr(sqlite3, "SQLITE_FORMAT", None),
+                ) if value is not None
+            }
+            if primary_code in corruption_codes:
+                return True
+        return "malformed" in message or "not a database" in message
+
+    def _recover_database(
+        self,
+        prepared: _PreparedPath,
+    ) -> None:
+        """Replace only a positively identified Cereja database."""
+        if self._cache_lock is None or not self._cache_lock.exclusive:
+            raise CacheDatabaseError(
+                "context cache recovery requires exclusive ownership"
+            )
+        _, directory_identity, file_identity, sidecars = prepared
+        self._close_connection()
+        self._validate_identity(directory_identity, file_identity)
+        self._validate_sidecars()
+        directory = self.path.parent.resolve(strict=True)
+        quarantine_paths = self._quarantine_paths(sidecars, directory)
+        self._move_to_quarantine(
+            quarantine_paths, file_identity, sidecars
+        )
+
+        replacement_path = self.path.with_name(
+            f"{self.path.name}.replacement-{time.time_ns()}-{uuid.uuid4().hex}"
+        )
+        self._validate_recovery_sibling(replacement_path, directory)
+        replacement_database = type(self)(replacement_path)
+        try:
+            replacement = replacement_database._prepare_path()
+            replacement_database._open_prepared(replacement)
+            replacement_database._checkpoint_wal()
+            replacement_database._close_connection()
+            replacement = replacement_database._prepare_path()
+            replacement_database._read_header_identity(
+                replacement[2], replacement[3]
+            )
+            if replacement[3]:
+                raise CacheDatabaseUnavailable(
+                    "context cache replacement has live sidecars"
+                )
+            replacement_identity = replacement[2]
+            self._publish_replacement(
+                replacement_path, replacement_identity
+            )
+            published = self._prepare_path()
+            if published[2] != replacement_identity:
+                raise _ReplacementPublicationError(
+                    "context cache replacement identity changed"
+                )
+            self._read_header_identity(published[2], published[3])
+            self._open_prepared(published)
+        except BaseException as error:
+            self._close_connection()
+            replacement_database._close_connection()
+            if not isinstance(error, _ReplacementPublicationError):
+                self._discard_failed_replacement(replacement_path)
+            if isinstance(error, CacheDatabaseError):
+                raise
+            if isinstance(error, (OSError, sqlite3.Error)):
+                raise CacheDatabaseUnavailable(
+                    "context cache replacement could not be created"
+                ) from error
+            raise
+
+        try:
+            self._discard_quarantine(
+                quarantine_paths, file_identity, sidecars
+            )
+        except BaseException:
+            self._close_connection()
+            raise
+
+    def _quarantine_paths(
+        self,
+        sidecars: dict[Path, tuple[int, int]],
+        directory: Path,
+    ) -> dict[Path, Path]:
+        quarantine = self.path.with_name(
+            f"{self.path.name}.quarantine-{time.time_ns()}-{uuid.uuid4().hex}"
+        )
+        self._validate_recovery_sibling(quarantine, directory)
+        quarantine_paths = {self.path: quarantine}
+        for sidecar in self._sidecar_paths():
+            if sidecar in sidecars:
+                suffix = sidecar.name[len(self.path.name):]
+                candidate = quarantine.with_name(quarantine.name + suffix)
+                self._validate_recovery_sibling(candidate, directory)
+                quarantine_paths[sidecar] = candidate
+        if any(
+            target.exists() or self._is_link(target)
+            for target in quarantine_paths.values()
+        ):
+            raise CacheDatabaseUnavailable(
+                "context cache quarantine path already exists"
+            )
+        return quarantine_paths
+
+    def _move_to_quarantine(
+        self,
+        quarantine_paths: dict[Path, Path],
+        file_identity: tuple[int, int],
+        sidecars: dict[Path, tuple[int, int]],
+    ) -> None:
+        moved = []
+        try:
+            for source, target in quarantine_paths.items():
+                expected_identity = (
+                    file_identity if source == self.path else sidecars[source]
+                )
+                if self._identity(source) != expected_identity:
+                    raise CacheDatabaseError(
+                        "context cache file identity changed during recovery"
+                    )
+                self._validate_secure_file(source)
+                if target.exists() or self._is_link(target):
+                    raise CacheDatabaseUnavailable(
+                        "context cache quarantine path already exists"
+                    )
+                os.rename(source, target)
+                moved.append((source, target, expected_identity))
+        except BaseException as primary_error:
+            rollback_errors = []
+            for source, target, expected_identity in reversed(moved):
+                try:
+                    if source.exists() or self._is_link(source):
+                        raise CacheDatabaseError(
+                            "context cache recovery rollback target exists"
+                        )
+                    if self._identity(target) != expected_identity:
+                        raise CacheDatabaseError(
+                            "context cache quarantine identity changed"
+                        )
+                    os.rename(target, source)
+                except BaseException as rollback_error:
+                    rollback_errors.append(rollback_error)
+            if rollback_errors:
+                raise BaseExceptionGroup(
+                    "context cache quarantine move and rollback failed",
+                    [primary_error, *rollback_errors],
+                )
+            raise
+
+    def _discard_failed_replacement(self, replacement_path: Path) -> None:
+        for candidate in (
+            *(
+                Path(f"{replacement_path}{suffix}")
+                for suffix in ("-wal", "-shm")
+            ),
+            replacement_path,
+        ):
+            if candidate.exists() or self._is_link(candidate):
+                self._validate_secure_file(candidate)
+                candidate.unlink()
+
+    def _publish_replacement(
+        self,
+        replacement_path: Path,
+        replacement_identity: tuple[int, int],
+    ) -> None:
+        """Publish a validated sibling without overwriting a new target."""
+        if self.path.exists() or self._is_link(self.path):
+            raise _ReplacementPublicationError(
+                "context cache path reappeared during recovery"
+            )
+        self._validate_secure_file(replacement_path)
+        if self._identity(replacement_path) != replacement_identity:
+            raise _ReplacementPublicationError(
+                "context cache replacement identity changed"
+            )
+        try:
+            if os.name == "nt":
+                os.rename(replacement_path, self.path)
+                return
+            os.link(
+                replacement_path,
+                self.path,
+                follow_symlinks=False,
+            )
+            if self._identity(self.path) != replacement_identity:
+                raise CacheDatabaseError(
+                    "context cache replacement identity changed"
+                )
+            replacement_path.unlink()
+        except OSError as error:
+            raise _ReplacementPublicationError(
+                "context cache replacement could not be published"
+            ) from error
+
+    def _discard_quarantine(
+        self,
+        quarantine_paths: dict[Path, Path],
+        file_identity: tuple[int, int],
+        sidecars: dict[Path, tuple[int, int]],
+    ) -> None:
+        for source, target in reversed(tuple(quarantine_paths.items())):
+            expected_identity = (
+                file_identity if source == self.path else sidecars[source]
+            )
+            if self._identity(target) != expected_identity:
+                raise CacheDatabaseError(
+                    "context cache quarantine identity changed"
+                )
+            self._validate_secure_file(target)
+            target.unlink()
+
+    @staticmethod
+    def _validate_recovery_sibling(path: Path, directory: Path) -> None:
+        if path.parent.resolve(strict=True) != directory:
+            raise CacheDatabaseError("context cache recovery escaped its directory")
+
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         self._close_connection()
+        self._release_cache_lock()
 
     def table_names(self) -> set[str]:
         """Return the set of application tables in the open database."""
@@ -254,6 +794,318 @@ class ContextCacheDatabase:
             )
             if not row[0].startswith("sqlite_")
         }
+
+    @classmethod
+    def read_info(cls, path: Union[Path, str]) -> ContextCacheInfo:
+        """Read default-namespace statistics through a read-only connection."""
+        database = cls(path)
+        directory_identity, file_identity, sidecars = (
+            database._prepare_read_only_path()
+        )
+        database._read_header_identity(file_identity, sidecars)
+        try:
+            database._acquire_existing_cache_lock(True)
+            directory_identity, file_identity, sidecars = (
+                database._prepare_read_only_path()
+            )
+            database._read_header_identity(file_identity, sidecars)
+            database_bytes, wal_bytes, shm_bytes = database._storage_sizes()
+            if wal_bytes:
+                return database._read_info_snapshot(
+                    directory_identity,
+                    file_identity,
+                    sidecars,
+                    database_bytes,
+                    wal_bytes,
+                    shm_bytes,
+                )
+            query = "mode=ro" if wal_bytes else "mode=ro&immutable=1"
+            uri = f"{database.path.absolute().as_uri()}?{query}"
+            database._connection = sqlite3.connect(
+                uri, uri=True, timeout=BUSY_TIMEOUT_MS / 1000
+            )
+            database._validate_identity(directory_identity, file_identity)
+            database.connection.execute("PRAGMA query_only = ON")
+            database.connection.execute(
+                f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
+            )
+            return database._query_info(
+                database_bytes, wal_bytes, shm_bytes
+            )
+        except CacheDatabaseError:
+            raise
+        except (OSError, sqlite3.Error) as error:
+            raise CacheDatabaseUnavailable(
+                "context cache database is unavailable"
+            ) from error
+        finally:
+            database._close_connection()
+            database._release_cache_lock()
+
+    def _acquire_existing_cache_lock(self, exclusive: bool) -> None:
+        lock = _CachePathLock(self.path)
+        if not lock.path.exists() and not self._is_link(lock.path):
+            return
+        lock.acquire(exclusive, create=False)
+        self._cache_lock = lock
+
+    def _read_info_snapshot(
+        self,
+        directory_identity: tuple[int, int],
+        file_identity: tuple[int, int],
+        sidecars: dict[Path, tuple[int, int]],
+        database_bytes: int,
+        wal_bytes: int,
+        shm_bytes: int,
+    ) -> ContextCacheInfo:
+        snapshot_sources = (self.path, Path(f"{self.path}-wal"))
+        before = {
+            source: _stable_file_identity(source)
+            for source in snapshot_sources
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            snapshot_path = Path(temporary_directory) / self.path.name
+            shutil.copyfile(self.path, snapshot_path)
+            shutil.copyfile(
+                Path(f"{self.path}-wal"),
+                Path(f"{snapshot_path}-wal"),
+            )
+            if _uses_posix_permissions():
+                snapshot_path.chmod(0o600)
+                Path(f"{snapshot_path}-wal").chmod(0o600)
+            self._validate_identity(directory_identity, file_identity)
+            for source, identity in sidecars.items():
+                if self._identity(source) != identity:
+                    raise CacheDatabaseError(
+                        "context cache sidecar identity changed"
+                    )
+            after = {
+                source: _stable_file_identity(source)
+                for source in snapshot_sources
+            }
+            if after != before:
+                raise CacheDatabaseUnavailable(
+                    "context cache changed while reading metadata"
+                )
+            lock_path = _CachePathLock(self.path).path
+            if self._cache_lock is None and (
+                lock_path.exists() or self._is_link(lock_path)
+            ):
+                raise CacheDatabaseUnavailable(
+                    "context cache changed while reading metadata"
+                )
+            snapshot = type(self)(snapshot_path)
+            uri = f"{snapshot_path.absolute().as_uri()}?mode=ro"
+            try:
+                snapshot._connection = sqlite3.connect(
+                    uri, uri=True, timeout=BUSY_TIMEOUT_MS / 1000
+                )
+                snapshot.connection.execute("PRAGMA query_only = ON")
+                info = snapshot._query_info(
+                    database_bytes, wal_bytes, shm_bytes
+                )
+            finally:
+                snapshot._close_connection()
+        return ContextCacheInfo(
+            path=self.path.absolute().as_posix(),
+            schema_version=info.schema_version,
+            namespace=info.namespace,
+            database_bytes=database_bytes,
+            wal_bytes=wal_bytes,
+            shm_bytes=shm_bytes,
+            roots=info.roots,
+            files=info.files,
+            text_files=info.text_files,
+            skipped_files=info.skipped_files,
+            last_access_ns=info.last_access_ns,
+        )
+
+    def _prepare_read_only_path(
+        self,
+    ) -> tuple[
+        tuple[int, int], tuple[int, int], dict[Path, tuple[int, int]]
+    ]:
+        if self._is_link(self.path):
+            raise CacheDatabaseError(
+                "context cache database must not be a symlink"
+            )
+        try:
+            mode = self.path.lstat().st_mode
+        except FileNotFoundError as error:
+            raise CacheDatabaseUnavailable(
+                "context cache database is unavailable"
+            ) from error
+        if not stat.S_ISREG(mode):
+            raise CacheDatabaseError(
+                "context cache database must be a regular file"
+            )
+        directory = self.path.parent
+        if self._is_link(directory) or not directory.is_dir():
+            raise CacheDatabaseError("context cache directory is unsafe")
+        directory_identity = self._identity(directory)
+        file_identity = self._identity(self.path)
+        self._validate_secure_file(self.path)
+        self._validate_sidecars()
+        return directory_identity, file_identity, self._existing_sidecars()
+
+    def _query_info(
+        self,
+        database_bytes: int,
+        wal_bytes: int,
+        shm_bytes: int,
+    ) -> ContextCacheInfo:
+        application_id = self.connection.execute(
+            "PRAGMA application_id"
+        ).fetchone()[0]
+        schema_version = self.connection.execute(
+            "PRAGMA user_version"
+        ).fetchone()[0]
+        if application_id != APPLICATION_ID:
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unknown application id"
+            )
+        if schema_version != SCHEMA_VERSION:
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unsupported schema version"
+            )
+        if self.table_names() != _TABLE_NAMES:
+            raise CacheDatabaseError(
+                "context cache database schema is incomplete"
+            )
+        namespace = self.connection.execute(
+            "SELECT id, last_access_ns FROM namespaces WHERE name = ?",
+            (DEFAULT_NAMESPACE,),
+        ).fetchone()
+        if namespace is None:
+            raise CacheDatabaseError(
+                "context cache database default namespace is missing"
+            )
+        namespace_id, last_access_ns = namespace
+        roots = self.connection.execute(
+            "SELECT COUNT(*) FROM namespace_roots WHERE namespace_id = ?",
+            (namespace_id,),
+        ).fetchone()[0]
+        files, text_files, skipped_files = self.connection.execute(
+            """SELECT COUNT(DISTINCT f.id),
+                      COUNT(DISTINCT CASE WHEN f.state = 'text' THEN f.id END),
+                      COUNT(DISTINCT CASE WHEN f.state <> 'text' THEN f.id END)
+               FROM namespace_roots AS nr
+               JOIN root_files AS rf ON rf.root_id = nr.root_id
+               JOIN files AS f ON f.id = rf.file_id
+               WHERE nr.namespace_id = ?""",
+            (namespace_id,),
+        ).fetchone()
+        return ContextCacheInfo(
+            path=self.path.absolute().as_posix(),
+            schema_version=int(schema_version),
+            namespace=DEFAULT_NAMESPACE,
+            database_bytes=database_bytes,
+            wal_bytes=wal_bytes,
+            shm_bytes=shm_bytes,
+            roots=int(roots),
+            files=int(files),
+            text_files=int(text_files),
+            skipped_files=int(skipped_files),
+            last_access_ns=int(last_access_ns),
+        )
+
+    def clear_default_namespace(self) -> ContextCacheClearReport:
+        """Clear default associations and rows made orphaned by that clear."""
+        connection = self.connection
+        before_bytes = 0
+        committed = False
+        primary_error = None
+        secondary_errors = []
+        associations_removed = 0
+        roots_removed = 0
+        files_removed = 0
+        try:
+            connection.execute("PRAGMA locking_mode = EXCLUSIVE")
+            connection.execute("BEGIN EXCLUSIVE")
+            before_bytes = self.aggregate_size_bytes()
+            namespace = connection.execute(
+                "SELECT id FROM namespaces WHERE name = ?",
+                (DEFAULT_NAMESPACE,),
+            ).fetchone()
+            if namespace is not None:
+                namespace_id = namespace[0]
+                associations_removed = connection.execute(
+                    "SELECT COUNT(*) FROM namespace_roots WHERE namespace_id = ?",
+                    (namespace_id,),
+                ).fetchone()[0]
+                connection.execute(
+                    "DELETE FROM namespace_roots WHERE namespace_id = ?",
+                    (namespace_id,),
+                )
+            roots_removed = connection.execute(
+                """DELETE FROM roots
+                   WHERE NOT EXISTS (
+                       SELECT 1 FROM namespace_roots
+                       WHERE namespace_roots.root_id = roots.id
+                   )"""
+            ).rowcount
+            files_removed = connection.execute(
+                """DELETE FROM files
+                   WHERE NOT EXISTS (
+                       SELECT 1 FROM root_files
+                       WHERE root_files.file_id = files.id
+                   )"""
+            ).rowcount
+            connection.commit()
+            committed = True
+            self._maintain_after_clear()
+        except BaseException as error:
+            primary_error = error
+            if connection.in_transaction:
+                try:
+                    connection.rollback()
+                except BaseException as rollback_error:
+                    secondary_errors.append(rollback_error)
+            raise
+        finally:
+            try:
+                self._restore_normal_locking()
+            except BaseException as error:
+                if not committed:
+                    secondary_errors.append(error)
+            if secondary_errors:
+                cleanup_error = secondary_errors[0]
+                if len(secondary_errors) > 1:
+                    cleanup_error = BaseExceptionGroup(
+                        "context cache clear cleanup failed",
+                        secondary_errors,
+                    )
+                if primary_error is not None:
+                    raise primary_error from cleanup_error
+                raise cleanup_error
+        return ContextCacheClearReport(
+            associations_removed=int(associations_removed),
+            roots_removed=int(roots_removed),
+            files_removed=int(files_removed),
+            before_bytes=before_bytes,
+            after_bytes=self.aggregate_size_bytes(),
+        )
+
+    def _maintain_after_clear(self) -> None:
+        """Best-effort physical reclaim after the logical clear committed."""
+        try:
+            checkpoint = self._checkpoint_wal()
+            if checkpoint[0] == 0 and self._freelist_pages():
+                self._run_bounded_vacuum()
+                self._checkpoint_wal()
+        except sqlite3.OperationalError as error:
+            message = str(error).casefold()
+            code = getattr(error, "sqlite_errorcode", None)
+            locked_codes = {
+                value for value in (
+                    getattr(sqlite3, "SQLITE_BUSY", None),
+                    getattr(sqlite3, "SQLITE_LOCKED", None),
+                ) if value is not None
+            }
+            if ((code is None or code & 0xFF not in locked_codes)
+                    and "locked" not in message
+                    and "busy" not in message):
+                raise
 
     def begin_scan(self, namespace: str, canonical_root: str) -> ScanToken:
         """Return an immutable in-memory scan token without writing SQLite."""
@@ -622,13 +1474,16 @@ class ContextCacheDatabase:
 
     def aggregate_size_bytes(self) -> int:
         """Return the current byte size of the database and WAL sidecars."""
-        total = 0
+        return sum(self._storage_sizes())
+
+    def _storage_sizes(self) -> tuple[int, int, int]:
+        sizes = []
         for path in (self.path, *self._sidecar_paths()):
             try:
-                total += path.stat(follow_symlinks=False).st_size
+                sizes.append(path.stat(follow_symlinks=False).st_size)
             except FileNotFoundError:
-                continue
-        return total
+                sizes.append(0)
+        return tuple(sizes)
 
     def _projected_aggregate_size(self) -> int:
         """Return a conservative aggregate size for a possible write."""
@@ -1056,6 +1911,11 @@ class ContextCacheDatabase:
                 COMMIT;
             """
         )
+        checkpoint = self._checkpoint_wal()
+        if checkpoint[0] != 0:
+            raise CacheDatabaseUnavailable(
+                "context cache identity could not be published"
+            )
 
     def _close_connection(self) -> None:
         if self._connection is not None:
@@ -1065,6 +1925,222 @@ class ContextCacheDatabase:
 
 def _uses_posix_permissions() -> bool:
     return os.name != "nt"
+
+
+def _acquire_descriptor_lock(descriptor: int, exclusive: bool):
+    deadline = time.monotonic() + BUSY_TIMEOUT_MS / 1000
+    while True:
+        try:
+            if os.name == "nt":
+                return _acquire_windows_descriptor_lock(
+                    descriptor, exclusive
+                )
+            import fcntl
+            operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+            fcntl.flock(descriptor, operation | fcntl.LOCK_NB)
+            return None
+        except (BlockingIOError, PermissionError):
+            if time.monotonic() >= deadline:
+                raise CacheDatabaseUnavailable(
+                    "context cache database is locked"
+                ) from None
+            time.sleep(0.01)
+
+
+def _release_descriptor_lock(descriptor: int, platform_state) -> None:
+    if os.name == "nt":
+        _release_windows_descriptor_lock(descriptor, platform_state)
+        return
+    import fcntl
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def _acquire_windows_descriptor_lock(descriptor: int, exclusive: bool):
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    unsigned_pointer = (
+        ctypes.c_ulonglong
+        if ctypes.sizeof(ctypes.c_void_p) == 8
+        else ctypes.c_ulong
+    )
+
+    class Overlapped(ctypes.Structure):
+        _fields_ = [
+            ("Internal", unsigned_pointer),
+            ("InternalHigh", unsigned_pointer),
+            ("Offset", wintypes.DWORD),
+            ("OffsetHigh", wintypes.DWORD),
+            ("hEvent", wintypes.HANDLE),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    operation = kernel32.LockFileEx
+    operation.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(Overlapped),
+    ]
+    operation.restype = wintypes.BOOL
+    flags = 0x00000001 | (0x00000002 if exclusive else 0)
+    overlapped = Overlapped()
+    handle = msvcrt.get_osfhandle(descriptor)
+    if not operation(handle, flags, 0, 1, 0, ctypes.byref(overlapped)):
+        error = ctypes.get_last_error()
+        if error in (32, 33):
+            raise BlockingIOError(error, "context cache database is locked")
+        raise ctypes.WinError(error)
+    return overlapped
+
+
+def _release_windows_descriptor_lock(descriptor: int, overlapped) -> None:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    operation = kernel32.UnlockFileEx
+    operation.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(type(overlapped)),
+    ]
+    operation.restype = wintypes.BOOL
+    handle = msvcrt.get_osfhandle(descriptor)
+    if not operation(handle, 0, 1, 0, ctypes.byref(overlapped)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _database_header_identity(header: bytes) -> tuple[int, int]:
+    if (len(header) < _SQLITE_IDENTITY_BYTES
+            or header[:len(_SQLITE_HEADER)] != _SQLITE_HEADER):
+        raise CacheDatabaseUnavailable(
+            "context cache database identity is not recognized"
+        )
+    schema_version = int.from_bytes(
+        header[_SQLITE_USER_VERSION_OFFSET:_SQLITE_USER_VERSION_OFFSET + 4],
+        "big",
+    )
+    application_id = int.from_bytes(
+        header[
+            _SQLITE_APPLICATION_ID_OFFSET:_SQLITE_APPLICATION_ID_OFFSET + 4
+        ],
+        "big",
+    )
+    return application_id, schema_version
+
+
+def _stable_file_identity(path: Path) -> tuple[int, int, int, int, int]:
+    result = path.stat(follow_symlinks=False)
+    return (
+        result.st_dev,
+        result.st_ino,
+        result.st_size,
+        result.st_mtime_ns,
+        result.st_ctime_ns,
+    )
+
+
+def _last_committed_wal_page_one(descriptor: int) -> bytes | None:
+    page_size, checksum_byte_order, checksum, salts = _read_wal_header(
+        descriptor
+    )
+    latest_page_one = None
+    committed_page_one = None
+    while True:
+        frame = _read_valid_wal_frame(
+            descriptor,
+            page_size,
+            salts,
+            checksum_byte_order,
+            checksum,
+        )
+        if frame is None:
+            break
+        page_number, database_pages, page, checksum = frame
+        if page_number == 1:
+            latest_page_one = page
+        if database_pages:
+            committed_page_one = latest_page_one
+    return committed_page_one
+
+
+def _read_wal_header(
+    descriptor: int,
+) -> tuple[int, str, tuple[int, int], bytes]:
+    header = _read_exact(descriptor, _WAL_HEADER_BYTES)
+    if len(header) != _WAL_HEADER_BYTES:
+        raise CacheDatabaseUnavailable("context cache WAL header is incomplete")
+    magic, version, page_size = struct.unpack(">III", header[:12])
+    checksum_byte_order = _WAL_CHECKSUM_BYTE_ORDERS.get(magic)
+    if checksum_byte_order is None or version != _WAL_FORMAT_VERSION:
+        raise CacheDatabaseUnavailable("context cache WAL header is incompatible")
+    if page_size == 1:
+        page_size = 65_536
+    if (page_size < 512 or page_size > 65_536
+            or page_size & (page_size - 1)):
+        raise CacheDatabaseUnavailable("context cache WAL page size is invalid")
+    checksum = _wal_checksum(header[:24], checksum_byte_order)
+    if checksum != struct.unpack(">II", header[24:32]):
+        raise CacheDatabaseUnavailable("context cache WAL header checksum failed")
+    return page_size, checksum_byte_order, checksum, header[16:24]
+
+
+def _read_valid_wal_frame(
+    descriptor: int,
+    page_size: int,
+    salts: bytes,
+    checksum_byte_order: str,
+    checksum: tuple[int, int],
+) -> tuple[int, int, bytes, tuple[int, int]] | None:
+    frame_header = _read_exact(descriptor, _WAL_FRAME_HEADER_BYTES)
+    if not frame_header:
+        return None
+    page = _read_exact(descriptor, page_size)
+    if len(frame_header) != _WAL_FRAME_HEADER_BYTES or len(page) != page_size:
+        return None
+    if frame_header[8:16] != salts:
+        return None
+    next_checksum = _wal_checksum(
+        frame_header[:8] + page,
+        checksum_byte_order,
+        checksum,
+    )
+    if next_checksum != struct.unpack(">II", frame_header[16:24]):
+        return None
+    page_number, database_pages = struct.unpack(">II", frame_header[:8])
+    return page_number, database_pages, page, next_checksum
+
+
+def _read_exact(descriptor: int, size: int) -> bytes:
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _wal_checksum(
+    data: bytes,
+    byte_order: str,
+    initial: tuple[int, int] = (0, 0),
+) -> tuple[int, int]:
+    values = struct.unpack(f"{byte_order}{len(data) // 4}I", data)
+    first, second = initial
+    for offset in range(0, len(values), 2):
+        first = (first + values[offset] + second) & 0xFFFFFFFF
+        second = (second + values[offset + 1] + first) & 0xFFFFFFFF
+    return first, second
 
 
 def _next_scan_started_ns() -> int:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -493,11 +493,12 @@ class ContextCacheDatabase:
         roots_removed = 0
         files_removed = self._collect_orphan_files()
         vacuum_available = True
-        self._checkpoint_wal()
-        if self._freelist_pages() and self.aggregate_size_bytes() > max_bytes:
+        checkpoint_busy = self._checkpoint_wal()[0] != 0
+        if (not checkpoint_busy and self._freelist_pages()
+                and self.aggregate_size_bytes() > max_bytes):
             self._run_bounded_vacuum()
             vacuum_available = False
-            self._checkpoint_wal()
+            checkpoint_busy = self._checkpoint_wal()[0] != 0
 
         candidates = self.connection.execute(
             """SELECT id FROM roots
@@ -506,7 +507,7 @@ class ContextCacheDatabase:
             (protected_root,),
         ).fetchall()
         for (root_id,) in candidates:
-            if self.aggregate_size_bytes() <= max_bytes:
+            if checkpoint_busy or self.aggregate_size_bytes() <= max_bytes:
                 break
             connection = self.connection
             try:
@@ -532,11 +533,12 @@ class ContextCacheDatabase:
             associations_removed += association_count
             roots_removed += root_count
             files_removed += file_count
-            self._checkpoint_wal()
-            if vacuum_available and self.aggregate_size_bytes() > max_bytes:
+            checkpoint_busy = self._checkpoint_wal()[0] != 0
+            if (not checkpoint_busy and vacuum_available and self._freelist_pages()
+                    and self.aggregate_size_bytes() > max_bytes):
                 self._run_bounded_vacuum()
                 vacuum_available = False
-                self._checkpoint_wal()
+                checkpoint_busy = self._checkpoint_wal()[0] != 0
 
         self._checkpoint_wal()
         return CacheMaintenanceReport(
@@ -564,8 +566,12 @@ class ContextCacheDatabase:
             raise
         return removed
 
-    def _checkpoint_wal(self) -> None:
-        self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    def _checkpoint_wal(self) -> tuple[int, int, int]:
+        """Return SQLite's busy, log-frame, and checkpointed-frame counts."""
+        result = self.connection.execute(
+            "PRAGMA wal_checkpoint(TRUNCATE)"
+        ).fetchone()
+        return int(result[0]), int(result[1]), int(result[2])
 
     def _run_bounded_vacuum(self) -> None:
         """Reclaim at most the per-call maintenance budget."""

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -280,9 +280,14 @@ class ContextCacheDatabase:
         return scan_token
 
     def commit_scan(
-        self, scan_token: str, files: Iterable[CachedFile]
-    ) -> None:
-        """Atomically publish one completed root scan."""
+        self,
+        scan_token: str,
+        files: Iterable[CachedFile],
+        max_bytes: int | None = None,
+    ) -> tuple[CachedFile, ...]:
+        """Atomically publish the deterministic prefix admitted by quota."""
+        if max_bytes is not None and max_bytes < 0:
+            raise ValueError("max_bytes must not be negative")
         try:
             namespace, canonical_root, generation = self._scans[scan_token]
         except KeyError as error:
@@ -291,6 +296,12 @@ class ContextCacheDatabase:
         cached_files = tuple(files)
         connection = self.connection
         timestamp = time.time_ns()
+        admitted = []
+        admission_open = (
+            max_bytes is None or self._checkpoint_wal()[0] == 0
+        )
+        if max_bytes is not None:
+            connection.execute("PRAGMA cache_spill = OFF")
         try:
             connection.execute("BEGIN IMMEDIATE")
             current_root = connection.execute(
@@ -326,6 +337,10 @@ class ContextCacheDatabase:
             )
 
             for cached_file in cached_files:
+                if not admission_open:
+                    break
+                if max_bytes is not None:
+                    connection.execute("SAVEPOINT cache_admission")
                 signature = cached_file.signature
                 connection.execute(
                     """INSERT INTO files (
@@ -372,6 +387,14 @@ class ContextCacheDatabase:
                            last_seen_scan = excluded.last_seen_scan""",
                     (root_id, file_id, cached_file.relative_path, scan_token),
                 )
+                if (max_bytes is not None
+                        and self._projected_aggregate_size() > max_bytes):
+                    connection.execute("ROLLBACK TO cache_admission")
+                    connection.execute("RELEASE cache_admission")
+                    break
+                if max_bytes is not None:
+                    connection.execute("RELEASE cache_admission")
+                admitted.append(cached_file)
 
             connection.execute(
                 """DELETE FROM root_files
@@ -379,6 +402,8 @@ class ContextCacheDatabase:
                 (root_id, scan_token),
             )
             connection.commit()
+            if max_bytes is not None:
+                self._checkpoint_wal()
         except BaseException:
             if connection.in_transaction:
                 connection.rollback()
@@ -386,6 +411,10 @@ class ContextCacheDatabase:
         else:
             del self._scans[scan_token]
             self._active_scans.pop((namespace, canonical_root), None)
+        finally:
+            if max_bytes is not None:
+                connection.execute("PRAGMA cache_spill = ON")
+        return tuple(admitted)
 
     def iter_root_files(
         self, namespace: str, canonical_root: str
@@ -502,11 +531,6 @@ class ContextCacheDatabase:
             return None
         if row[7] == "file_too_large" and signature.size_bytes <= max_file_bytes:
             return None
-        self.connection.execute(
-            "UPDATE files SET last_access_ns = ? WHERE id = ?",
-            (time.time_ns(), row[10]),
-        )
-        self.connection.commit()
         return _cached_file_from_row(tuple(row[:10]))
 
     def aggregate_size_bytes(self) -> int:
@@ -518,6 +542,43 @@ class ContextCacheDatabase:
             except FileNotFoundError:
                 continue
         return total
+
+    def _projected_aggregate_size(self) -> int:
+        """Return a conservative post-checkpoint size for the current write."""
+        page_size = self.connection.execute("PRAGMA page_size").fetchone()[0]
+        page_count = self.connection.execute("PRAGMA page_count").fetchone()[0]
+        try:
+            current_database = self.path.stat(follow_symlinks=False).st_size
+        except FileNotFoundError:
+            current_database = 0
+        projected_database = max(current_database, page_size * page_count)
+        write_ahead_log, shared_memory = self._sidecar_paths()
+        try:
+            write_ahead_log_bytes = write_ahead_log.stat(
+                follow_symlinks=False
+            ).st_size
+        except FileNotFoundError:
+            write_ahead_log_bytes = 0
+        try:
+            shared_memory_bytes = shared_memory.stat(
+                follow_symlinks=False
+            ).st_size
+        except FileNotFoundError:
+            shared_memory_bytes = 32 * 1024
+        projected_wal = 32 + page_count * (page_size + 24)
+        existing_frames = max(
+            0,
+            (write_ahead_log_bytes - 32) // (page_size + 24),
+        )
+        total_frames = existing_frames + page_count
+        wal_index_blocks = max(1, (total_frames + 4_095) // 4_096)
+        projected_shared_memory = 32 * 1024 * (1 + wal_index_blocks)
+        return (
+            projected_database
+            + write_ahead_log_bytes
+            + projected_wal
+            + max(shared_memory_bytes, projected_shared_memory)
+        )
 
     def enforce_quota(
         self,

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -492,6 +492,12 @@ class ContextCacheDatabase:
         associations_removed = 0
         roots_removed = 0
         files_removed = self._collect_orphan_files()
+        vacuum_available = True
+        self._checkpoint_wal()
+        if self._freelist_pages() and self.aggregate_size_bytes() > max_bytes:
+            self._run_bounded_vacuum()
+            vacuum_available = False
+            self._checkpoint_wal()
 
         candidates = self.connection.execute(
             """SELECT id FROM roots
@@ -526,8 +532,13 @@ class ContextCacheDatabase:
             associations_removed += association_count
             roots_removed += root_count
             files_removed += file_count
+            self._checkpoint_wal()
+            if vacuum_available and self.aggregate_size_bytes() > max_bytes:
+                self._run_bounded_vacuum()
+                vacuum_available = False
+                self._checkpoint_wal()
 
-        self._run_bounded_maintenance()
+        self._checkpoint_wal()
         return CacheMaintenanceReport(
             associations_removed=associations_removed,
             roots_removed=roots_removed,
@@ -553,10 +564,15 @@ class ContextCacheDatabase:
             raise
         return removed
 
-    def _run_bounded_maintenance(self) -> None:
-        """Checkpoint WAL and reclaim at most a bounded number of pages."""
+    def _checkpoint_wal(self) -> None:
         self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+
+    def _run_bounded_vacuum(self) -> None:
+        """Reclaim at most the per-call maintenance budget."""
         self.connection.execute("PRAGMA incremental_vacuum(128)")
+
+    def _freelist_pages(self) -> int:
+        return self.connection.execute("PRAGMA freelist_count").fetchone()[0]
 
     @staticmethod
     def _identity(path: Path) -> tuple[int, int]:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -470,6 +470,45 @@ class ContextCacheDatabase:
         normalized = tuple(row[:10])
         return _cached_file_from_row(normalized)
 
+    def get_cached_content(
+        self,
+        canonical_path: str,
+        signature: FileSignature,
+        max_file_bytes: int,
+    ) -> CachedFile | None:
+        """Return reusable content without requiring one root association."""
+        row = self.connection.execute(
+            """SELECT canonical_path, '', device, inode, size_bytes,
+                      mtime_ns, ctime_ns, state, folded_text, content_sha256, id
+               FROM files
+               WHERE canonical_path = ?
+                 AND device IS ?
+                 AND inode IS ?
+                 AND size_bytes = ?
+                 AND mtime_ns = ?
+                 AND ctime_ns = ?""",
+            (
+                canonical_path,
+                signature.device,
+                signature.inode,
+                signature.size_bytes,
+                signature.mtime_ns,
+                signature.ctime_ns,
+            ),
+        ).fetchone()
+        if row is None:
+            return None
+        if signature.size_bytes > max_file_bytes and row[7] != "file_too_large":
+            return None
+        if row[7] == "file_too_large" and signature.size_bytes <= max_file_bytes:
+            return None
+        self.connection.execute(
+            "UPDATE files SET last_access_ns = ? WHERE id = ?",
+            (time.time_ns(), row[10]),
+        )
+        self.connection.commit()
+        return _cached_file_from_row(tuple(row[:10]))
+
     def aggregate_size_bytes(self) -> int:
         """Return the current byte size of the database and WAL sidecars."""
         total = 0
@@ -482,12 +521,16 @@ class ContextCacheDatabase:
 
     def enforce_quota(
         self,
-        protected_root: str,
+        protected_root: Union[str, os.PathLike, Iterable[str]],
         max_bytes: int = DEFAULT_MAX_BYTES,
     ) -> CacheMaintenanceReport:
-        """Evict unprotected roots in LRU order until quota or candidates end."""
+        """Evict roots not in the protected set until quota or candidates end."""
         if max_bytes < 0:
             raise ValueError("max_bytes must not be negative")
+        if isinstance(protected_root, (str, os.PathLike)):
+            protected_roots = (os.fspath(protected_root),)
+        else:
+            protected_roots = tuple(protected_root)
         before_bytes = self.aggregate_size_bytes()
         associations_removed = 0
         roots_removed = 0
@@ -500,11 +543,16 @@ class ContextCacheDatabase:
             vacuum_available = False
             checkpoint_busy = self._checkpoint_wal()[0] != 0
 
+        placeholders = ", ".join("?" for _ in protected_roots)
+        where_clause = (
+            f"WHERE canonical_path NOT IN ({placeholders})"
+            if protected_roots else ""
+        )
         candidates = self.connection.execute(
-            """SELECT id FROM roots
-               WHERE canonical_path <> ?
-               ORDER BY last_access_ns, id""",
-            (protected_root,),
+            f"""SELECT id FROM roots
+                {where_clause}
+                ORDER BY last_access_ns, id""",
+            protected_roots,
         ).fetchall()
         for (root_id,) in candidates:
             if checkpoint_busy or self.aggregate_size_bytes() <= max_bytes:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -5,7 +5,6 @@ import re
 import shutil
 import sqlite3
 import stat
-import struct
 import sys
 import tempfile
 import threading
@@ -25,17 +24,12 @@ DEFAULT_MAX_BYTES = 256 * 1024 * 1024
 BUSY_TIMEOUT_MS = 500
 
 _SQLITE_HEADER = b"SQLite format 3\x00"
+_SQLITE_PAGE_SIZE_OFFSET = 16
+_SQLITE_WRITE_VERSION_OFFSET = 18
+_SQLITE_READ_VERSION_OFFSET = 19
 _SQLITE_USER_VERSION_OFFSET = 60
 _SQLITE_APPLICATION_ID_OFFSET = 68
 _SQLITE_IDENTITY_BYTES = 72
-_WAL_HEADER_BYTES = 32
-_WAL_FRAME_HEADER_BYTES = 24
-_WAL_FORMAT_VERSION = 3_007_000
-_WAL_CHECKSUM_BYTE_ORDERS = {
-    0x377F0682: "<",
-    0x377F0683: ">",
-}
-
 _PreparedPath = tuple[
     bool, tuple[int, int], tuple[int, int], dict[Path, tuple[int, int]]
 ]
@@ -168,14 +162,6 @@ class CacheDatabaseUnavailable(CacheDatabaseError):
     """Raised when the cache database cannot be opened."""
 
 
-class _RecognizedCacheCorruption(CacheDatabaseUnavailable):
-    """Signal corruption only after the main file proves cache ownership."""
-
-
-class _ReplacementPublicationError(CacheDatabaseUnavailable):
-    """Keep recovery inputs when a no-clobber publication cannot complete."""
-
-
 class _CachePathLock:
     """Shared/exclusive advisory lock coordinated by every cache opener."""
 
@@ -185,7 +171,13 @@ class _CachePathLock:
         self._platform_state = None
         self.exclusive = False
 
-    def acquire(self, exclusive: bool, *, create: bool = True) -> None:
+    def acquire(
+        self,
+        exclusive: bool,
+        *,
+        create: bool = True,
+        wait: bool = True,
+    ) -> None:
         if self._descriptor is not None:
             raise CacheDatabaseError("context cache lock is already held")
         if ContextCacheDatabase._is_link(self.path):
@@ -210,7 +202,7 @@ class _CachePathLock:
                     != (result.st_dev, result.st_ino)):
                 raise CacheDatabaseError("context cache lock identity changed")
             self._platform_state = _acquire_descriptor_lock(
-                descriptor, exclusive
+                descriptor, exclusive, wait=wait
             )
         except BaseException:
             os.close(descriptor)
@@ -327,102 +319,82 @@ class ContextCacheDatabase:
         return self._connection
 
     def __enter__(self) -> "ContextCacheDatabase":
+        bootstrap: _PreparedPath | None = None
         try:
-            prepared = self._prepare_path()
-            database_is_empty, directory_identity, file_identity, sidecars = prepared
-            recovery_required = False
-            schema_version = SCHEMA_VERSION
-            if not database_is_empty:
-                try:
-                    schema_version = self._read_header_identity(
-                        file_identity, sidecars
+            self._prepare_directory()
+            if not self._database_exists():
+                self._reject_orphan_sidecars()
+                self._acquire_cache_lock(True)
+                prepared = self._prepare_path(create=True)
+                if prepared[0]:
+                    bootstrap = prepared
+                self._open_locked(prepared)
+            else:
+                prepared = self._prepare_path()
+                self._read_main_header_identity(prepared[2])
+                self._acquire_existing_cache_lock()
+                locked_prepared = self._prepare_path()
+                if locked_prepared[1:4] != prepared[1:4]:
+                    raise CacheDatabaseError(
+                        "context cache storage identity changed"
                     )
-                except _RecognizedCacheCorruption:
-                    recovery_required = True
-            self._acquire_cache_lock(
-                database_is_empty or recovery_required or schema_version == 0
-            )
-            locked_prepared = self._prepare_path()
-            if locked_prepared[1] != directory_identity:
-                raise CacheDatabaseError(
-                    "context cache directory identity changed"
-                )
-            if locked_prepared[2] != file_identity:
-                raise CacheDatabaseError(
-                    "context cache database identity changed"
-                )
-            self._open_locked(locked_prepared)
+                self._open_locked(locked_prepared)
         except CacheDatabaseError:
             self._close_connection()
+            if bootstrap is not None:
+                self._cleanup_failed_bootstrap(bootstrap)
             self._release_cache_lock()
             raise
         except (OSError, sqlite3.Error) as error:
             self._close_connection()
+            if bootstrap is not None:
+                self._cleanup_failed_bootstrap(bootstrap)
             self._release_cache_lock()
-            raise CacheDatabaseUnavailable("context cache database is unavailable") from error
+            raise CacheDatabaseUnavailable(
+                "context cache database is unavailable"
+            ) from error
         return self
 
-    def _open_locked(self, prepared: _PreparedPath) -> None:
-        database_is_empty, _, file_identity, sidecars = prepared
+    def _open_locked(
+        self,
+        prepared: _PreparedPath,
+    ) -> None:
+        database_is_empty, directory_identity, file_identity, sidecars = prepared
         if database_is_empty:
             self._require_exclusive_lock()
             self._open_prepared(prepared)
             self._cache_lock.change(False)
             return
 
-        try:
-            schema_version = self._read_header_identity(
-                file_identity, sidecars
+        schema_version = self._read_header_identity(
+            file_identity,
+            sidecars,
+        )
+        if schema_version != SCHEMA_VERSION:
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unsupported schema version"
             )
-        except _RecognizedCacheCorruption:
+        legacy_schema = self._preflight_existing_database(
+            prepared,
+        )
+        if legacy_schema:
             self._require_exclusive_lock()
-            prepared = self._prepare_path()
-            try:
-                self._read_header_identity(prepared[2], prepared[3])
-            except _RecognizedCacheCorruption:
-                self._recover_database(prepared)
-                self._cache_lock.change(False)
-                return
-            return self._open_locked(prepared)
-        if schema_version == 0:
-            self._require_exclusive_lock()
-            prepared = self._prepare_path()
-            schema_version = self._read_header_identity(
-                prepared[2], prepared[3]
-            )
-            if schema_version == 0:
-                self._recover_database(prepared)
-                self._cache_lock.change(False)
-                return
-            return self._open_locked(prepared)
-
-        try:
-            self._open_prepared(prepared)
-        except sqlite3.DatabaseError as error:
-            self._close_connection()
-            if not self._is_corruption_error(error):
-                raise
-            self._require_exclusive_lock()
-            prepared = self._prepare_path()
-            try:
-                schema_version = self._read_header_identity(
-                    prepared[2], prepared[3]
+            locked_prepared = self._prepare_path()
+            if locked_prepared[1:4] != prepared[1:4]:
+                raise CacheDatabaseError(
+                    "context cache storage identity changed"
                 )
-            except _RecognizedCacheCorruption:
-                self._recover_database(prepared)
-                self._cache_lock.change(False)
-                return
-            if schema_version == 0:
-                self._recover_database(prepared)
-                self._cache_lock.change(False)
-                return
-            try:
-                self._open_prepared(prepared)
-            except sqlite3.DatabaseError as retry_error:
-                self._close_connection()
-                if not self._is_corruption_error(retry_error):
-                    raise
-                self._recover_database(prepared)
+            schema_version = self._read_header_identity(
+                locked_prepared[2],
+                locked_prepared[3],
+            )
+            if schema_version != SCHEMA_VERSION:
+                raise CacheDatabaseUnavailable(
+                    "context cache database has an unsupported schema version"
+                )
+            self._preflight_existing_database(locked_prepared)
+            prepared = locked_prepared
+        self._open_prepared(prepared)
         if self._cache_lock.exclusive:
             self._cache_lock.change(False)
 
@@ -430,6 +402,33 @@ class ContextCacheDatabase:
         lock = _CachePathLock(self.path)
         lock.acquire(exclusive)
         self._cache_lock = lock
+
+    def _acquire_existing_cache_lock(self) -> None:
+        """Lock existing storage, preferring exclusive access when available."""
+        lock = _CachePathLock(self.path)
+        try:
+            lock.acquire(True, wait=False)
+        except BlockingIOError:
+            lock.acquire(False)
+        self._cache_lock = lock
+
+    def _cleanup_failed_bootstrap(self, prepared: _PreparedPath) -> None:
+        """Remove only storage identities created by this failed bootstrap."""
+        if self._cache_lock is None or not self._cache_lock.exclusive:
+            return
+        _, directory_identity, file_identity, sidecars = prepared
+        try:
+            if self._identity(self.path.parent) != directory_identity:
+                return
+            for sidecar, identity in sidecars.items():
+                if (sidecar.exists() and not self._is_link(sidecar)
+                        and self._identity(sidecar) == identity):
+                    sidecar.unlink()
+            if (self.path.exists() and not self._is_link(self.path)
+                    and self._identity(self.path) == file_identity):
+                self.path.unlink()
+        except OSError:
+            return
 
     def _require_exclusive_lock(self) -> None:
         if self._cache_lock is None:
@@ -446,14 +445,62 @@ class ContextCacheDatabase:
         prepared: _PreparedPath,
     ) -> None:
         database_is_empty, directory_identity, file_identity, sidecars = prepared
-        self._connection = sqlite3.connect(
-            str(self.path), timeout=BUSY_TIMEOUT_MS / 1000
-        )
+        journal_reservation = None
+        try:
+            if not database_is_empty:
+                journal_reservation = self._reserve_rollback_journal()
+                self._validate_sidecars()
+            self._connection = sqlite3.connect(
+                str(self.path), timeout=BUSY_TIMEOUT_MS / 1000
+            )
+        finally:
+            if journal_reservation is not None:
+                self._release_rollback_journal_reservation(
+                    journal_reservation,
+                    directory_identity,
+                    file_identity,
+                )
         self._validate_identity(directory_identity, file_identity)
         self._configure_connection(database_is_empty)
         self._secure_new_sidecars(sidecars)
         self._verify_or_create_schema()
         self._secure_new_sidecars(sidecars)
+
+    def _reserve_rollback_journal(self) -> tuple[int, tuple[int, int]]:
+        journal = Path(f"{self.path}-journal")
+        flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+        flags |= getattr(os, "O_BINARY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(journal, flags, 0o400)
+        try:
+            result = os.fstat(descriptor)
+            identity = (result.st_dev, result.st_ino)
+            if _uses_posix_permissions() and hasattr(os, "fchmod"):
+                os.fchmod(descriptor, 0o400)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor, identity
+
+    def _release_rollback_journal_reservation(
+        self,
+        reservation: tuple[int, tuple[int, int]],
+        directory_identity: tuple[int, int],
+        file_identity: tuple[int, int],
+    ) -> None:
+        descriptor, identity = reservation
+        os.close(descriptor)
+        journal = Path(f"{self.path}-journal")
+        self._validate_identity(directory_identity, file_identity)
+        if (self._is_link(journal) or not journal.is_file()
+                or self._identity(journal) != identity
+                or journal.stat(follow_symlinks=False).st_size != 0):
+            raise CacheDatabaseUnavailable(
+                "context cache rollback journal changed during open"
+            )
+        if _uses_posix_permissions() or os.name == "nt":
+            journal.chmod(0o600)
+        journal.unlink()
 
     def _read_header_identity(
         self,
@@ -461,6 +508,21 @@ class ContextCacheDatabase:
         sidecars: dict[Path, tuple[int, int]],
     ) -> int:
         """Return a recognized schema version without opening SQLite."""
+        application_id, schema_version, _ = (
+            self._read_main_header_identity(file_identity)
+        )
+        if sidecars:
+            raise CacheDatabaseUnavailable(
+                "context cache has existing SQLite sidecars"
+            )
+        self._validate_header_values(application_id, schema_version)
+        return schema_version
+
+    def _read_main_header_identity(
+        self,
+        file_identity: tuple[int, int],
+    ) -> tuple[int, int, int]:
+        """Read identity and WAL-mode metadata from the main database header."""
         flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
         flags |= getattr(os, "O_NOFOLLOW", 0)
         descriptor = os.open(self.path, flags)
@@ -481,64 +543,99 @@ class ContextCacheDatabase:
             )
         application_id, schema_version = _database_header_identity(header)
         self._validate_header_values(application_id, schema_version)
-        write_ahead_log, _ = self._sidecar_paths()
-        if (write_ahead_log in sidecars
-                and write_ahead_log.stat(follow_symlinks=False).st_size > 32):
-            try:
-                application_id, schema_version = self._read_wal_identity(
-                    file_identity,
-                    sidecars,
-                    application_id,
-                    schema_version,
-                )
-            except CacheDatabaseUnavailable as error:
-                raise _RecognizedCacheCorruption(
-                    "recognized context cache WAL is corrupt"
-                ) from error
-        self._validate_header_values(application_id, schema_version)
-        return schema_version
+        page_size = _database_page_size(header)
+        if (header[_SQLITE_WRITE_VERSION_OFFSET] != 2
+                or header[_SQLITE_READ_VERSION_OFFSET] != 2):
+            raise CacheDatabaseUnavailable(
+                "context cache database is not in WAL mode"
+            )
+        return application_id, schema_version, page_size
 
-    def _read_wal_identity(
+    def _preflight_existing_database(
         self,
-        file_identity: tuple[int, int],
-        sidecars: dict[Path, tuple[int, int]],
-        application_id: int,
-        schema_version: int,
-    ) -> tuple[int, int]:
-        write_ahead_log, _ = self._sidecar_paths()
-        descriptor = self._open_validated_wal(write_ahead_log, sidecars)
+        prepared: _PreparedPath,
+    ) -> bool:
+        """Validate an existing cache on a private copy before opening it RW."""
+        sources = (self.path,)
+        before = {
+            source: _stable_file_identity(source)
+            for source in sources
+        }
         try:
-            page_one = _last_committed_wal_page_one(descriptor)
-        finally:
-            os.close(descriptor)
-        if self._identity(self.path) != file_identity:
-            raise CacheDatabaseError(
-                "context cache database identity changed"
-            )
-        for sidecar, identity in sidecars.items():
-            if self._identity(sidecar) != identity:
-                raise CacheDatabaseError(
-                    "context cache sidecar identity changed"
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                snapshot_path = Path(temporary_directory) / self.path.name
+                shutil.copyfile(self.path, snapshot_path)
+                if _uses_posix_permissions():
+                    snapshot_path.chmod(0o600)
+                self._validate_preflight_sources(
+                    prepared,
+                    before,
                 )
-        if page_one is not None:
-            application_id, schema_version = _database_header_identity(page_one)
-        return int(application_id), int(schema_version)
 
-    def _open_validated_wal(
+                snapshot = type(self)(snapshot_path)
+                uri = f"{snapshot_path.absolute().as_uri()}?mode=ro"
+                try:
+                    snapshot._connection = sqlite3.connect(
+                        uri,
+                        uri=True,
+                        timeout=BUSY_TIMEOUT_MS / 1000,
+                    )
+                    snapshot.connection.execute("PRAGMA query_only = ON")
+                    snapshot.connection.execute(
+                        f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
+                    )
+                    if tuple(snapshot.connection.execute("PRAGMA integrity_check")) != (
+                        ("ok",),
+                    ):
+                        raise CacheDatabaseUnavailable(
+                            "recognized context cache database is corrupt"
+                        )
+                    if tuple(snapshot.connection.execute(
+                        "PRAGMA foreign_key_check"
+                    )):
+                        raise CacheDatabaseUnavailable(
+                            "recognized context cache database has invalid references"
+                        )
+                    legacy_schema = snapshot._validate_existing_schema()
+                finally:
+                    snapshot._close_connection()
+                self._validate_preflight_sources(
+                    prepared,
+                    before,
+                )
+        except CacheDatabaseError:
+            raise
+        except (OSError, sqlite3.Error) as error:
+            raise CacheDatabaseUnavailable(
+                "context cache database is unavailable"
+            ) from error
+        return legacy_schema
+
+    def _validate_preflight_sources(
         self,
-        write_ahead_log: Path,
-        sidecars: dict[Path, tuple[int, int]],
-    ) -> int:
-        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
-        flags |= getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(write_ahead_log, flags)
-        result = os.fstat(descriptor)
-        if (result.st_dev, result.st_ino) != sidecars[write_ahead_log]:
-            os.close(descriptor)
-            raise CacheDatabaseError(
-                "context cache WAL identity changed"
+        prepared: _PreparedPath,
+        expected: dict[Path, tuple[int, int, int, int, int]],
+    ) -> None:
+        _, directory_identity, file_identity, sidecars = prepared
+        self._validate_identity(directory_identity, file_identity)
+        self._validate_sidecars()
+        if sidecars:
+            raise CacheDatabaseUnavailable(
+                "context cache has existing SQLite sidecars"
             )
-        return descriptor
+        self._reject_existing_rollback_journal()
+        if self._existing_sidecars() != sidecars:
+            raise CacheDatabaseUnavailable(
+                "context cache sidecar set changed while being validated"
+            )
+        actual = {
+            source: _stable_file_identity(source)
+            for source in expected
+        }
+        if actual != expected:
+            raise CacheDatabaseUnavailable(
+                "context cache changed while being validated"
+            )
 
     @staticmethod
     def _validate_header_values(application_id: int, schema_version: int) -> None:
@@ -550,236 +647,10 @@ class ContextCacheDatabase:
             raise CacheDatabaseUnavailable(
                 "context cache database has a newer schema version"
             )
-        if schema_version not in (0, SCHEMA_VERSION):
+        if schema_version != SCHEMA_VERSION:
             raise CacheDatabaseUnavailable(
                 "context cache database has an unsupported schema version"
             )
-
-    @staticmethod
-    def _is_corruption_error(error: sqlite3.DatabaseError) -> bool:
-        message = str(error).casefold()
-        if "malformed database schema" in message:
-            return False
-        code = getattr(error, "sqlite_errorcode", None)
-        if code is not None:
-            primary_code = code & 0xFF
-            corruption_codes = {
-                value for value in (
-                    getattr(sqlite3, "SQLITE_CORRUPT", None),
-                    getattr(sqlite3, "SQLITE_NOTADB", None),
-                    getattr(sqlite3, "SQLITE_FORMAT", None),
-                ) if value is not None
-            }
-            if primary_code in corruption_codes:
-                return True
-        return "malformed" in message or "not a database" in message
-
-    def _recover_database(
-        self,
-        prepared: _PreparedPath,
-    ) -> None:
-        """Replace only a positively identified Cereja database."""
-        if self._cache_lock is None or not self._cache_lock.exclusive:
-            raise CacheDatabaseError(
-                "context cache recovery requires exclusive ownership"
-            )
-        _, directory_identity, file_identity, sidecars = prepared
-        self._close_connection()
-        self._validate_identity(directory_identity, file_identity)
-        self._validate_sidecars()
-        directory = self.path.parent.resolve(strict=True)
-        quarantine_paths = self._quarantine_paths(sidecars, directory)
-        self._move_to_quarantine(
-            quarantine_paths, file_identity, sidecars
-        )
-
-        replacement_path = self.path.with_name(
-            f"{self.path.name}.replacement-{time.time_ns()}-{uuid.uuid4().hex}"
-        )
-        self._validate_recovery_sibling(replacement_path, directory)
-        replacement_database = type(self)(replacement_path)
-        try:
-            replacement = replacement_database._prepare_path()
-            replacement_database._open_prepared(replacement)
-            replacement_database._checkpoint_wal()
-            replacement_database._close_connection()
-            replacement = replacement_database._prepare_path()
-            replacement_database._read_header_identity(
-                replacement[2], replacement[3]
-            )
-            if replacement[3]:
-                raise CacheDatabaseUnavailable(
-                    "context cache replacement has live sidecars"
-                )
-            replacement_identity = replacement[2]
-            self._publish_replacement(
-                replacement_path, replacement_identity
-            )
-            published = self._prepare_path()
-            if published[2] != replacement_identity:
-                raise _ReplacementPublicationError(
-                    "context cache replacement identity changed"
-                )
-            self._read_header_identity(published[2], published[3])
-            self._open_prepared(published)
-        except BaseException as error:
-            self._close_connection()
-            replacement_database._close_connection()
-            if not isinstance(error, _ReplacementPublicationError):
-                self._discard_failed_replacement(replacement_path)
-            if isinstance(error, CacheDatabaseError):
-                raise
-            if isinstance(error, (OSError, sqlite3.Error)):
-                raise CacheDatabaseUnavailable(
-                    "context cache replacement could not be created"
-                ) from error
-            raise
-
-        try:
-            self._discard_quarantine(
-                quarantine_paths, file_identity, sidecars
-            )
-        except BaseException:
-            self._close_connection()
-            raise
-
-    def _quarantine_paths(
-        self,
-        sidecars: dict[Path, tuple[int, int]],
-        directory: Path,
-    ) -> dict[Path, Path]:
-        quarantine = self.path.with_name(
-            f"{self.path.name}.quarantine-{time.time_ns()}-{uuid.uuid4().hex}"
-        )
-        self._validate_recovery_sibling(quarantine, directory)
-        quarantine_paths = {self.path: quarantine}
-        for sidecar in self._sidecar_paths():
-            if sidecar in sidecars:
-                suffix = sidecar.name[len(self.path.name):]
-                candidate = quarantine.with_name(quarantine.name + suffix)
-                self._validate_recovery_sibling(candidate, directory)
-                quarantine_paths[sidecar] = candidate
-        if any(
-            target.exists() or self._is_link(target)
-            for target in quarantine_paths.values()
-        ):
-            raise CacheDatabaseUnavailable(
-                "context cache quarantine path already exists"
-            )
-        return quarantine_paths
-
-    def _move_to_quarantine(
-        self,
-        quarantine_paths: dict[Path, Path],
-        file_identity: tuple[int, int],
-        sidecars: dict[Path, tuple[int, int]],
-    ) -> None:
-        moved = []
-        try:
-            for source, target in quarantine_paths.items():
-                expected_identity = (
-                    file_identity if source == self.path else sidecars[source]
-                )
-                if self._identity(source) != expected_identity:
-                    raise CacheDatabaseError(
-                        "context cache file identity changed during recovery"
-                    )
-                self._validate_secure_file(source)
-                if target.exists() or self._is_link(target):
-                    raise CacheDatabaseUnavailable(
-                        "context cache quarantine path already exists"
-                    )
-                os.rename(source, target)
-                moved.append((source, target, expected_identity))
-        except BaseException as primary_error:
-            rollback_errors = []
-            for source, target, expected_identity in reversed(moved):
-                try:
-                    if source.exists() or self._is_link(source):
-                        raise CacheDatabaseError(
-                            "context cache recovery rollback target exists"
-                        )
-                    if self._identity(target) != expected_identity:
-                        raise CacheDatabaseError(
-                            "context cache quarantine identity changed"
-                        )
-                    os.rename(target, source)
-                except BaseException as rollback_error:
-                    rollback_errors.append(rollback_error)
-            if rollback_errors:
-                raise BaseExceptionGroup(
-                    "context cache quarantine move and rollback failed",
-                    [primary_error, *rollback_errors],
-                )
-            raise
-
-    def _discard_failed_replacement(self, replacement_path: Path) -> None:
-        for candidate in (
-            *(
-                Path(f"{replacement_path}{suffix}")
-                for suffix in ("-wal", "-shm")
-            ),
-            replacement_path,
-        ):
-            if candidate.exists() or self._is_link(candidate):
-                self._validate_secure_file(candidate)
-                candidate.unlink()
-
-    def _publish_replacement(
-        self,
-        replacement_path: Path,
-        replacement_identity: tuple[int, int],
-    ) -> None:
-        """Publish a validated sibling without overwriting a new target."""
-        if self.path.exists() or self._is_link(self.path):
-            raise _ReplacementPublicationError(
-                "context cache path reappeared during recovery"
-            )
-        self._validate_secure_file(replacement_path)
-        if self._identity(replacement_path) != replacement_identity:
-            raise _ReplacementPublicationError(
-                "context cache replacement identity changed"
-            )
-        try:
-            if os.name == "nt":
-                os.rename(replacement_path, self.path)
-                return
-            os.link(
-                replacement_path,
-                self.path,
-                follow_symlinks=False,
-            )
-            if self._identity(self.path) != replacement_identity:
-                raise CacheDatabaseError(
-                    "context cache replacement identity changed"
-                )
-            replacement_path.unlink()
-        except OSError as error:
-            raise _ReplacementPublicationError(
-                "context cache replacement could not be published"
-            ) from error
-
-    def _discard_quarantine(
-        self,
-        quarantine_paths: dict[Path, Path],
-        file_identity: tuple[int, int],
-        sidecars: dict[Path, tuple[int, int]],
-    ) -> None:
-        for source, target in reversed(tuple(quarantine_paths.items())):
-            expected_identity = (
-                file_identity if source == self.path else sidecars[source]
-            )
-            if self._identity(target) != expected_identity:
-                raise CacheDatabaseError(
-                    "context cache quarantine identity changed"
-                )
-            self._validate_secure_file(target)
-            target.unlink()
-
-    @staticmethod
-    def _validate_recovery_sibling(path: Path, directory: Path) -> None:
-        if path.parent.resolve(strict=True) != directory:
-            raise CacheDatabaseError("context cache recovery escaped its directory")
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         self._close_connection()
@@ -802,35 +673,30 @@ class ContextCacheDatabase:
         directory_identity, file_identity, sidecars = (
             database._prepare_read_only_path()
         )
-        database._read_header_identity(file_identity, sidecars)
+        database._read_main_header_identity(file_identity)
         try:
-            database._acquire_existing_cache_lock(True)
+            database._acquire_existing_cache_lock()
             directory_identity, file_identity, sidecars = (
                 database._prepare_read_only_path()
             )
-            database._read_header_identity(file_identity, sidecars)
-            database_bytes, wal_bytes, shm_bytes = database._storage_sizes()
-            if wal_bytes:
-                return database._read_info_snapshot(
-                    directory_identity,
-                    file_identity,
-                    sidecars,
-                    database_bytes,
-                    wal_bytes,
-                    shm_bytes,
+            schema_version = database._read_header_identity(
+                file_identity,
+                sidecars,
+            )
+            if schema_version != SCHEMA_VERSION:
+                raise CacheDatabaseUnavailable(
+                    "context cache database has an unsupported schema version"
                 )
-            query = "mode=ro" if wal_bytes else "mode=ro&immutable=1"
-            uri = f"{database.path.absolute().as_uri()}?{query}"
-            database._connection = sqlite3.connect(
-                uri, uri=True, timeout=BUSY_TIMEOUT_MS / 1000
+            database._preflight_existing_database(
+                (False, directory_identity, file_identity, sidecars),
             )
-            database._validate_identity(directory_identity, file_identity)
-            database.connection.execute("PRAGMA query_only = ON")
-            database.connection.execute(
-                f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
-            )
-            return database._query_info(
-                database_bytes, wal_bytes, shm_bytes
+            database_bytes, wal_bytes, shm_bytes = database._storage_sizes()
+            return database._read_info_snapshot(
+                directory_identity,
+                file_identity,
+                database_bytes,
+                wal_bytes,
+                shm_bytes,
             )
         except CacheDatabaseError:
             raise
@@ -842,23 +708,15 @@ class ContextCacheDatabase:
             database._close_connection()
             database._release_cache_lock()
 
-    def _acquire_existing_cache_lock(self, exclusive: bool) -> None:
-        lock = _CachePathLock(self.path)
-        if not lock.path.exists() and not self._is_link(lock.path):
-            return
-        lock.acquire(exclusive, create=False)
-        self._cache_lock = lock
-
     def _read_info_snapshot(
         self,
         directory_identity: tuple[int, int],
         file_identity: tuple[int, int],
-        sidecars: dict[Path, tuple[int, int]],
         database_bytes: int,
         wal_bytes: int,
         shm_bytes: int,
     ) -> ContextCacheInfo:
-        snapshot_sources = (self.path, Path(f"{self.path}-wal"))
+        snapshot_sources = (self.path,)
         before = {
             source: _stable_file_identity(source)
             for source in snapshot_sources
@@ -866,31 +724,19 @@ class ContextCacheDatabase:
         with tempfile.TemporaryDirectory() as temporary_directory:
             snapshot_path = Path(temporary_directory) / self.path.name
             shutil.copyfile(self.path, snapshot_path)
-            shutil.copyfile(
-                Path(f"{self.path}-wal"),
-                Path(f"{snapshot_path}-wal"),
-            )
             if _uses_posix_permissions():
                 snapshot_path.chmod(0o600)
-                Path(f"{snapshot_path}-wal").chmod(0o600)
             self._validate_identity(directory_identity, file_identity)
-            for source, identity in sidecars.items():
-                if self._identity(source) != identity:
-                    raise CacheDatabaseError(
-                        "context cache sidecar identity changed"
-                    )
+            self._validate_sidecars()
+            if self._existing_sidecars():
+                raise CacheDatabaseUnavailable(
+                    "context cache has existing SQLite sidecars"
+                )
             after = {
                 source: _stable_file_identity(source)
                 for source in snapshot_sources
             }
             if after != before:
-                raise CacheDatabaseUnavailable(
-                    "context cache changed while reading metadata"
-                )
-            lock_path = _CachePathLock(self.path).path
-            if self._cache_lock is None and (
-                lock_path.exists() or self._is_link(lock_path)
-            ):
                 raise CacheDatabaseUnavailable(
                     "context cache changed while reading metadata"
                 )
@@ -906,6 +752,11 @@ class ContextCacheDatabase:
                 )
             finally:
                 snapshot._close_connection()
+            self._validate_sidecars()
+            if self._existing_sidecars():
+                raise CacheDatabaseUnavailable(
+                    "context cache has existing SQLite sidecars"
+                )
         return ContextCacheInfo(
             path=self.path.absolute().as_posix(),
             schema_version=info.schema_version,
@@ -946,6 +797,7 @@ class ContextCacheDatabase:
         file_identity = self._identity(self.path)
         self._validate_secure_file(self.path)
         self._validate_sidecars()
+        self._reject_existing_rollback_journal()
         return directory_identity, file_identity, self._existing_sidecars()
 
     def _query_info(
@@ -1053,7 +905,10 @@ class ContextCacheDatabase:
             ).rowcount
             connection.commit()
             committed = True
-            self._maintain_after_clear()
+            try:
+                self._maintain_after_clear()
+            except Exception:
+                pass
         except BaseException as error:
             primary_error = error
             if connection.in_transaction:
@@ -1065,7 +920,7 @@ class ContextCacheDatabase:
         finally:
             try:
                 self._restore_normal_locking()
-            except BaseException as error:
+            except Exception as error:
                 if not committed:
                     secondary_errors.append(error)
             if secondary_errors:
@@ -1078,12 +933,16 @@ class ContextCacheDatabase:
                 if primary_error is not None:
                     raise primary_error from cleanup_error
                 raise cleanup_error
+        try:
+            after_bytes = self.aggregate_size_bytes()
+        except Exception:
+            after_bytes = before_bytes
         return ContextCacheClearReport(
             associations_removed=int(associations_removed),
             roots_removed=int(roots_removed),
             files_removed=int(files_removed),
             before_bytes=before_bytes,
-            after_bytes=self.aggregate_size_bytes(),
+            after_bytes=after_bytes,
         )
 
     def _maintain_after_clear(self) -> None:
@@ -1686,7 +1545,9 @@ class ContextCacheDatabase:
 
     def _prepare_path(
         self,
-    ) -> tuple[bool, tuple[int, int], tuple[int, int], set[Path]]:
+        *,
+        create: bool = False,
+    ) -> _PreparedPath:
         if self._is_link(self.path):
             raise CacheDatabaseError("context cache database must not be a symlink")
         try:
@@ -1698,6 +1559,13 @@ class ContextCacheDatabase:
                 raise CacheDatabaseError("context cache database must be a regular file")
             database_existed = True
 
+        if not database_existed:
+            self._reject_orphan_sidecars()
+            if not create:
+                raise CacheDatabaseUnavailable(
+                    "context cache database is unavailable"
+                )
+
         directory = self._prepare_directory()
 
         directory_identity = self._identity(directory)
@@ -1706,16 +1574,53 @@ class ContextCacheDatabase:
             flags |= getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(self.path, flags, 0o600)
             try:
+                result = os.fstat(descriptor)
+                file_identity = (result.st_dev, result.st_ino)
                 if _uses_posix_permissions() and hasattr(os, "fchmod"):
                     os.fchmod(descriptor, 0o600)
             finally:
                 os.close(descriptor)
-        file_identity = self._identity(self.path)
+            if self._identity(directory) != directory_identity:
+                raise CacheDatabaseError(
+                    "context cache directory identity changed"
+                )
+            if self._identity(self.path) != file_identity:
+                raise CacheDatabaseError(
+                    "context cache database identity changed"
+                )
+        else:
+            file_identity = self._identity(self.path)
         self._validate_secure_file(self.path)
         self._validate_sidecars()
+        self._reject_existing_rollback_journal()
         sidecars = self._existing_sidecars()
         database_is_empty = self.path.stat(follow_symlinks=False).st_size == 0
-        return database_is_empty, directory_identity, file_identity, sidecars
+        if database_is_empty and sidecars:
+            raise CacheDatabaseUnavailable(
+                "empty context cache has existing SQLite sidecars"
+            )
+        if database_is_empty and database_existed:
+            raise CacheDatabaseUnavailable(
+                "context cache database identity is not recognized"
+            )
+        initialize_database = database_is_empty and not database_existed
+        return initialize_database, directory_identity, file_identity, sidecars
+
+    def _database_exists(self) -> bool:
+        return self.path.exists() or self._is_link(self.path)
+
+    def _reject_orphan_sidecars(self) -> None:
+        orphan_sidecars = (
+            *self._sidecar_paths(),
+            Path(f"{self.path}-journal"),
+        )
+        if any(
+            sidecar.exists() or self._is_link(sidecar)
+            for sidecar in orphan_sidecars
+        ):
+            raise CacheDatabaseUnavailable(
+                "context cache sidecar exists without a database"
+            )
 
     def _validate_identity(
         self, directory_identity: tuple[int, int], file_identity: tuple[int, int]
@@ -1743,9 +1648,20 @@ class ContextCacheDatabase:
         return Path(f"{self.path}-wal"), Path(f"{self.path}-shm")
 
     def _validate_sidecars(self) -> None:
-        for sidecar in self._sidecar_paths():
-            if sidecar.exists() or self._is_link(sidecar):
-                self._validate_secure_file(sidecar)
+        if any(
+            sidecar.exists() or self._is_link(sidecar)
+            for sidecar in self._sidecar_paths()
+        ):
+            raise CacheDatabaseUnavailable(
+                "context cache has existing SQLite sidecars"
+            )
+
+    def _reject_existing_rollback_journal(self) -> None:
+        journal = Path(f"{self.path}-journal")
+        if journal.exists() or self._is_link(journal):
+            raise CacheDatabaseUnavailable(
+                "context cache has an existing rollback journal"
+            )
 
     def _secure_new_sidecars(self, existing: dict[Path, tuple[int, int]]) -> None:
         for sidecar in self._sidecar_paths():
@@ -1766,7 +1682,11 @@ class ContextCacheDatabase:
         if database_is_empty:
             connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
             connection.execute("VACUUM")
-        journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+            journal_mode = connection.execute(
+                "PRAGMA journal_mode = WAL"
+            ).fetchone()[0]
+        else:
+            journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
         if journal_mode.lower() != "wal":
             raise CacheDatabaseUnavailable("context cache database cannot enable WAL mode")
         connection.execute("PRAGMA wal_autocheckpoint = 0")
@@ -1783,22 +1703,45 @@ class ContextCacheDatabase:
         if application_id == 0 and schema_version == 0 and not tables:
             self._create_schema()
             return
+        if self._validate_existing_schema():
+            self._migrate_legacy_schema()
+
+    def _validate_existing_schema(self) -> bool:
+        """Return whether a recognized existing cache needs supported migration."""
+        application_id = self.connection.execute(
+            "PRAGMA application_id"
+        ).fetchone()[0]
+        schema_version = self.connection.execute(
+            "PRAGMA user_version"
+        ).fetchone()[0]
+        tables = self.table_names()
         if application_id != APPLICATION_ID:
-            raise CacheDatabaseError("context cache database has an unknown application id")
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unknown application id"
+            )
         if schema_version != SCHEMA_VERSION:
-            raise CacheDatabaseError("context cache database has an unsupported schema version")
+            raise CacheDatabaseUnavailable(
+                "context cache database has an unsupported schema version"
+            )
         if self.connection.execute("PRAGMA auto_vacuum").fetchone()[0] != 2:
-            raise CacheDatabaseError("context cache database auto_vacuum is incompatible")
+            raise CacheDatabaseUnavailable(
+                "context cache database auto_vacuum is incompatible"
+            )
         if tables != _TABLE_NAMES:
-            raise CacheDatabaseError("context cache database schema is incomplete")
+            raise CacheDatabaseUnavailable(
+                "context cache database schema is incomplete"
+            )
         namespace = self.connection.execute(
             "SELECT id FROM namespaces WHERE name = ?", (DEFAULT_NAMESPACE,)
         ).fetchone()
         if namespace is None:
-            raise CacheDatabaseError("context cache database default namespace is missing")
+            raise CacheDatabaseUnavailable(
+                "context cache database default namespace is missing"
+            )
         if self._schema_objects_match(_LEGACY_SCHEMA_DDL):
-            self._migrate_legacy_schema()
+            return True
         self._validate_schema_structure()
+        return False
 
     def _schema_objects_match(self, schema_ddl: dict[str, str]) -> bool:
         expected_objects = {
@@ -1831,9 +1774,10 @@ class ContextCacheDatabase:
                     "scan_nonce TEXT NOT NULL DEFAULT ''"
                 )
             elif not self._schema_objects_match(_SCHEMA_DDL):
-                raise CacheDatabaseError(
+                raise CacheDatabaseUnavailable(
                     "context cache database schema changed during migration"
                 )
+            self._validate_schema_structure()
             connection.commit()
         except BaseException:
             connection.rollback()
@@ -1841,7 +1785,9 @@ class ContextCacheDatabase:
 
     def _validate_schema_structure(self) -> None:
         if not self._schema_objects_match(_SCHEMA_DDL):
-            raise CacheDatabaseError("context cache database schema objects differ")
+            raise CacheDatabaseUnavailable(
+                "context cache database schema objects differ"
+            )
         actual_ddl = dict(self.connection.execute(
             "SELECT name, sql FROM sqlite_schema WHERE type = 'table' "
             "AND name NOT LIKE 'sqlite_%'"
@@ -1850,21 +1796,25 @@ class ContextCacheDatabase:
             name: _canonical_ddl(ddl) for name, ddl in _SCHEMA_DDL.items()
         }
         if {name: _canonical_ddl(ddl) for name, ddl in actual_ddl.items()} != expected_ddl:
-            raise CacheDatabaseError("context cache database schema DDL differs")
+            raise CacheDatabaseUnavailable(
+                "context cache database schema DDL differs"
+            )
         for table, expected in _EXPECTED_COLUMNS.items():
             actual = tuple(
                 (row[1], row[2].upper(), row[3], row[5])
                 for row in self.connection.execute(f'PRAGMA table_info("{table}")')
             )
             if actual != expected:
-                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+                raise CacheDatabaseUnavailable(
+                    f"context cache database schema differs: {table}"
+                )
         for (table, column), expected in _EXPECTED_COLUMN_DEFAULTS.items():
             defaults = {
                 row[1]: row[4]
                 for row in self.connection.execute(f'PRAGMA table_info("{table}")')
             }
             if defaults.get(column) != expected:
-                raise CacheDatabaseError(
+                raise CacheDatabaseUnavailable(
                     f"context cache database schema differs: {table}.{column}"
                 )
         for table, expected in _EXPECTED_FOREIGN_KEYS.items():
@@ -1873,7 +1823,9 @@ class ContextCacheDatabase:
                 for row in self.connection.execute(f'PRAGMA foreign_key_list("{table}")')
             }
             if actual != expected:
-                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+                raise CacheDatabaseUnavailable(
+                    f"context cache database schema differs: {table}"
+                )
         for table, expected in _EXPECTED_UNIQUE_COLUMNS.items():
             actual = set()
             for index in self.connection.execute(f'PRAGMA index_list("{table}")'):
@@ -1884,7 +1836,9 @@ class ContextCacheDatabase:
                         )
                     ))
             if actual != expected:
-                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+                raise CacheDatabaseUnavailable(
+                    f"context cache database schema differs: {table}"
+                )
         files_sql = self.connection.execute(
             "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'files'"
         ).fetchone()[0]
@@ -1895,7 +1849,9 @@ class ContextCacheDatabase:
             item.strip().strip("'") for item in state_check.group(1).split(",")
         )
         if states != ("text", "binary_file", "invalid_utf8", "file_too_large"):
-            raise CacheDatabaseError("context cache database schema differs: files state")
+            raise CacheDatabaseUnavailable(
+                "context cache database schema differs: files state"
+            )
 
     def _create_schema(self) -> None:
         timestamp = time.time_ns()
@@ -1927,7 +1883,12 @@ def _uses_posix_permissions() -> bool:
     return os.name != "nt"
 
 
-def _acquire_descriptor_lock(descriptor: int, exclusive: bool):
+def _acquire_descriptor_lock(
+    descriptor: int,
+    exclusive: bool,
+    *,
+    wait: bool = True,
+):
     deadline = time.monotonic() + BUSY_TIMEOUT_MS / 1000
     while True:
         try:
@@ -1940,6 +1901,8 @@ def _acquire_descriptor_lock(descriptor: int, exclusive: bool):
             fcntl.flock(descriptor, operation | fcntl.LOCK_NB)
             return None
         except (BlockingIOError, PermissionError):
+            if not wait:
+                raise
             if time.monotonic() >= deadline:
                 raise CacheDatabaseUnavailable(
                     "context cache database is locked"
@@ -2036,6 +1999,20 @@ def _database_header_identity(header: bytes) -> tuple[int, int]:
     return application_id, schema_version
 
 
+def _database_page_size(header: bytes) -> int:
+    encoded = int.from_bytes(
+        header[_SQLITE_PAGE_SIZE_OFFSET:_SQLITE_PAGE_SIZE_OFFSET + 2],
+        "big",
+    )
+    page_size = 65_536 if encoded == 1 else encoded
+    if (page_size < 512 or page_size > 65_536
+            or page_size & (page_size - 1)):
+        raise CacheDatabaseUnavailable(
+            "context cache database page size is invalid"
+        )
+    return page_size
+
+
 def _stable_file_identity(path: Path) -> tuple[int, int, int, int, int]:
     result = path.stat(follow_symlinks=False)
     return (
@@ -2045,102 +2022,6 @@ def _stable_file_identity(path: Path) -> tuple[int, int, int, int, int]:
         result.st_mtime_ns,
         result.st_ctime_ns,
     )
-
-
-def _last_committed_wal_page_one(descriptor: int) -> bytes | None:
-    page_size, checksum_byte_order, checksum, salts = _read_wal_header(
-        descriptor
-    )
-    latest_page_one = None
-    committed_page_one = None
-    while True:
-        frame = _read_valid_wal_frame(
-            descriptor,
-            page_size,
-            salts,
-            checksum_byte_order,
-            checksum,
-        )
-        if frame is None:
-            break
-        page_number, database_pages, page, checksum = frame
-        if page_number == 1:
-            latest_page_one = page
-        if database_pages:
-            committed_page_one = latest_page_one
-    return committed_page_one
-
-
-def _read_wal_header(
-    descriptor: int,
-) -> tuple[int, str, tuple[int, int], bytes]:
-    header = _read_exact(descriptor, _WAL_HEADER_BYTES)
-    if len(header) != _WAL_HEADER_BYTES:
-        raise CacheDatabaseUnavailable("context cache WAL header is incomplete")
-    magic, version, page_size = struct.unpack(">III", header[:12])
-    checksum_byte_order = _WAL_CHECKSUM_BYTE_ORDERS.get(magic)
-    if checksum_byte_order is None or version != _WAL_FORMAT_VERSION:
-        raise CacheDatabaseUnavailable("context cache WAL header is incompatible")
-    if page_size == 1:
-        page_size = 65_536
-    if (page_size < 512 or page_size > 65_536
-            or page_size & (page_size - 1)):
-        raise CacheDatabaseUnavailable("context cache WAL page size is invalid")
-    checksum = _wal_checksum(header[:24], checksum_byte_order)
-    if checksum != struct.unpack(">II", header[24:32]):
-        raise CacheDatabaseUnavailable("context cache WAL header checksum failed")
-    return page_size, checksum_byte_order, checksum, header[16:24]
-
-
-def _read_valid_wal_frame(
-    descriptor: int,
-    page_size: int,
-    salts: bytes,
-    checksum_byte_order: str,
-    checksum: tuple[int, int],
-) -> tuple[int, int, bytes, tuple[int, int]] | None:
-    frame_header = _read_exact(descriptor, _WAL_FRAME_HEADER_BYTES)
-    if not frame_header:
-        return None
-    page = _read_exact(descriptor, page_size)
-    if len(frame_header) != _WAL_FRAME_HEADER_BYTES or len(page) != page_size:
-        return None
-    if frame_header[8:16] != salts:
-        return None
-    next_checksum = _wal_checksum(
-        frame_header[:8] + page,
-        checksum_byte_order,
-        checksum,
-    )
-    if next_checksum != struct.unpack(">II", frame_header[16:24]):
-        return None
-    page_number, database_pages = struct.unpack(">II", frame_header[:8])
-    return page_number, database_pages, page, next_checksum
-
-
-def _read_exact(descriptor: int, size: int) -> bytes:
-    chunks = []
-    remaining = size
-    while remaining:
-        chunk = os.read(descriptor, remaining)
-        if not chunk:
-            break
-        chunks.append(chunk)
-        remaining -= len(chunk)
-    return b"".join(chunks)
-
-
-def _wal_checksum(
-    data: bytes,
-    byte_order: str,
-    initial: tuple[int, int] = (0, 0),
-) -> tuple[int, int]:
-    values = struct.unpack(f"{byte_order}{len(data) // 4}I", data)
-    first, second = initial
-    for offset in range(0, len(values), 2):
-        first = (first + values[offset] + second) & 0xFFFFFFFF
-        second = (second + values[offset + 1] + first) & 0xFFFFFFFF
-    return first, second
 
 
 def _next_scan_started_ns() -> int:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -149,7 +149,7 @@ class CacheDatabaseUnavailable(CacheDatabaseError):
 
 @dataclass(frozen=True, slots=True)
 class ScanToken:
-    """Total-order token generated in memory when a scan starts."""
+    """Scan identity with a process-monotonic start timestamp."""
 
     namespace: str
     canonical_root: str
@@ -276,9 +276,8 @@ class ContextCacheDatabase:
         roots = tuple(dict.fromkeys(canonical_roots))
         if not roots:
             return {}
-        if self._checkpoint_wal()[0] != 0:
-            return None
-        if self.aggregate_size_bytes() >= max_bytes:
+        if (self.aggregate_size_bytes() >= max_bytes
+                or self._projected_aggregate_size() > max_bytes):
             return None
 
         return {root: self.begin_scan(namespace, root) for root in roots}
@@ -330,17 +329,17 @@ class ContextCacheDatabase:
         connection = self.connection
         timestamp = time.time_ns()
         admitted = []
-        if max_bytes is not None:
-            connection.execute("PRAGMA locking_mode = EXCLUSIVE")
-            if self._checkpoint_wal()[0] != 0:
-                self._restore_normal_locking()
-                return None
-            if self.aggregate_size_bytes() >= max_bytes:
-                self._restore_normal_locking()
-                return None
-        if max_bytes is not None:
-            connection.execute("PRAGMA cache_spill = OFF")
+        if (max_bytes is not None
+                and (self.aggregate_size_bytes() >= max_bytes
+                     or self._projected_aggregate_size() > max_bytes)):
+            return None
+
+        primary_error = None
+        secondary_errors = []
         try:
+            if max_bytes is not None:
+                connection.execute("PRAGMA locking_mode = EXCLUSIVE")
+                connection.execute("PRAGMA cache_spill = OFF")
             try:
                 connection.execute(
                     "BEGIN EXCLUSIVE" if max_bytes is not None else "BEGIN IMMEDIATE"
@@ -349,15 +348,19 @@ class ContextCacheDatabase:
                 if "locked" in str(error).casefold():
                     return None
                 raise
+            if (max_bytes is not None
+                    and (self.aggregate_size_bytes() >= max_bytes
+                         or self._projected_aggregate_size() > max_bytes)):
+                connection.rollback()
+                return None
             current_root = connection.execute(
                 """SELECT id, scan_started_ns, scan_nonce FROM roots
                    WHERE canonical_path = ?""",
                 (canonical_root,),
             ).fetchone()
             if current_root is not None:
-                published_order = int(current_root[1]), str(current_root[2])
-                token_order = scan_token.started_ns, scan_token.nonce
-                if published_order >= token_order:
+                published_started_ns = int(current_root[1])
+                if published_started_ns >= scan_token.started_ns:
                     raise CacheDatabaseError("context cache scan token is stale")
             connection.execute(
                 """INSERT INTO namespaces (name, last_access_ns)
@@ -463,16 +466,34 @@ class ContextCacheDatabase:
                 connection.rollback()
                 return None
             connection.commit()
-            if max_bytes is not None:
-                self._checkpoint_wal()
-        except BaseException:
+        except BaseException as error:
+            primary_error = error
             if connection.in_transaction:
-                connection.rollback()
+                try:
+                    connection.rollback()
+                except BaseException as rollback_error:
+                    secondary_errors.append(rollback_error)
             raise
         finally:
             if max_bytes is not None:
-                connection.execute("PRAGMA cache_spill = ON")
-                self._restore_normal_locking()
+                try:
+                    connection.execute("PRAGMA cache_spill = ON")
+                except BaseException as error:
+                    secondary_errors.append(error)
+                try:
+                    self._restore_normal_locking()
+                except BaseException as error:
+                    secondary_errors.append(error)
+            if secondary_errors:
+                cleanup_error = secondary_errors[0]
+                if len(secondary_errors) > 1:
+                    cleanup_error = BaseExceptionGroup(
+                        "context cache transaction cleanup failed",
+                        secondary_errors,
+                    )
+                if primary_error is not None:
+                    raise primary_error from cleanup_error
+                raise cleanup_error
         return tuple(admitted)
 
     def _restore_normal_locking(self) -> None:
@@ -610,7 +631,7 @@ class ContextCacheDatabase:
         return total
 
     def _projected_aggregate_size(self) -> int:
-        """Return a conservative post-checkpoint size for the current write."""
+        """Return a conservative aggregate size for a possible write."""
         page_size = self.connection.execute("PRAGMA page_size").fetchone()[0]
         page_count = self.connection.execute("PRAGMA page_count").fetchone()[0]
         try:
@@ -893,6 +914,11 @@ class ContextCacheDatabase:
         journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
         if journal_mode.lower() != "wal":
             raise CacheDatabaseUnavailable("context cache database cannot enable WAL mode")
+        connection.execute("PRAGMA wal_autocheckpoint = 0")
+        if connection.execute("PRAGMA wal_autocheckpoint").fetchone()[0] != 0:
+            raise CacheDatabaseUnavailable(
+                "context cache database cannot disable automatic checkpoints"
+            )
         connection.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
 
     def _verify_or_create_schema(self) -> None:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -31,7 +31,8 @@ _SCHEMA_DDL = {
     "roots": """CREATE TABLE roots (
         id INTEGER PRIMARY KEY,
         canonical_path TEXT NOT NULL UNIQUE,
-        last_access_ns INTEGER NOT NULL
+        last_access_ns INTEGER NOT NULL,
+        scan_generation INTEGER NOT NULL DEFAULT 0
     )""",
     "namespace_roots": """CREATE TABLE namespace_roots (
         namespace_id INTEGER NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
@@ -82,7 +83,8 @@ _EXPECTED_COLUMNS = {
     "namespaces": (("id", "INTEGER", 0, 1), ("name", "TEXT", 1, 0),
                    ("last_access_ns", "INTEGER", 1, 0)),
     "roots": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
-              ("last_access_ns", "INTEGER", 1, 0)),
+              ("last_access_ns", "INTEGER", 1, 0),
+              ("scan_generation", "INTEGER", 1, 0)),
     "namespace_roots": (("namespace_id", "INTEGER", 1, 1),
                         ("root_id", "INTEGER", 1, 2)),
     "files": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
@@ -112,6 +114,10 @@ _EXPECTED_UNIQUE_COLUMNS = {
     "namespaces": {("name",)},
     "roots": {("canonical_path",)},
     "files": {("canonical_path",)},
+}
+
+_EXPECTED_COLUMN_DEFAULTS = {
+    ("roots", "scan_generation"): "0",
 }
 
 
@@ -182,7 +188,7 @@ class ContextCacheDatabase:
     def __init__(self, path: Union[Path, str]):
         self.path = Path(path)
         self._connection: Optional[sqlite3.Connection] = None
-        self._scans: dict[str, tuple[str, str]] = {}
+        self._scans: dict[str, tuple[str, str, int]] = {}
         self._active_scans: dict[tuple[str, str], str] = {}
 
     @property
@@ -224,14 +230,52 @@ class ContextCacheDatabase:
         }
 
     def begin_scan(self, namespace: str, canonical_root: str) -> str:
-        """Return an opaque scan token without changing persisted state."""
-        self.connection
+        """Persist a new generation without removing cached associations."""
         scan_token = str(uuid.uuid4())
         scan_key = namespace, canonical_root
+        timestamp = time.time_ns()
+        connection = self.connection
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """INSERT INTO namespaces (name, last_access_ns)
+                   VALUES (?, ?)
+                   ON CONFLICT(name) DO UPDATE SET
+                       last_access_ns = excluded.last_access_ns""",
+                (namespace, timestamp),
+            )
+            namespace_id = connection.execute(
+                "SELECT id FROM namespaces WHERE name = ?", (namespace,)
+            ).fetchone()[0]
+            connection.execute(
+                """INSERT INTO roots (
+                       canonical_path, last_access_ns, scan_generation
+                   ) VALUES (?, ?, 1)
+                   ON CONFLICT(canonical_path) DO UPDATE SET
+                       last_access_ns = excluded.last_access_ns,
+                       scan_generation = roots.scan_generation + 1""",
+                (canonical_root, timestamp),
+            )
+            root_id, generation = connection.execute(
+                """SELECT id, scan_generation FROM roots
+                   WHERE canonical_path = ?""",
+                (canonical_root,),
+            ).fetchone()
+            connection.execute(
+                """INSERT INTO namespace_roots (namespace_id, root_id)
+                   VALUES (?, ?)
+                   ON CONFLICT(namespace_id, root_id) DO NOTHING""",
+                (namespace_id, root_id),
+            )
+            connection.commit()
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
         previous_token = self._active_scans.get(scan_key)
         if previous_token is not None:
             self._scans.pop(previous_token, None)
-        self._scans[scan_token] = scan_key
+        self._scans[scan_token] = namespace, canonical_root, generation
         self._active_scans[scan_key] = scan_token
         return scan_token
 
@@ -240,7 +284,7 @@ class ContextCacheDatabase:
     ) -> None:
         """Atomically publish one completed root scan."""
         try:
-            namespace, canonical_root = self._scans[scan_token]
+            namespace, canonical_root, generation = self._scans[scan_token]
         except KeyError as error:
             raise CacheDatabaseError("context cache scan token is unknown") from error
 
@@ -249,6 +293,13 @@ class ContextCacheDatabase:
         timestamp = time.time_ns()
         try:
             connection.execute("BEGIN IMMEDIATE")
+            current_root = connection.execute(
+                """SELECT id FROM roots
+                   WHERE canonical_path = ? AND scan_generation = ?""",
+                (canonical_root, generation),
+            ).fetchone()
+            if current_root is None:
+                raise CacheDatabaseError("context cache scan token is stale")
             connection.execute(
                 """INSERT INTO namespaces (name, last_access_ns)
                    VALUES (?, ?)
@@ -266,9 +317,7 @@ class ContextCacheDatabase:
                        last_access_ns = excluded.last_access_ns""",
                 (canonical_root, timestamp),
             )
-            root_id = connection.execute(
-                "SELECT id FROM roots WHERE canonical_path = ?", (canonical_root,)
-            ).fetchone()[0]
+            root_id = current_root[0]
             connection.execute(
                 """INSERT INTO namespace_roots (namespace_id, root_id)
                    VALUES (?, ?)
@@ -443,7 +492,6 @@ class ContextCacheDatabase:
         associations_removed = 0
         roots_removed = 0
         files_removed = self._collect_orphan_files()
-        self._run_bounded_maintenance()
 
         candidates = self.connection.execute(
             """SELECT id FROM roots
@@ -478,7 +526,6 @@ class ContextCacheDatabase:
             associations_removed += association_count
             roots_removed += root_count
             files_removed += file_count
-            self._run_bounded_maintenance()
 
         self._run_bounded_maintenance()
         return CacheMaintenanceReport(
@@ -508,8 +555,8 @@ class ContextCacheDatabase:
 
     def _run_bounded_maintenance(self) -> None:
         """Checkpoint WAL and reclaim at most a bounded number of pages."""
-        self.connection.execute("PRAGMA incremental_vacuum(128)")
         self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        self.connection.execute("PRAGMA incremental_vacuum(128)")
 
     @staticmethod
     def _identity(path: Path) -> tuple[int, int]:
@@ -706,6 +753,15 @@ class ContextCacheDatabase:
             )
             if actual != expected:
                 raise CacheDatabaseError(f"context cache database schema differs: {table}")
+        for (table, column), expected in _EXPECTED_COLUMN_DEFAULTS.items():
+            defaults = {
+                row[1]: row[4]
+                for row in self.connection.execute(f'PRAGMA table_info("{table}")')
+            }
+            if defaults.get(column) != expected:
+                raise CacheDatabaseError(
+                    f"context cache database schema differs: {table}.{column}"
+                )
         for table, expected in _EXPECTED_FOREIGN_KEYS.items():
             actual = {
                 (row[3], row[2], row[4], row[5].upper(), row[6].upper(), row[7].upper())

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -16,6 +16,52 @@ DEFAULT_NAMESPACE = "default"
 DEFAULT_MAX_BYTES = 256 * 1024 * 1024
 BUSY_TIMEOUT_MS = 500
 
+_SCHEMA_DDL = {
+    "metadata": """CREATE TABLE metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )""",
+    "namespaces": """CREATE TABLE namespaces (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        last_access_ns INTEGER NOT NULL
+    )""",
+    "roots": """CREATE TABLE roots (
+        id INTEGER PRIMARY KEY,
+        canonical_path TEXT NOT NULL UNIQUE,
+        last_access_ns INTEGER NOT NULL
+    )""",
+    "namespace_roots": """CREATE TABLE namespace_roots (
+        namespace_id INTEGER NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+        root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
+        PRIMARY KEY (namespace_id, root_id)
+    )""",
+    "files": """CREATE TABLE files (
+        id INTEGER PRIMARY KEY,
+        canonical_path TEXT NOT NULL UNIQUE,
+        device INTEGER,
+        inode INTEGER,
+        size_bytes INTEGER NOT NULL,
+        mtime_ns INTEGER NOT NULL,
+        ctime_ns INTEGER NOT NULL,
+        state TEXT NOT NULL CHECK (
+            state IN ('text', 'binary_file', 'invalid_utf8', 'file_too_large')
+        ),
+        content_sha256 TEXT,
+        folded_text TEXT,
+        created_ns INTEGER NOT NULL,
+        validated_ns INTEGER NOT NULL,
+        last_access_ns INTEGER NOT NULL
+    )""",
+    "root_files": """CREATE TABLE root_files (
+        root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
+        file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+        relative_path TEXT NOT NULL,
+        last_seen_scan TEXT NOT NULL,
+        PRIMARY KEY (root_id, file_id)
+    )""",
+}
+
 _TABLE_NAMES = frozenset(
     {"metadata", "namespaces", "namespace_roots", "roots", "root_files", "files"}
 )
@@ -41,10 +87,14 @@ _EXPECTED_COLUMNS = {
 }
 
 _EXPECTED_FOREIGN_KEYS = {
-    "namespace_roots": {("root_id", "roots", "id", "CASCADE"),
-                        ("namespace_id", "namespaces", "id", "CASCADE")},
-    "root_files": {("file_id", "files", "id", "CASCADE"),
-                   ("root_id", "roots", "id", "CASCADE")},
+    "namespace_roots": {
+        ("root_id", "roots", "id", "NO ACTION", "CASCADE", "NONE"),
+        ("namespace_id", "namespaces", "id", "NO ACTION", "CASCADE", "NONE"),
+    },
+    "root_files": {
+        ("file_id", "files", "id", "NO ACTION", "CASCADE", "NONE"),
+        ("root_id", "roots", "id", "NO ACTION", "CASCADE", "NONE"),
+    },
 }
 
 _EXPECTED_UNIQUE_COLUMNS = {
@@ -75,7 +125,12 @@ def default_cache_path() -> Path:
 
 
 class ContextCacheDatabase:
-    """Own the lifecycle and schema identity of one context-cache database."""
+    """Own the lifecycle and schema identity of one context-cache database.
+
+    POSIX creation uses exclusive/no-follow flags when available. On Windows,
+    stdlib SQLite must reopen by path, so protection is best-effort: reparse
+    points and identity changes are rejected before any database operation.
+    """
 
     def __init__(self, path: Union[Path, str]):
         self.path = Path(path)
@@ -90,17 +145,14 @@ class ContextCacheDatabase:
 
     def __enter__(self) -> "ContextCacheDatabase":
         try:
-            database_is_empty, directory_identity, file_identity = self._prepare_path()
-            previous_umask = os.umask(0o077) if os.name != "nt" else None
-            try:
-                self._connection = sqlite3.connect(str(self.path), timeout=0.5)
-                self._validate_identity(directory_identity, file_identity)
-                self._configure_connection(database_is_empty)
-                self._validate_sidecars()
-            finally:
-                if previous_umask is not None:
-                    os.umask(previous_umask)
+            prepared = self._prepare_path()
+            database_is_empty, directory_identity, file_identity, sidecars = prepared
+            self._connection = sqlite3.connect(str(self.path), timeout=0.5)
+            self._validate_identity(directory_identity, file_identity)
+            self._configure_connection(database_is_empty)
+            self._secure_new_sidecars(sidecars)
             self._verify_or_create_schema()
+            self._secure_new_sidecars(sidecars)
         except CacheDatabaseError:
             self._close_connection()
             raise
@@ -129,6 +181,13 @@ class ContextCacheDatabase:
 
     @staticmethod
     def _is_link(path: Path) -> bool:
+        try:
+            attributes = getattr(path.lstat(), "st_file_attributes", 0)
+        except FileNotFoundError:
+            attributes = 0
+        reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if os.name == "nt" and attributes & reparse_point:
+            return True
         is_junction = getattr(path, "is_junction", None)
         return path.is_symlink() or (is_junction is not None and is_junction())
 
@@ -168,7 +227,9 @@ class ContextCacheDatabase:
             directory.mkdir(mode=0o700)
         return directory
 
-    def _prepare_path(self) -> tuple[bool, tuple[int, int], tuple[int, int]]:
+    def _prepare_path(
+        self,
+    ) -> tuple[bool, tuple[int, int], tuple[int, int], set[Path]]:
         if self._is_link(self.path):
             raise CacheDatabaseError("context cache database must not be a symlink")
         try:
@@ -191,8 +252,9 @@ class ContextCacheDatabase:
         file_identity = self._identity(self.path)
         self._validate_secure_file(self.path)
         self._validate_sidecars()
+        sidecars = self._existing_sidecars()
         database_is_empty = self.path.stat(follow_symlinks=False).st_size == 0
-        return database_is_empty, directory_identity, file_identity
+        return database_is_empty, directory_identity, file_identity, sidecars
 
     def _validate_identity(
         self, directory_identity: tuple[int, int], file_identity: tuple[int, int]
@@ -207,13 +269,28 @@ class ContextCacheDatabase:
     def _validate_secure_file(self, path: Path) -> None:
         if self._is_link(path) or not path.is_file():
             raise CacheDatabaseError("context cache file is unsafe")
-        if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) & 0o077:
+        if _uses_posix_permissions() and stat.S_IMODE(path.stat().st_mode) & 0o077:
             raise CacheDatabaseError("context cache file permissions are unsafe")
 
+    def _existing_sidecars(self) -> set[Path]:
+        return {
+            sidecar for sidecar in self._sidecar_paths()
+            if sidecar.exists() or self._is_link(sidecar)
+        }
+
+    def _sidecar_paths(self) -> tuple[Path, Path]:
+        return Path(f"{self.path}-wal"), Path(f"{self.path}-shm")
+
     def _validate_sidecars(self) -> None:
-        for suffix in ("-wal", "-shm"):
-            sidecar = Path(f"{self.path}{suffix}")
+        for sidecar in self._sidecar_paths():
             if sidecar.exists() or self._is_link(sidecar):
+                self._validate_secure_file(sidecar)
+
+    def _secure_new_sidecars(self, existing: set[Path]) -> None:
+        for sidecar in self._sidecar_paths():
+            if sidecar.exists() and sidecar not in existing:
+                if _uses_posix_permissions():
+                    sidecar.chmod(0o600)
                 self._validate_secure_file(sidecar)
 
     def _configure_connection(self, database_is_empty: bool) -> None:
@@ -250,6 +327,15 @@ class ContextCacheDatabase:
             raise CacheDatabaseError("context cache database default namespace is missing")
 
     def _validate_schema_structure(self) -> None:
+        actual_ddl = dict(self.connection.execute(
+            "SELECT name, sql FROM sqlite_schema WHERE type = 'table' "
+            "AND name NOT LIKE 'sqlite_%'"
+        ))
+        expected_ddl = {
+            name: _canonical_ddl(ddl) for name, ddl in _SCHEMA_DDL.items()
+        }
+        if {name: _canonical_ddl(ddl) for name, ddl in actual_ddl.items()} != expected_ddl:
+            raise CacheDatabaseError("context cache database schema DDL differs")
         for table, expected in _EXPECTED_COLUMNS.items():
             actual = tuple(
                 (row[1], row[2].upper(), row[3], row[5])
@@ -259,7 +345,7 @@ class ContextCacheDatabase:
                 raise CacheDatabaseError(f"context cache database schema differs: {table}")
         for table, expected in _EXPECTED_FOREIGN_KEYS.items():
             actual = {
-                (row[3], row[2], row[4], row[6].upper())
+                (row[3], row[2], row[4], row[5].upper(), row[6].upper(), row[7].upper())
                 for row in self.connection.execute(f'PRAGMA foreign_key_list("{table}")')
             }
             if actual != expected:
@@ -289,54 +375,13 @@ class ContextCacheDatabase:
 
     def _create_schema(self) -> None:
         timestamp = time.time_ns()
+        schema_ddl = ";\n".join(_SCHEMA_DDL.values())
         self.connection.executescript(
             f"""
                 BEGIN;
                 PRAGMA application_id = {APPLICATION_ID};
                 PRAGMA user_version = {SCHEMA_VERSION};
-                CREATE TABLE metadata (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL
-                );
-                CREATE TABLE namespaces (
-                    id INTEGER PRIMARY KEY,
-                    name TEXT NOT NULL UNIQUE,
-                    last_access_ns INTEGER NOT NULL
-                );
-                CREATE TABLE roots (
-                    id INTEGER PRIMARY KEY,
-                    canonical_path TEXT NOT NULL UNIQUE,
-                    last_access_ns INTEGER NOT NULL
-                );
-                CREATE TABLE namespace_roots (
-                    namespace_id INTEGER NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
-                    root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
-                    PRIMARY KEY (namespace_id, root_id)
-                );
-                CREATE TABLE files (
-                    id INTEGER PRIMARY KEY,
-                    canonical_path TEXT NOT NULL UNIQUE,
-                    device INTEGER,
-                    inode INTEGER,
-                    size_bytes INTEGER NOT NULL,
-                    mtime_ns INTEGER NOT NULL,
-                    ctime_ns INTEGER NOT NULL,
-                    state TEXT NOT NULL CHECK (
-                        state IN ('text', 'binary_file', 'invalid_utf8', 'file_too_large')
-                    ),
-                    content_sha256 TEXT,
-                    folded_text TEXT,
-                    created_ns INTEGER NOT NULL,
-                    validated_ns INTEGER NOT NULL,
-                    last_access_ns INTEGER NOT NULL
-                );
-                CREATE TABLE root_files (
-                    root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
-                    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
-                    relative_path TEXT NOT NULL,
-                    last_seen_scan TEXT NOT NULL,
-                    PRIMARY KEY (root_id, file_id)
-                );
+                {schema_ddl};
                 INSERT INTO namespaces (name, last_access_ns)
                     VALUES ('{DEFAULT_NAMESPACE}', {timestamp});
                 COMMIT;
@@ -347,3 +392,11 @@ class ContextCacheDatabase:
         if self._connection is not None:
             self._connection.close()
             self._connection = None
+
+
+def _uses_posix_permissions() -> bool:
+    return os.name != "nt"
+
+
+def _canonical_ddl(ddl: str) -> str:
+    return re.sub(r"\s+", "", ddl).rstrip(";").casefold()

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -5,6 +5,7 @@ import re
 import sqlite3
 import stat
 import sys
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -17,6 +18,9 @@ SCHEMA_VERSION = 1
 DEFAULT_NAMESPACE = "default"
 DEFAULT_MAX_BYTES = 256 * 1024 * 1024
 BUSY_TIMEOUT_MS = 500
+
+_SCAN_TOKEN_LOCK = threading.Lock()
+_LAST_SCAN_STARTED_NS = 0
 
 _SCHEMA_DDL = {
     "metadata": """CREATE TABLE metadata (
@@ -32,7 +36,9 @@ _SCHEMA_DDL = {
         id INTEGER PRIMARY KEY,
         canonical_path TEXT NOT NULL UNIQUE,
         last_access_ns INTEGER NOT NULL,
-        scan_generation INTEGER NOT NULL DEFAULT 0
+        scan_generation INTEGER NOT NULL DEFAULT 0,
+        scan_started_ns INTEGER NOT NULL DEFAULT 0,
+        scan_nonce TEXT NOT NULL DEFAULT ''
     )""",
     "namespace_roots": """CREATE TABLE namespace_roots (
         namespace_id INTEGER NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
@@ -65,6 +71,14 @@ _SCHEMA_DDL = {
     )""",
 }
 
+_LEGACY_SCHEMA_DDL = dict(_SCHEMA_DDL)
+_LEGACY_SCHEMA_DDL["roots"] = """CREATE TABLE roots (
+        id INTEGER PRIMARY KEY,
+        canonical_path TEXT NOT NULL UNIQUE,
+        last_access_ns INTEGER NOT NULL,
+        scan_generation INTEGER NOT NULL DEFAULT 0
+    )"""
+
 _EXPECTED_AUTOINDEXES = {
     ("sqlite_autoindex_metadata_1", "metadata"),
     ("sqlite_autoindex_namespaces_1", "namespaces"),
@@ -84,7 +98,9 @@ _EXPECTED_COLUMNS = {
                    ("last_access_ns", "INTEGER", 1, 0)),
     "roots": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
               ("last_access_ns", "INTEGER", 1, 0),
-              ("scan_generation", "INTEGER", 1, 0)),
+              ("scan_generation", "INTEGER", 1, 0),
+              ("scan_started_ns", "INTEGER", 1, 0),
+              ("scan_nonce", "TEXT", 1, 0)),
     "namespace_roots": (("namespace_id", "INTEGER", 1, 1),
                         ("root_id", "INTEGER", 1, 2)),
     "files": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
@@ -118,6 +134,8 @@ _EXPECTED_UNIQUE_COLUMNS = {
 
 _EXPECTED_COLUMN_DEFAULTS = {
     ("roots", "scan_generation"): "0",
+    ("roots", "scan_started_ns"): "0",
+    ("roots", "scan_nonce"): "''",
 }
 
 
@@ -127,6 +145,16 @@ class CacheDatabaseError(RuntimeError):
 
 class CacheDatabaseUnavailable(CacheDatabaseError):
     """Raised when the cache database cannot be opened."""
+
+
+@dataclass(frozen=True, slots=True)
+class ScanToken:
+    """Total-order token generated in memory when a scan starts."""
+
+    namespace: str
+    canonical_root: str
+    started_ns: int
+    nonce: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,8 +216,6 @@ class ContextCacheDatabase:
     def __init__(self, path: Union[Path, str]):
         self.path = Path(path)
         self._connection: Optional[sqlite3.Connection] = None
-        self._scans: dict[str, tuple[str, str, int]] = {}
-        self._active_scans: dict[tuple[str, str], str] = {}
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -229,63 +255,22 @@ class ContextCacheDatabase:
             if not row[0].startswith("sqlite_")
         }
 
-    def begin_scan(self, namespace: str, canonical_root: str) -> str:
-        """Persist a new generation without removing cached associations."""
-        scan_token = str(uuid.uuid4())
-        scan_key = namespace, canonical_root
-        timestamp = time.time_ns()
-        connection = self.connection
-        try:
-            connection.execute("BEGIN IMMEDIATE")
-            connection.execute(
-                """INSERT INTO namespaces (name, last_access_ns)
-                   VALUES (?, ?)
-                   ON CONFLICT(name) DO UPDATE SET
-                       last_access_ns = excluded.last_access_ns""",
-                (namespace, timestamp),
-            )
-            namespace_id = connection.execute(
-                "SELECT id FROM namespaces WHERE name = ?", (namespace,)
-            ).fetchone()[0]
-            connection.execute(
-                """INSERT INTO roots (
-                       canonical_path, last_access_ns, scan_generation
-                   ) VALUES (?, ?, 1)
-                   ON CONFLICT(canonical_path) DO UPDATE SET
-                       last_access_ns = excluded.last_access_ns,
-                       scan_generation = roots.scan_generation + 1""",
-                (canonical_root, timestamp),
-            )
-            root_id, generation = connection.execute(
-                """SELECT id, scan_generation FROM roots
-                   WHERE canonical_path = ?""",
-                (canonical_root,),
-            ).fetchone()
-            connection.execute(
-                """INSERT INTO namespace_roots (namespace_id, root_id)
-                   VALUES (?, ?)
-                   ON CONFLICT(namespace_id, root_id) DO NOTHING""",
-                (namespace_id, root_id),
-            )
-            connection.commit()
-        except BaseException:
-            if connection.in_transaction:
-                connection.rollback()
-            raise
-        previous_token = self._active_scans.get(scan_key)
-        if previous_token is not None:
-            self._scans.pop(previous_token, None)
-        self._scans[scan_token] = namespace, canonical_root, generation
-        self._active_scans[scan_key] = scan_token
-        return scan_token
+    def begin_scan(self, namespace: str, canonical_root: str) -> ScanToken:
+        """Return an immutable in-memory scan token without writing SQLite."""
+        return ScanToken(
+            namespace=namespace,
+            canonical_root=canonical_root,
+            started_ns=_next_scan_started_ns(),
+            nonce=str(uuid.uuid4()),
+        )
 
     def begin_scans_if_admitted(
         self,
         namespace: str,
         canonical_roots: Iterable[str],
         max_bytes: int,
-    ) -> dict[str, str] | None:
-        """Begin all root scans only when their minimum mutation fits quota."""
+    ) -> dict[str, ScanToken] | None:
+        """Prepare scan tokens after a read-only physical-capacity preflight."""
         if max_bytes < 0:
             raise ValueError("max_bytes must not be negative")
         roots = tuple(dict.fromkeys(canonical_roots))
@@ -296,72 +281,7 @@ class ContextCacheDatabase:
         if self.aggregate_size_bytes() >= max_bytes:
             return None
 
-        connection = self.connection
-        timestamp = time.time_ns()
-        scans = {root: str(uuid.uuid4()) for root in roots}
-        generations = {}
-        connection.execute("PRAGMA cache_spill = OFF")
-        try:
-            connection.execute("BEGIN IMMEDIATE")
-            if self.aggregate_size_bytes() >= max_bytes:
-                connection.rollback()
-                return None
-            connection.execute(
-                """INSERT INTO namespaces (name, last_access_ns)
-                   VALUES (?, ?)
-                   ON CONFLICT(name) DO UPDATE SET
-                       last_access_ns = excluded.last_access_ns""",
-                (namespace, timestamp),
-            )
-            namespace_id = connection.execute(
-                "SELECT id FROM namespaces WHERE name = ?", (namespace,)
-            ).fetchone()[0]
-            for canonical_root in roots:
-                connection.execute(
-                    """INSERT INTO roots (
-                           canonical_path, last_access_ns, scan_generation
-                       ) VALUES (?, ?, 1)
-                       ON CONFLICT(canonical_path) DO UPDATE SET
-                           last_access_ns = excluded.last_access_ns,
-                           scan_generation = roots.scan_generation + 1""",
-                    (canonical_root, timestamp),
-                )
-                root_id, generation = connection.execute(
-                    """SELECT id, scan_generation FROM roots
-                       WHERE canonical_path = ?""",
-                    (canonical_root,),
-                ).fetchone()
-                generations[canonical_root] = generation
-                connection.execute(
-                    """INSERT INTO namespace_roots (namespace_id, root_id)
-                       VALUES (?, ?)
-                       ON CONFLICT(namespace_id, root_id) DO NOTHING""",
-                    (namespace_id, root_id),
-                )
-            if self._projected_aggregate_size() > max_bytes:
-                connection.rollback()
-                return None
-            connection.commit()
-            self._checkpoint_wal()
-        except BaseException:
-            if connection.in_transaction:
-                connection.rollback()
-            raise
-        finally:
-            connection.execute("PRAGMA cache_spill = ON")
-
-        for canonical_root, scan_token in scans.items():
-            scan_key = namespace, canonical_root
-            previous_token = self._active_scans.get(scan_key)
-            if previous_token is not None:
-                self._scans.pop(previous_token, None)
-            self._scans[scan_token] = (
-                namespace,
-                canonical_root,
-                generations[canonical_root],
-            )
-            self._active_scans[scan_key] = scan_token
-        return scans
+        return {root: self.begin_scan(namespace, root) for root in roots}
 
     def roots_requiring_scan(
         self,
@@ -394,38 +314,51 @@ class ContextCacheDatabase:
 
     def commit_scan(
         self,
-        scan_token: str,
+        scan_token: ScanToken,
         files: Iterable[CachedFile],
         max_bytes: int | None = None,
     ) -> tuple[CachedFile, ...] | None:
         """Atomically publish the deterministic prefix admitted by quota."""
         if max_bytes is not None and max_bytes < 0:
             raise ValueError("max_bytes must not be negative")
-        try:
-            namespace, canonical_root, generation = self._scans[scan_token]
-        except KeyError as error:
-            raise CacheDatabaseError("context cache scan token is unknown") from error
+        if not isinstance(scan_token, ScanToken):
+            raise CacheDatabaseError("context cache scan token is invalid")
+        namespace = scan_token.namespace
+        canonical_root = scan_token.canonical_root
 
         cached_files = tuple(files)
         connection = self.connection
         timestamp = time.time_ns()
         admitted = []
         if max_bytes is not None:
+            connection.execute("PRAGMA locking_mode = EXCLUSIVE")
             if self._checkpoint_wal()[0] != 0:
+                self._restore_normal_locking()
                 return None
             if self.aggregate_size_bytes() >= max_bytes:
+                self._restore_normal_locking()
                 return None
         if max_bytes is not None:
             connection.execute("PRAGMA cache_spill = OFF")
         try:
-            connection.execute("BEGIN IMMEDIATE")
+            try:
+                connection.execute(
+                    "BEGIN EXCLUSIVE" if max_bytes is not None else "BEGIN IMMEDIATE"
+                )
+            except sqlite3.OperationalError as error:
+                if "locked" in str(error).casefold():
+                    return None
+                raise
             current_root = connection.execute(
-                """SELECT id FROM roots
-                   WHERE canonical_path = ? AND scan_generation = ?""",
-                (canonical_root, generation),
+                """SELECT id, scan_started_ns, scan_nonce FROM roots
+                   WHERE canonical_path = ?""",
+                (canonical_root,),
             ).fetchone()
-            if current_root is None:
-                raise CacheDatabaseError("context cache scan token is stale")
+            if current_root is not None:
+                published_order = int(current_root[1]), str(current_root[2])
+                token_order = scan_token.started_ns, scan_token.nonce
+                if published_order >= token_order:
+                    raise CacheDatabaseError("context cache scan token is stale")
             connection.execute(
                 """INSERT INTO namespaces (name, last_access_ns)
                    VALUES (?, ?)
@@ -437,13 +370,17 @@ class ContextCacheDatabase:
                 "SELECT id FROM namespaces WHERE name = ?", (namespace,)
             ).fetchone()[0]
             connection.execute(
-                """INSERT INTO roots (canonical_path, last_access_ns)
-                   VALUES (?, ?)
+                """INSERT INTO roots (
+                       canonical_path, last_access_ns, scan_started_ns, scan_nonce
+                   ) VALUES (?, ?, 0, '')
                    ON CONFLICT(canonical_path) DO UPDATE SET
                        last_access_ns = excluded.last_access_ns""",
                 (canonical_root, timestamp),
             )
-            root_id = current_root[0]
+            root_id = connection.execute(
+                "SELECT id FROM roots WHERE canonical_path = ?",
+                (canonical_root,),
+            ).fetchone()[0]
             connection.execute(
                 """INSERT INTO namespace_roots (namespace_id, root_id)
                    VALUES (?, ?)
@@ -498,7 +435,7 @@ class ContextCacheDatabase:
                        ON CONFLICT(root_id, file_id) DO UPDATE SET
                            relative_path = excluded.relative_path,
                            last_seen_scan = excluded.last_seen_scan""",
-                    (root_id, file_id, cached_file.relative_path, scan_token),
+                    (root_id, file_id, cached_file.relative_path, scan_token.nonce),
                 )
                 if (max_bytes is not None
                         and self._projected_aggregate_size() > max_bytes):
@@ -512,7 +449,14 @@ class ContextCacheDatabase:
             connection.execute(
                 """DELETE FROM root_files
                    WHERE root_id = ? AND last_seen_scan <> ?""",
-                (root_id, scan_token),
+                (root_id, scan_token.nonce),
+            )
+            connection.execute(
+                """UPDATE roots SET
+                       scan_generation = scan_generation + 1,
+                       scan_started_ns = ?, scan_nonce = ?, last_access_ns = ?
+                   WHERE id = ?""",
+                (scan_token.started_ns, scan_token.nonce, timestamp, root_id),
             )
             if (max_bytes is not None
                     and self._projected_aggregate_size() > max_bytes):
@@ -525,13 +469,18 @@ class ContextCacheDatabase:
             if connection.in_transaction:
                 connection.rollback()
             raise
-        else:
-            del self._scans[scan_token]
-            self._active_scans.pop((namespace, canonical_root), None)
         finally:
             if max_bytes is not None:
                 connection.execute("PRAGMA cache_spill = ON")
+                self._restore_normal_locking()
         return tuple(admitted)
+
+    def _restore_normal_locking(self) -> None:
+        """Restore normal locking and force release on the next file access."""
+        self.connection.execute("PRAGMA locking_mode = NORMAL")
+        self.connection.execute(
+            "SELECT name FROM sqlite_schema ORDER BY name LIMIT 1"
+        ).fetchone()
 
     def iter_root_files(
         self, namespace: str, canonical_root: str
@@ -961,17 +910,19 @@ class ContextCacheDatabase:
             raise CacheDatabaseError("context cache database auto_vacuum is incompatible")
         if tables != _TABLE_NAMES:
             raise CacheDatabaseError("context cache database schema is incomplete")
-        self._validate_schema_structure()
         namespace = self.connection.execute(
             "SELECT id FROM namespaces WHERE name = ?", (DEFAULT_NAMESPACE,)
         ).fetchone()
         if namespace is None:
             raise CacheDatabaseError("context cache database default namespace is missing")
+        if self._schema_objects_match(_LEGACY_SCHEMA_DDL):
+            self._migrate_legacy_schema()
+        self._validate_schema_structure()
 
-    def _validate_schema_structure(self) -> None:
+    def _schema_objects_match(self, schema_ddl: dict[str, str]) -> bool:
         expected_objects = {
             ("table", name, name, _canonical_ddl(ddl))
-            for name, ddl in _SCHEMA_DDL.items()
+            for name, ddl in schema_ddl.items()
         }
         expected_objects.update(
             ("index", name, table, None)
@@ -983,7 +934,32 @@ class ContextCacheDatabase:
                 "SELECT type, name, tbl_name, sql FROM sqlite_schema"
             )
         }
-        if actual_objects != expected_objects:
+        return actual_objects == expected_objects
+
+    def _migrate_legacy_schema(self) -> None:
+        connection = self.connection
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            if self._schema_objects_match(_LEGACY_SCHEMA_DDL):
+                connection.execute(
+                    "ALTER TABLE roots ADD COLUMN "
+                    "scan_started_ns INTEGER NOT NULL DEFAULT 0"
+                )
+                connection.execute(
+                    "ALTER TABLE roots ADD COLUMN "
+                    "scan_nonce TEXT NOT NULL DEFAULT ''"
+                )
+            elif not self._schema_objects_match(_SCHEMA_DDL):
+                raise CacheDatabaseError(
+                    "context cache database schema changed during migration"
+                )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+
+    def _validate_schema_structure(self) -> None:
+        if not self._schema_objects_match(_SCHEMA_DDL):
             raise CacheDatabaseError("context cache database schema objects differ")
         actual_ddl = dict(self.connection.execute(
             "SELECT name, sql FROM sqlite_schema WHERE type = 'table' "
@@ -1059,12 +1035,18 @@ class ContextCacheDatabase:
         if self._connection is not None:
             self._connection.close()
             self._connection = None
-        self._scans.clear()
-        self._active_scans.clear()
 
 
 def _uses_posix_permissions() -> bool:
     return os.name != "nt"
+
+
+def _next_scan_started_ns() -> int:
+    """Return process-monotonic wall time for deterministic local ordering."""
+    global _LAST_SCAN_STARTED_NS
+    with _SCAN_TOKEN_LOCK:
+        _LAST_SCAN_STARTED_NS = max(time.time_ns(), _LAST_SCAN_STARTED_NS + 1)
+        return _LAST_SCAN_STARTED_NS
 
 
 def _canonical_ddl(ddl: str) -> str:

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -62,6 +62,15 @@ _SCHEMA_DDL = {
     )""",
 }
 
+_EXPECTED_AUTOINDEXES = {
+    ("sqlite_autoindex_metadata_1", "metadata"),
+    ("sqlite_autoindex_namespaces_1", "namespaces"),
+    ("sqlite_autoindex_roots_1", "roots"),
+    ("sqlite_autoindex_namespace_roots_1", "namespace_roots"),
+    ("sqlite_autoindex_files_1", "files"),
+    ("sqlite_autoindex_root_files_1", "root_files"),
+}
+
 _TABLE_NAMES = frozenset(
     {"metadata", "namespaces", "namespace_roots", "roots", "root_files", "files"}
 )
@@ -127,9 +136,11 @@ def default_cache_path() -> Path:
 class ContextCacheDatabase:
     """Own the lifecycle and schema identity of one context-cache database.
 
-    POSIX creation uses exclusive/no-follow flags when available. On Windows,
-    stdlib SQLite must reopen by path, so protection is best-effort: reparse
-    points and identity changes are rejected before any database operation.
+    POSIX creation uses exclusive/no-follow flags when available and validates
+    identity before and after ``sqlite3.connect()``. Windows uses the same
+    checks as best-effort protection. Because stdlib SQLite reopens by path,
+    neither platform can absolutely exclude a swap-and-restore during that
+    interval; post-connect validation precedes configuration and schema work.
     """
 
     def __init__(self, path: Union[Path, str]):
@@ -248,7 +259,11 @@ class ContextCacheDatabase:
             flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
             flags |= getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(self.path, flags, 0o600)
-            os.close(descriptor)
+            try:
+                if _uses_posix_permissions() and hasattr(os, "fchmod"):
+                    os.fchmod(descriptor, 0o600)
+            finally:
+                os.close(descriptor)
         file_identity = self._identity(self.path)
         self._validate_secure_file(self.path)
         self._validate_sidecars()
@@ -272,9 +287,9 @@ class ContextCacheDatabase:
         if _uses_posix_permissions() and stat.S_IMODE(path.stat().st_mode) & 0o077:
             raise CacheDatabaseError("context cache file permissions are unsafe")
 
-    def _existing_sidecars(self) -> set[Path]:
+    def _existing_sidecars(self) -> dict[Path, tuple[int, int]]:
         return {
-            sidecar for sidecar in self._sidecar_paths()
+            sidecar: self._identity(sidecar) for sidecar in self._sidecar_paths()
             if sidecar.exists() or self._is_link(sidecar)
         }
 
@@ -286,12 +301,18 @@ class ContextCacheDatabase:
             if sidecar.exists() or self._is_link(sidecar):
                 self._validate_secure_file(sidecar)
 
-    def _secure_new_sidecars(self, existing: set[Path]) -> None:
+    def _secure_new_sidecars(self, existing: dict[Path, tuple[int, int]]) -> None:
         for sidecar in self._sidecar_paths():
-            if sidecar.exists() and sidecar not in existing:
+            present = sidecar.exists() or self._is_link(sidecar)
+            if sidecar in existing:
+                if not present or self._identity(sidecar) != existing[sidecar]:
+                    raise CacheDatabaseError("context cache sidecar identity changed")
+                self._validate_secure_file(sidecar)
+            elif present:
                 if _uses_posix_permissions():
                     sidecar.chmod(0o600)
                 self._validate_secure_file(sidecar)
+                existing[sidecar] = self._identity(sidecar)
 
     def _configure_connection(self, database_is_empty: bool) -> None:
         connection = self.connection
@@ -327,6 +348,22 @@ class ContextCacheDatabase:
             raise CacheDatabaseError("context cache database default namespace is missing")
 
     def _validate_schema_structure(self) -> None:
+        expected_objects = {
+            ("table", name, name, _canonical_ddl(ddl))
+            for name, ddl in _SCHEMA_DDL.items()
+        }
+        expected_objects.update(
+            ("index", name, table, None)
+            for name, table in _EXPECTED_AUTOINDEXES
+        )
+        actual_objects = {
+            (kind, name, table, None if ddl is None else _canonical_ddl(ddl))
+            for kind, name, table, ddl in self.connection.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_schema"
+            )
+        }
+        if actual_objects != expected_objects:
+            raise CacheDatabaseError("context cache database schema objects differ")
         actual_ddl = dict(self.connection.execute(
             "SELECT name, sql FROM sqlite_schema WHERE type = 'table' "
             "AND name NOT LIKE 'sqlite_%'"

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -1,0 +1,192 @@
+"""Private SQLite bootstrap for the bounded text-context cache."""
+
+import os
+import sqlite3
+import stat
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+
+APPLICATION_ID = 0x434A4358  # "CJCX"
+SCHEMA_VERSION = 1
+DEFAULT_NAMESPACE = "default"
+DEFAULT_MAX_BYTES = 256 * 1024 * 1024
+BUSY_TIMEOUT_MS = 500
+
+_TABLE_NAMES = frozenset(
+    {"metadata", "namespaces", "namespace_roots", "roots", "root_files", "files"}
+)
+
+
+class CacheDatabaseError(RuntimeError):
+    """Raised when a cache database is not safe or compatible to use."""
+
+
+class CacheDatabaseUnavailable(CacheDatabaseError):
+    """Raised when the cache database cannot be opened."""
+
+
+def default_cache_path() -> Path:
+    """Return the platform-specific location for Cereja's context cache."""
+    if os.name == "nt":
+        return Path(os.environ["LOCALAPPDATA"]) / "Cereja" / "cache" / "context.sqlite3"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "Cereja" / "context.sqlite3"
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    if cache_home:
+        return Path(cache_home) / "cereja" / "context.sqlite3"
+    return Path.home() / ".cache" / "cereja" / "context.sqlite3"
+
+
+class ContextCacheDatabase:
+    """Own the lifecycle and schema identity of one context-cache database."""
+
+    def __init__(self, path: Union[Path, str]):
+        self.path = Path(path)
+        self._connection: Optional[sqlite3.Connection] = None
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """Return the open SQLite connection."""
+        if self._connection is None:
+            raise CacheDatabaseError("context cache database is not open")
+        return self._connection
+
+    def __enter__(self) -> "ContextCacheDatabase":
+        try:
+            database_existed = self._prepare_path()
+            self._connection = sqlite3.connect(str(self.path), timeout=0.5)
+            self._configure_connection(database_existed)
+            self._verify_or_create_schema()
+        except CacheDatabaseError:
+            self._close_connection()
+            raise
+        except (OSError, sqlite3.Error) as error:
+            self._close_connection()
+            raise CacheDatabaseUnavailable("context cache database is unavailable") from error
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._close_connection()
+
+    def table_names(self) -> set[str]:
+        """Return the set of application tables in the open database."""
+        return {
+            row[0]
+            for row in self.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+            if not row[0].startswith("sqlite_")
+        }
+
+    def _prepare_path(self) -> bool:
+        if self.path.is_symlink():
+            raise CacheDatabaseError("context cache database must not be a symlink")
+        try:
+            mode = self.path.lstat().st_mode
+        except FileNotFoundError:
+            database_existed = False
+        else:
+            if not stat.S_ISREG(mode):
+                raise CacheDatabaseError("context cache database must be a regular file")
+            database_existed = True
+
+        directory = self.path.parent
+        if directory.is_symlink():
+            raise CacheDatabaseError("context cache directory must not be a symlink")
+        if directory.exists() and not directory.is_dir():
+            raise CacheDatabaseError("context cache directory must be a directory")
+        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            os.chmod(directory, 0o700)
+        return database_existed
+
+    def _configure_connection(self, database_existed: bool) -> None:
+        connection = self.connection
+        connection.execute("PRAGMA foreign_keys = ON")
+        journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+        if journal_mode.lower() != "wal":
+            raise CacheDatabaseUnavailable("context cache database cannot enable WAL mode")
+        connection.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+        if not database_existed:
+            connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
+            connection.execute("VACUUM")
+            if os.name != "nt":
+                os.chmod(self.path, 0o600)
+
+    def _verify_or_create_schema(self) -> None:
+        application_id = self.connection.execute("PRAGMA application_id").fetchone()[0]
+        schema_version = self.connection.execute("PRAGMA user_version").fetchone()[0]
+        tables = self.table_names()
+        if application_id == 0 and schema_version == 0 and not tables:
+            self._create_schema()
+            return
+        if application_id != APPLICATION_ID:
+            raise CacheDatabaseError("context cache database has an unknown application id")
+        if schema_version != SCHEMA_VERSION:
+            raise CacheDatabaseError("context cache database has an unsupported schema version")
+        if tables != _TABLE_NAMES:
+            raise CacheDatabaseError("context cache database schema is incomplete")
+
+    def _create_schema(self) -> None:
+        timestamp = time.time_ns()
+        self.connection.executescript(
+            f"""
+                BEGIN;
+                PRAGMA application_id = {APPLICATION_ID};
+                PRAGMA user_version = {SCHEMA_VERSION};
+                CREATE TABLE metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                CREATE TABLE namespaces (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    last_access_ns INTEGER NOT NULL
+                );
+                CREATE TABLE roots (
+                    id INTEGER PRIMARY KEY,
+                    canonical_path TEXT NOT NULL UNIQUE,
+                    last_access_ns INTEGER NOT NULL
+                );
+                CREATE TABLE namespace_roots (
+                    namespace_id INTEGER NOT NULL REFERENCES namespaces(id) ON DELETE CASCADE,
+                    root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
+                    PRIMARY KEY (namespace_id, root_id)
+                );
+                CREATE TABLE files (
+                    id INTEGER PRIMARY KEY,
+                    canonical_path TEXT NOT NULL UNIQUE,
+                    device INTEGER,
+                    inode INTEGER,
+                    size_bytes INTEGER NOT NULL,
+                    mtime_ns INTEGER NOT NULL,
+                    ctime_ns INTEGER NOT NULL,
+                    state TEXT NOT NULL CHECK (
+                        state IN ('text', 'binary_file', 'invalid_utf8', 'file_too_large')
+                    ),
+                    content_sha256 TEXT,
+                    folded_text TEXT,
+                    created_ns INTEGER NOT NULL,
+                    validated_ns INTEGER NOT NULL,
+                    last_access_ns INTEGER NOT NULL
+                );
+                CREATE TABLE root_files (
+                    root_id INTEGER NOT NULL REFERENCES roots(id) ON DELETE CASCADE,
+                    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                    relative_path TEXT NOT NULL,
+                    last_seen_scan TEXT NOT NULL,
+                    PRIMARY KEY (root_id, file_id)
+                );
+                INSERT INTO namespaces (name, last_access_ns)
+                    VALUES ('{DEFAULT_NAMESPACE}', {timestamp});
+                COMMIT;
+            """
+        )
+
+    def _close_connection(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -868,6 +868,7 @@ class ContextCacheDatabase:
         committed = False
         primary_error = None
         secondary_errors = []
+        post_commit_errors = []
         associations_removed = 0
         roots_removed = 0
         files_removed = 0
@@ -907,8 +908,8 @@ class ContextCacheDatabase:
             committed = True
             try:
                 self._maintain_after_clear()
-            except Exception:
-                pass
+            except Exception as error:
+                post_commit_errors.append(error)
         except BaseException as error:
             primary_error = error
             if connection.in_transaction:
@@ -921,7 +922,9 @@ class ContextCacheDatabase:
             try:
                 self._restore_normal_locking()
             except Exception as error:
-                if not committed:
+                if committed:
+                    post_commit_errors.append(error)
+                else:
                     secondary_errors.append(error)
             if secondary_errors:
                 cleanup_error = secondary_errors[0]
@@ -933,10 +936,8 @@ class ContextCacheDatabase:
                 if primary_error is not None:
                     raise primary_error from cleanup_error
                 raise cleanup_error
-        try:
-            after_bytes = self.aggregate_size_bytes()
-        except Exception:
-            after_bytes = before_bytes
+        after_bytes = self._measure_after_clear(post_commit_errors)
+        self._raise_post_commit_clear_failure(post_commit_errors)
         return ContextCacheClearReport(
             associations_removed=int(associations_removed),
             roots_removed=int(roots_removed),
@@ -945,26 +946,41 @@ class ContextCacheDatabase:
             after_bytes=after_bytes,
         )
 
-    def _maintain_after_clear(self) -> None:
-        """Best-effort physical reclaim after the logical clear committed."""
+    def _measure_after_clear(self, post_commit_errors: list[Exception]) -> int:
         try:
+            return self.aggregate_size_bytes()
+        except Exception as error:
+            post_commit_errors.append(error)
+            return 0
+
+    @staticmethod
+    def _raise_post_commit_clear_failure(errors: list[Exception]) -> None:
+        if not errors:
+            return
+        post_commit_error = errors[0]
+        if len(errors) > 1:
+            post_commit_error = ExceptionGroup(
+                "context cache clear post-commit failures",
+                errors,
+            )
+        raise CacheDatabaseUnavailable(
+            "context cache clear was committed but post-commit maintenance failed"
+        ) from post_commit_error
+
+    def _maintain_after_clear(self) -> None:
+        """Reclaim physical storage after the logical clear committed."""
+        checkpoint = self._checkpoint_wal()
+        if checkpoint[0] != 0:
+            raise CacheDatabaseUnavailable(
+                "context cache checkpoint remained busy after clear"
+            )
+        if self._freelist_pages():
+            self._run_bounded_vacuum()
             checkpoint = self._checkpoint_wal()
-            if checkpoint[0] == 0 and self._freelist_pages():
-                self._run_bounded_vacuum()
-                self._checkpoint_wal()
-        except sqlite3.OperationalError as error:
-            message = str(error).casefold()
-            code = getattr(error, "sqlite_errorcode", None)
-            locked_codes = {
-                value for value in (
-                    getattr(sqlite3, "SQLITE_BUSY", None),
-                    getattr(sqlite3, "SQLITE_LOCKED", None),
-                ) if value is not None
-            }
-            if ((code is None or code & 0xFF not in locked_codes)
-                    and "locked" not in message
-                    and "busy" not in message):
-                raise
+            if checkpoint[0] != 0:
+                raise CacheDatabaseUnavailable(
+                    "context cache checkpoint remained busy after vacuum"
+                )
 
     def begin_scan(self, namespace: str, canonical_root: str) -> ScanToken:
         """Return an immutable in-memory scan token without writing SQLite."""
@@ -1526,22 +1542,31 @@ class ContextCacheDatabase:
             for part in parts:
                 current = current / part
                 if current.exists():
-                    if self._is_link(current) or not current.is_dir():
-                        raise CacheDatabaseError("context cache directory is unsafe")
+                    self._validate_secure_directory(current)
                 else:
                     current.mkdir(mode=0o700)
+                    self._validate_secure_directory(current)
             return current
 
         if self._is_link(directory):
             raise CacheDatabaseError("context cache directory must not be a symlink")
         if directory.exists():
-            if not directory.is_dir():
-                raise CacheDatabaseError("context cache directory must be a directory")
+            self._validate_secure_directory(directory)
         else:
             if not directory.parent.is_dir() or self._is_link(directory.parent):
                 raise CacheDatabaseError("context cache directory parent must already exist")
             directory.mkdir(mode=0o700)
+            self._validate_secure_directory(directory)
         return directory
+
+    def _validate_secure_directory(self, directory: Path) -> None:
+        if self._is_link(directory) or not directory.is_dir():
+            raise CacheDatabaseError("context cache directory is unsafe")
+        if (_uses_posix_permissions()
+                and stat.S_IMODE(directory.stat().st_mode) & 0o077):
+            raise CacheDatabaseError(
+                "context cache directory permissions are unsafe"
+            )
 
     def _prepare_path(
         self,

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -1,6 +1,7 @@
 """Private SQLite bootstrap for the bounded text-context cache."""
 
 import os
+import re
 import sqlite3
 import stat
 import sys
@@ -18,6 +19,39 @@ BUSY_TIMEOUT_MS = 500
 _TABLE_NAMES = frozenset(
     {"metadata", "namespaces", "namespace_roots", "roots", "root_files", "files"}
 )
+
+_EXPECTED_COLUMNS = {
+    "metadata": (("key", "TEXT", 0, 1), ("value", "TEXT", 1, 0)),
+    "namespaces": (("id", "INTEGER", 0, 1), ("name", "TEXT", 1, 0),
+                   ("last_access_ns", "INTEGER", 1, 0)),
+    "roots": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
+              ("last_access_ns", "INTEGER", 1, 0)),
+    "namespace_roots": (("namespace_id", "INTEGER", 1, 1),
+                        ("root_id", "INTEGER", 1, 2)),
+    "files": (("id", "INTEGER", 0, 1), ("canonical_path", "TEXT", 1, 0),
+              ("device", "INTEGER", 0, 0), ("inode", "INTEGER", 0, 0),
+              ("size_bytes", "INTEGER", 1, 0), ("mtime_ns", "INTEGER", 1, 0),
+              ("ctime_ns", "INTEGER", 1, 0), ("state", "TEXT", 1, 0),
+              ("content_sha256", "TEXT", 0, 0), ("folded_text", "TEXT", 0, 0),
+              ("created_ns", "INTEGER", 1, 0), ("validated_ns", "INTEGER", 1, 0),
+              ("last_access_ns", "INTEGER", 1, 0)),
+    "root_files": (("root_id", "INTEGER", 1, 1), ("file_id", "INTEGER", 1, 2),
+                   ("relative_path", "TEXT", 1, 0),
+                   ("last_seen_scan", "TEXT", 1, 0)),
+}
+
+_EXPECTED_FOREIGN_KEYS = {
+    "namespace_roots": {("root_id", "roots", "id", "CASCADE"),
+                        ("namespace_id", "namespaces", "id", "CASCADE")},
+    "root_files": {("file_id", "files", "id", "CASCADE"),
+                   ("root_id", "roots", "id", "CASCADE")},
+}
+
+_EXPECTED_UNIQUE_COLUMNS = {
+    "namespaces": {("name",)},
+    "roots": {("canonical_path",)},
+    "files": {("canonical_path",)},
+}
 
 
 class CacheDatabaseError(RuntimeError):
@@ -56,9 +90,16 @@ class ContextCacheDatabase:
 
     def __enter__(self) -> "ContextCacheDatabase":
         try:
-            database_existed = self._prepare_path()
-            self._connection = sqlite3.connect(str(self.path), timeout=0.5)
-            self._configure_connection(database_existed)
+            database_is_empty, directory_identity, file_identity = self._prepare_path()
+            previous_umask = os.umask(0o077) if os.name != "nt" else None
+            try:
+                self._connection = sqlite3.connect(str(self.path), timeout=0.5)
+                self._validate_identity(directory_identity, file_identity)
+                self._configure_connection(database_is_empty)
+                self._validate_sidecars()
+            finally:
+                if previous_umask is not None:
+                    os.umask(previous_umask)
             self._verify_or_create_schema()
         except CacheDatabaseError:
             self._close_connection()
@@ -81,8 +122,54 @@ class ContextCacheDatabase:
             if not row[0].startswith("sqlite_")
         }
 
-    def _prepare_path(self) -> bool:
-        if self.path.is_symlink():
+    @staticmethod
+    def _identity(path: Path) -> tuple[int, int]:
+        result = path.stat(follow_symlinks=False)
+        return result.st_dev, result.st_ino
+
+    @staticmethod
+    def _is_link(path: Path) -> bool:
+        is_junction = getattr(path, "is_junction", None)
+        return path.is_symlink() or (is_junction is not None and is_junction())
+
+    def _prepare_directory(self) -> Path:
+        directory = self.path.parent
+        if self.path == default_cache_path():
+            if os.name == "nt":
+                base = Path(os.environ["LOCALAPPDATA"])
+                parts = ("Cereja", "cache")
+            elif sys.platform == "darwin":
+                base = Path.home() / "Library" / "Caches"
+                parts = ("Cereja",)
+            else:
+                cache_home = os.environ.get("XDG_CACHE_HOME")
+                base = Path(cache_home) if cache_home else Path.home() / ".cache"
+                parts = ("cereja",)
+            if self._is_link(base) or not base.is_dir():
+                raise CacheDatabaseError("context cache base directory is unsafe")
+            current = base
+            for part in parts:
+                current = current / part
+                if current.exists():
+                    if self._is_link(current) or not current.is_dir():
+                        raise CacheDatabaseError("context cache directory is unsafe")
+                else:
+                    current.mkdir(mode=0o700)
+            return current
+
+        if self._is_link(directory):
+            raise CacheDatabaseError("context cache directory must not be a symlink")
+        if directory.exists():
+            if not directory.is_dir():
+                raise CacheDatabaseError("context cache directory must be a directory")
+        else:
+            if not directory.parent.is_dir() or self._is_link(directory.parent):
+                raise CacheDatabaseError("context cache directory parent must already exist")
+            directory.mkdir(mode=0o700)
+        return directory
+
+    def _prepare_path(self) -> tuple[bool, tuple[int, int], tuple[int, int]]:
+        if self._is_link(self.path):
             raise CacheDatabaseError("context cache database must not be a symlink")
         try:
             mode = self.path.lstat().st_mode
@@ -93,28 +180,52 @@ class ContextCacheDatabase:
                 raise CacheDatabaseError("context cache database must be a regular file")
             database_existed = True
 
-        directory = self.path.parent
-        if directory.is_symlink():
-            raise CacheDatabaseError("context cache directory must not be a symlink")
-        if directory.exists() and not directory.is_dir():
-            raise CacheDatabaseError("context cache directory must be a directory")
-        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-        if os.name != "nt":
-            os.chmod(directory, 0o700)
-        return database_existed
+        directory = self._prepare_directory()
 
-    def _configure_connection(self, database_existed: bool) -> None:
+        directory_identity = self._identity(directory)
+        if not database_existed:
+            flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(self.path, flags, 0o600)
+            os.close(descriptor)
+        file_identity = self._identity(self.path)
+        self._validate_secure_file(self.path)
+        self._validate_sidecars()
+        database_is_empty = self.path.stat(follow_symlinks=False).st_size == 0
+        return database_is_empty, directory_identity, file_identity
+
+    def _validate_identity(
+        self, directory_identity: tuple[int, int], file_identity: tuple[int, int]
+    ) -> None:
+        if self._is_link(self.path) or self._is_link(self.path.parent):
+            raise CacheDatabaseError("context cache path identity changed")
+        if self._identity(self.path.parent) != directory_identity:
+            raise CacheDatabaseError("context cache directory identity changed")
+        if self._identity(self.path) != file_identity:
+            raise CacheDatabaseError("context cache database identity changed")
+
+    def _validate_secure_file(self, path: Path) -> None:
+        if self._is_link(path) or not path.is_file():
+            raise CacheDatabaseError("context cache file is unsafe")
+        if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) & 0o077:
+            raise CacheDatabaseError("context cache file permissions are unsafe")
+
+    def _validate_sidecars(self) -> None:
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{self.path}{suffix}")
+            if sidecar.exists() or self._is_link(sidecar):
+                self._validate_secure_file(sidecar)
+
+    def _configure_connection(self, database_is_empty: bool) -> None:
         connection = self.connection
         connection.execute("PRAGMA foreign_keys = ON")
+        if database_is_empty:
+            connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
+            connection.execute("VACUUM")
         journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
         if journal_mode.lower() != "wal":
             raise CacheDatabaseUnavailable("context cache database cannot enable WAL mode")
         connection.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
-        if not database_existed:
-            connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
-            connection.execute("VACUUM")
-            if os.name != "nt":
-                os.chmod(self.path, 0o600)
 
     def _verify_or_create_schema(self) -> None:
         application_id = self.connection.execute("PRAGMA application_id").fetchone()[0]
@@ -127,8 +238,54 @@ class ContextCacheDatabase:
             raise CacheDatabaseError("context cache database has an unknown application id")
         if schema_version != SCHEMA_VERSION:
             raise CacheDatabaseError("context cache database has an unsupported schema version")
+        if self.connection.execute("PRAGMA auto_vacuum").fetchone()[0] != 2:
+            raise CacheDatabaseError("context cache database auto_vacuum is incompatible")
         if tables != _TABLE_NAMES:
             raise CacheDatabaseError("context cache database schema is incomplete")
+        self._validate_schema_structure()
+        namespace = self.connection.execute(
+            "SELECT id FROM namespaces WHERE name = ?", (DEFAULT_NAMESPACE,)
+        ).fetchone()
+        if namespace is None:
+            raise CacheDatabaseError("context cache database default namespace is missing")
+
+    def _validate_schema_structure(self) -> None:
+        for table, expected in _EXPECTED_COLUMNS.items():
+            actual = tuple(
+                (row[1], row[2].upper(), row[3], row[5])
+                for row in self.connection.execute(f'PRAGMA table_info("{table}")')
+            )
+            if actual != expected:
+                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+        for table, expected in _EXPECTED_FOREIGN_KEYS.items():
+            actual = {
+                (row[3], row[2], row[4], row[6].upper())
+                for row in self.connection.execute(f'PRAGMA foreign_key_list("{table}")')
+            }
+            if actual != expected:
+                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+        for table, expected in _EXPECTED_UNIQUE_COLUMNS.items():
+            actual = set()
+            for index in self.connection.execute(f'PRAGMA index_list("{table}")'):
+                if index[2]:
+                    actual.add(tuple(
+                        row[2] for row in self.connection.execute(
+                            f'PRAGMA index_info("{index[1]}")'
+                        )
+                    ))
+            if actual != expected:
+                raise CacheDatabaseError(f"context cache database schema differs: {table}")
+        files_sql = self.connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'files'"
+        ).fetchone()[0]
+        state_check = re.search(
+            r"CHECK\s*\(\s*state\s+IN\s*\(([^)]*)\)\s*\)", files_sql, re.IGNORECASE
+        )
+        states = () if state_check is None else tuple(
+            item.strip().strip("'") for item in state_check.group(1).split(",")
+        )
+        if states != ("text", "binary_file", "invalid_utf8", "file_too_large"):
+            raise CacheDatabaseError("context cache database schema differs: files state")
 
     def _create_schema(self) -> None:
         timestamp = time.time_ns()

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -279,12 +279,125 @@ class ContextCacheDatabase:
         self._active_scans[scan_key] = scan_token
         return scan_token
 
+    def begin_scans_if_admitted(
+        self,
+        namespace: str,
+        canonical_roots: Iterable[str],
+        max_bytes: int,
+    ) -> dict[str, str] | None:
+        """Begin all root scans only when their minimum mutation fits quota."""
+        if max_bytes < 0:
+            raise ValueError("max_bytes must not be negative")
+        roots = tuple(dict.fromkeys(canonical_roots))
+        if not roots:
+            return {}
+        if self._checkpoint_wal()[0] != 0:
+            return None
+        if self.aggregate_size_bytes() >= max_bytes:
+            return None
+
+        connection = self.connection
+        timestamp = time.time_ns()
+        scans = {root: str(uuid.uuid4()) for root in roots}
+        generations = {}
+        connection.execute("PRAGMA cache_spill = OFF")
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            if self.aggregate_size_bytes() >= max_bytes:
+                connection.rollback()
+                return None
+            connection.execute(
+                """INSERT INTO namespaces (name, last_access_ns)
+                   VALUES (?, ?)
+                   ON CONFLICT(name) DO UPDATE SET
+                       last_access_ns = excluded.last_access_ns""",
+                (namespace, timestamp),
+            )
+            namespace_id = connection.execute(
+                "SELECT id FROM namespaces WHERE name = ?", (namespace,)
+            ).fetchone()[0]
+            for canonical_root in roots:
+                connection.execute(
+                    """INSERT INTO roots (
+                           canonical_path, last_access_ns, scan_generation
+                       ) VALUES (?, ?, 1)
+                       ON CONFLICT(canonical_path) DO UPDATE SET
+                           last_access_ns = excluded.last_access_ns,
+                           scan_generation = roots.scan_generation + 1""",
+                    (canonical_root, timestamp),
+                )
+                root_id, generation = connection.execute(
+                    """SELECT id, scan_generation FROM roots
+                       WHERE canonical_path = ?""",
+                    (canonical_root,),
+                ).fetchone()
+                generations[canonical_root] = generation
+                connection.execute(
+                    """INSERT INTO namespace_roots (namespace_id, root_id)
+                       VALUES (?, ?)
+                       ON CONFLICT(namespace_id, root_id) DO NOTHING""",
+                    (namespace_id, root_id),
+                )
+            if self._projected_aggregate_size() > max_bytes:
+                connection.rollback()
+                return None
+            connection.commit()
+            self._checkpoint_wal()
+        except BaseException:
+            if connection.in_transaction:
+                connection.rollback()
+            raise
+        finally:
+            connection.execute("PRAGMA cache_spill = ON")
+
+        for canonical_root, scan_token in scans.items():
+            scan_key = namespace, canonical_root
+            previous_token = self._active_scans.get(scan_key)
+            if previous_token is not None:
+                self._scans.pop(previous_token, None)
+            self._scans[scan_token] = (
+                namespace,
+                canonical_root,
+                generations[canonical_root],
+            )
+            self._active_scans[scan_key] = scan_token
+        return scans
+
+    def roots_requiring_scan(
+        self,
+        namespace: str,
+        roots_with_inventory: Iterable[tuple[str, bool]],
+    ) -> tuple[str, ...]:
+        """Return roots whose current inventory requires cache publication."""
+        required = []
+        for canonical_root, has_inventory in roots_with_inventory:
+            if has_inventory:
+                required.append(canonical_root)
+                continue
+            row = self.connection.execute(
+                """SELECT EXISTS (
+                           SELECT 1 FROM namespace_roots AS nr
+                           JOIN namespaces AS n ON n.id = nr.namespace_id
+                           JOIN roots AS r ON r.id = nr.root_id
+                           WHERE n.name = ? AND r.canonical_path = ?
+                       ), EXISTS (
+                           SELECT 1 FROM root_files AS rf
+                           JOIN roots AS r ON r.id = rf.root_id
+                           WHERE r.canonical_path = ?
+                       )""",
+                (namespace, canonical_root, canonical_root),
+            ).fetchone()
+            is_published, has_cached_files = map(bool, row)
+            if not is_published or has_cached_files:
+                required.append(canonical_root)
+        return tuple(required)
+
     def commit_scan(
         self,
         scan_token: str,
         files: Iterable[CachedFile],
         max_bytes: int | None = None,
-    ) -> tuple[CachedFile, ...]:
+    ) -> tuple[CachedFile, ...] | None:
         """Atomically publish the deterministic prefix admitted by quota."""
         if max_bytes is not None and max_bytes < 0:
             raise ValueError("max_bytes must not be negative")
@@ -297,9 +410,11 @@ class ContextCacheDatabase:
         connection = self.connection
         timestamp = time.time_ns()
         admitted = []
-        admission_open = (
-            max_bytes is None or self._checkpoint_wal()[0] == 0
-        )
+        if max_bytes is not None:
+            if self._checkpoint_wal()[0] != 0:
+                return None
+            if self.aggregate_size_bytes() >= max_bytes:
+                return None
         if max_bytes is not None:
             connection.execute("PRAGMA cache_spill = OFF")
         try:
@@ -337,8 +452,6 @@ class ContextCacheDatabase:
             )
 
             for cached_file in cached_files:
-                if not admission_open:
-                    break
                 if max_bytes is not None:
                     connection.execute("SAVEPOINT cache_admission")
                 signature = cached_file.signature
@@ -401,6 +514,10 @@ class ContextCacheDatabase:
                    WHERE root_id = ? AND last_seen_scan <> ?""",
                 (root_id, scan_token),
             )
+            if (max_bytes is not None
+                    and self._projected_aggregate_size() > max_bytes):
+                connection.rollback()
+                return None
             connection.commit()
             if max_bytes is not None:
                 self._checkpoint_wal()

--- a/cereja/system/_context/models.py
+++ b/cereja/system/_context/models.py
@@ -37,5 +37,29 @@ class ContextResponse:
     truncated: bool
 
 
+@dataclass(frozen=True, slots=True)
+class ContextCacheInfo:
+    path: str
+    schema_version: int
+    namespace: str
+    database_bytes: int
+    wal_bytes: int
+    shm_bytes: int
+    roots: int
+    files: int
+    text_files: int
+    skipped_files: int
+    last_access_ns: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ContextCacheClearReport:
+    associations_removed: int
+    roots_removed: int
+    files_removed: int
+    before_bytes: int
+    after_bytes: int
+
+
 class ContextCacheWarning(RuntimeWarning):
     """Warn that context search continued without its optional cache."""

--- a/cereja/system/_context/models.py
+++ b/cereja/system/_context/models.py
@@ -1,0 +1,41 @@
+"""Data models for textual context search."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSnippet:
+    line: int
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextResult:
+    path: str
+    root: str
+    relative_path: str
+    size_bytes: int
+    score: int
+    match_count: int
+    snippets: tuple[ContextSnippet, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedFile:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextResponse:
+    schema_version: int
+    mode: str
+    query: str | None
+    roots: tuple[str, ...]
+    results: tuple[ContextResult, ...]
+    skipped: tuple[SkippedFile, ...]
+    truncated: bool
+
+
+class ContextCacheWarning(RuntimeWarning):
+    """Warn that context search continued without its optional cache."""

--- a/cereja/system/_context/query.py
+++ b/cereja/system/_context/query.py
@@ -8,17 +8,41 @@ def build_search_result(
         terms, max_snippets, max_snippet_chars,
 ):
     """Return (ContextResult | None, snippets_truncated)."""
-    folded_text = text.casefold()
+    result = build_search_candidate(
+        path=path,
+        root=root,
+        relative_path=relative_path,
+        size_bytes=size_bytes,
+        folded_text=text.casefold(),
+        terms=terms,
+    )
+    if result is None:
+        return None, False
+    snippets, snippets_truncated = extract_snippets(
+        text, terms, max_snippets, max_snippet_chars
+    )
+    return ContextResult(
+        path=result.path,
+        root=result.root,
+        relative_path=result.relative_path,
+        size_bytes=result.size_bytes,
+        score=result.score,
+        match_count=result.match_count,
+        snippets=snippets,
+    ), snippets_truncated
+
+
+def build_search_candidate(
+        *, path, root, relative_path, size_bytes, folded_text, terms,
+):
+    """Build a snippet-free result from normalized searchable content."""
     counts = tuple(folded_text.count(term) for term in terms)
     if not all(counts):
-        return None, False
+        return None
     match_count = sum(counts)
     filename = relative_path.rsplit("/", 1)[-1].casefold()
     filename_hits = sum(term in filename for term in terms)
     score = filename_hits * 1000 + match_count
-    snippets, snippets_truncated = extract_snippets(
-        text, terms, max_snippets, max_snippet_chars
-    )
     return ContextResult(
         path=path,
         root=root,
@@ -26,8 +50,8 @@ def build_search_result(
         size_bytes=size_bytes,
         score=score,
         match_count=match_count,
-        snippets=snippets,
-    ), snippets_truncated
+        snippets=(),
+    )
 
 
 def extract_snippets(text, terms, max_snippets, max_snippet_chars):
@@ -53,10 +77,8 @@ def finalize_response(
         max_results, snippets_truncated,
 ):
     """Apply stable ordering, bounds, and response truncation."""
-    if mode == "search":
-        results.sort(key=lambda item: (-item.score, item.path.casefold(), item.path))
-    else:
-        results.sort(key=lambda item: (item.path.casefold(), item.path))
+    results = tuple(results)
+    selected_results = select_context_results(results, mode, max_results)
     sorted_skipped = tuple(
         sorted(skipped, key=lambda item: (item.path.casefold(), item.path))
     )
@@ -67,10 +89,25 @@ def finalize_response(
         mode=mode,
         query=query,
         roots=roots,
-        results=tuple(results[:max_results]),
+        results=selected_results,
         skipped=sorted_skipped[:max_results],
         truncated=results_truncated or skipped_truncated or snippets_truncated,
     )
+
+
+def order_context_results(results, mode):
+    """Return results in the stable order for search or list mode."""
+    key = (
+        (lambda item: (-item.score, item.path.casefold(), item.path))
+        if mode == "search"
+        else (lambda item: (item.path.casefold(), item.path))
+    )
+    return tuple(sorted(results, key=key))
+
+
+def select_context_results(results, mode, max_results):
+    """Return the bounded stable selection for search or list mode."""
+    return order_context_results(results, mode)[:max_results]
 
 
 def context_response_to_dict(response):

--- a/cereja/system/_context/query.py
+++ b/cereja/system/_context/query.py
@@ -1,0 +1,118 @@
+"""Pure query semantics for textual context search."""
+
+from .models import ContextResponse, ContextResult, ContextSnippet
+
+
+def build_search_result(
+        *, path, root, relative_path, size_bytes, text,
+        terms, max_snippets, max_snippet_chars,
+):
+    """Return (ContextResult | None, snippets_truncated)."""
+    folded_text = text.casefold()
+    counts = tuple(folded_text.count(term) for term in terms)
+    if not all(counts):
+        return None, False
+    match_count = sum(counts)
+    filename = relative_path.rsplit("/", 1)[-1].casefold()
+    filename_hits = sum(term in filename for term in terms)
+    score = filename_hits * 1000 + match_count
+    snippets, snippets_truncated = extract_snippets(
+        text, terms, max_snippets, max_snippet_chars
+    )
+    return ContextResult(
+        path=path,
+        root=root,
+        relative_path=relative_path,
+        size_bytes=size_bytes,
+        score=score,
+        match_count=match_count,
+        snippets=snippets,
+    ), snippets_truncated
+
+
+def extract_snippets(text, terms, max_snippets, max_snippet_chars):
+    """Return bounded snippets and whether content was omitted."""
+    matching = []
+    characters_truncated = False
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        folded_line = line.casefold()
+        if any(term in folded_line for term in terms):
+            matching.append(ContextSnippet(
+                line_number,
+                _snippet_window(line, folded_line, terms, max_snippet_chars),
+            ))
+            characters_truncated = characters_truncated or len(line) > max_snippet_chars
+    return (
+        tuple(matching[:max_snippets]),
+        len(matching) > max_snippets or characters_truncated,
+    )
+
+
+def finalize_response(
+        *, mode, query, roots, results, skipped,
+        max_results, snippets_truncated,
+):
+    """Apply stable ordering, bounds, and response truncation."""
+    if mode == "search":
+        results.sort(key=lambda item: (-item.score, item.path.casefold(), item.path))
+    else:
+        results.sort(key=lambda item: (item.path.casefold(), item.path))
+    sorted_skipped = tuple(
+        sorted(skipped, key=lambda item: (item.path.casefold(), item.path))
+    )
+    results_truncated = len(results) > max_results
+    skipped_truncated = len(sorted_skipped) > max_results
+    return ContextResponse(
+        schema_version=1,
+        mode=mode,
+        query=query,
+        roots=roots,
+        results=tuple(results[:max_results]),
+        skipped=sorted_skipped[:max_results],
+        truncated=results_truncated or skipped_truncated or snippets_truncated,
+    )
+
+
+def context_response_to_dict(response):
+    """Convert a context response into stable JSON schema version 1."""
+    return {
+        "schema_version": response.schema_version,
+        "mode": response.mode,
+        "query": response.query,
+        "roots": list(response.roots),
+        "results": [
+            {
+                "path": item.path,
+                "root": item.root,
+                "relative_path": item.relative_path,
+                "size_bytes": item.size_bytes,
+                "score": item.score,
+                "match_count": item.match_count,
+                "snippets": [
+                    {"line": snippet.line, "text": snippet.text}
+                    for snippet in item.snippets
+                ],
+            }
+            for item in response.results
+        ],
+        "skipped": [
+            {"path": item.path, "reason": item.reason}
+            for item in response.skipped
+        ],
+        "truncated": response.truncated,
+    }
+
+
+def _snippet_window(line, folded_line, terms, max_snippet_chars):
+    if len(line) <= max_snippet_chars:
+        return line
+    occurrences = [
+        (folded_line.find(term), term)
+        for term in terms
+        if folded_line.find(term) >= 0
+    ]
+    first_match, term = min(occurrences, key=lambda item: item[0])
+    leading_context = max(0, max_snippet_chars - len(term)) // 2
+    start = max(0, first_match - leading_context)
+    start = min(start, len(line) - max_snippet_chars)
+    return line[start:start + max_snippet_chars]

--- a/cereja/system/_context/search.py
+++ b/cereja/system/_context/search.py
@@ -91,6 +91,7 @@ def _collect_context(
         refresh_cache,
 ):
     root_values = tuple(roots)
+    extension_values = None if extensions is None else tuple(extensions)
     if cache:
         from .cache import _collect_cached_context
 
@@ -100,7 +101,7 @@ def _collect_context(
                 mode=mode,
                 query=query,
                 terms=terms,
-                extensions=extensions,
+                extensions=extension_values,
                 max_results=max_results,
                 max_snippets=max_snippets,
                 max_snippet_chars=max_snippet_chars,
@@ -118,7 +119,7 @@ def _collect_context(
         mode=mode,
         query=query,
         terms=terms,
-        extensions=extensions,
+        extensions=extension_values,
         max_results=max_results,
         max_snippets=max_snippets,
         max_snippet_chars=max_snippet_chars,

--- a/cereja/system/_context/search.py
+++ b/cereja/system/_context/search.py
@@ -1,9 +1,15 @@
 """Direct orchestration for bounded textual context search."""
 
 import os
+import warnings
 from pathlib import Path as NativePath
 
-from cereja.system._context.models import ContextResult, SkippedFile
+from cereja.system._context.cache_db import CacheDatabaseError
+from cereja.system._context.models import (
+    ContextCacheWarning,
+    ContextResult,
+    SkippedFile,
+)
 from cereja.system._context.query import build_search_result, finalize_response
 from cereja.system._repository_files import iter_repository_files
 
@@ -27,7 +33,7 @@ def search_text_context(
     if not terms:
         raise ValueError("query must not be empty")
     _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes)
-    return _collect_direct_context(
+    return _collect_context(
         roots,
         mode="search",
         query=str(query),
@@ -37,6 +43,8 @@ def search_text_context(
         max_snippets=max_snippets,
         max_snippet_chars=max_snippet_chars,
         max_file_bytes=max_file_bytes,
+        cache=cache,
+        refresh_cache=refresh_cache,
     )
 
 
@@ -53,7 +61,7 @@ def list_text_context(
     if refresh_cache and not cache:
         raise ValueError("refresh_cache requires cache=True")
     _validate_limits(max_results, 1, 1, max_file_bytes)
-    return _collect_direct_context(
+    return _collect_context(
         roots,
         mode="list",
         query=None,
@@ -62,6 +70,58 @@ def list_text_context(
         max_results=max_results,
         max_snippets=1,
         max_snippet_chars=1,
+        max_file_bytes=max_file_bytes,
+        cache=cache,
+        refresh_cache=refresh_cache,
+    )
+
+
+def _collect_context(
+        roots,
+        *,
+        mode,
+        query,
+        terms,
+        extensions,
+        max_results,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+        cache,
+        refresh_cache,
+):
+    root_values = tuple(roots)
+    if cache:
+        from .cache import _collect_cached_context
+
+        try:
+            return _collect_cached_context(
+                root_values,
+                mode=mode,
+                query=query,
+                terms=terms,
+                extensions=extensions,
+                max_results=max_results,
+                max_snippets=max_snippets,
+                max_snippet_chars=max_snippet_chars,
+                max_file_bytes=max_file_bytes,
+                refresh_cache=refresh_cache,
+            )
+        except CacheDatabaseError as error:
+            warnings.warn(
+                f"Context cache unavailable: {error}",
+                ContextCacheWarning,
+                stacklevel=3,
+            )
+    return _collect_direct_context(
+        root_values,
+        mode=mode,
+        query=query,
+        terms=terms,
+        extensions=extensions,
+        max_results=max_results,
+        max_snippets=max_snippets,
+        max_snippet_chars=max_snippet_chars,
         max_file_bytes=max_file_bytes,
     )
 

--- a/cereja/system/_context/search.py
+++ b/cereja/system/_context/search.py
@@ -1,0 +1,166 @@
+"""Direct orchestration for bounded textual context search."""
+
+import os
+from pathlib import Path as NativePath
+
+from cereja.system._context.models import ContextResult, SkippedFile
+from cereja.system._context.query import build_search_result, finalize_response
+from cereja.system._repository_files import iter_repository_files
+
+
+def search_text_context(
+        roots,
+        query,
+        *,
+        extensions=None,
+        max_results=10,
+        max_snippets=2,
+        max_snippet_chars=240,
+        max_file_bytes=1_048_576,
+        cache=False,
+        refresh_cache=False,
+):
+    """Search UTF-8 text using AND terms and bounded result snippets."""
+    if refresh_cache and not cache:
+        raise ValueError("refresh_cache requires cache=True")
+    terms = tuple(str(query).split())
+    if not terms:
+        raise ValueError("query must not be empty")
+    _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes)
+    return _collect_direct_context(
+        roots,
+        mode="search",
+        query=str(query),
+        terms=tuple(term.casefold() for term in terms),
+        extensions=extensions,
+        max_results=max_results,
+        max_snippets=max_snippets,
+        max_snippet_chars=max_snippet_chars,
+        max_file_bytes=max_file_bytes,
+    )
+
+
+def list_text_context(
+        roots,
+        *,
+        extensions=None,
+        max_results=10,
+        max_file_bytes=1_048_576,
+        cache=False,
+        refresh_cache=False,
+):
+    """List bounded metadata for UTF-8 text files without returning content."""
+    if refresh_cache and not cache:
+        raise ValueError("refresh_cache requires cache=True")
+    _validate_limits(max_results, 1, 1, max_file_bytes)
+    return _collect_direct_context(
+        roots,
+        mode="list",
+        query=None,
+        terms=(),
+        extensions=extensions,
+        max_results=max_results,
+        max_snippets=1,
+        max_snippet_chars=1,
+        max_file_bytes=max_file_bytes,
+    )
+
+
+def _collect_direct_context(
+        roots,
+        *,
+        mode,
+        query,
+        terms,
+        extensions,
+        max_results,
+        max_snippets,
+        max_snippet_chars,
+        max_file_bytes,
+):
+    """Inventory and read files without persistent cache."""
+    root_values = tuple(roots)
+    normalized_roots = tuple(_normalized_path(root) for root in root_values)
+    results = []
+    skipped = []
+    snippets_truncated = False
+    for repository_file in iter_repository_files(root_values, extensions=extensions):
+        path = repository_file.path.path
+        normalized_path = _normalized_path(path)
+        try:
+            size_bytes = os.path.getsize(path)
+            if size_bytes > max_file_bytes:
+                skipped.append(SkippedFile(normalized_path, "file_too_large"))
+                continue
+            with open(path, "rb") as file:
+                data = file.read(max_file_bytes + 1)
+        except PermissionError:
+            skipped.append(SkippedFile(normalized_path, "permission_denied"))
+            continue
+        except FileNotFoundError:
+            skipped.append(SkippedFile(normalized_path, "disappeared"))
+            continue
+        if len(data) > max_file_bytes:
+            skipped.append(SkippedFile(normalized_path, "file_too_large"))
+            continue
+        if b"\x00" in data:
+            skipped.append(SkippedFile(normalized_path, "binary_file"))
+            continue
+        try:
+            text = data.decode("utf-8-sig", errors="strict")
+        except UnicodeDecodeError:
+            skipped.append(SkippedFile(normalized_path, "invalid_utf8"))
+            continue
+
+        if mode == "search":
+            result, omitted = build_search_result(
+                path=normalized_path,
+                root=_normalized_path(repository_file.root.path),
+                relative_path=repository_file.relative_path,
+                size_bytes=size_bytes,
+                text=text,
+                terms=terms,
+                max_snippets=max_snippets,
+                max_snippet_chars=max_snippet_chars,
+            )
+            if result is None:
+                continue
+            snippets_truncated = snippets_truncated or omitted
+        else:
+            result = ContextResult(
+                path=normalized_path,
+                root=_normalized_path(repository_file.root.path),
+                relative_path=repository_file.relative_path,
+                size_bytes=size_bytes,
+                score=0,
+                match_count=0,
+                snippets=(),
+            )
+
+        results.append(result)
+
+    return finalize_response(
+        mode=mode,
+        query=query,
+        roots=normalized_roots,
+        results=results,
+        skipped=skipped,
+        max_results=max_results,
+        snippets_truncated=snippets_truncated,
+    )
+
+
+def _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes):
+    values = {
+        "max_results": max_results,
+        "max_snippets": max_snippets,
+        "max_snippet_chars": max_snippet_chars,
+        "max_file_bytes": max_file_bytes,
+    }
+    for name, value in values.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+
+
+def _normalized_path(value):
+    return NativePath(os.fspath(value)).absolute().as_posix()

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -1,9 +1,19 @@
 """Bounded textual context search for explicit repository roots."""
 
-from dataclasses import dataclass
 import os
 from pathlib import Path as NativePath
 
+from cereja.system._context.models import (
+    ContextResponse,
+    ContextResult,
+    ContextSnippet,
+    SkippedFile,
+)
+from cereja.system._context.query import (
+    build_search_result,
+    context_response_to_dict,
+    finalize_response,
+)
 from cereja.system._repository_files import iter_repository_files
 
 __all__ = [
@@ -15,40 +25,6 @@ __all__ = [
     "list_text_context",
     "context_response_to_dict",
 ]
-
-
-@dataclass(frozen=True, slots=True)
-class ContextSnippet:
-    line: int
-    text: str
-
-
-@dataclass(frozen=True, slots=True)
-class ContextResult:
-    path: str
-    root: str
-    relative_path: str
-    size_bytes: int
-    score: int
-    match_count: int
-    snippets: tuple[ContextSnippet, ...]
-
-
-@dataclass(frozen=True, slots=True)
-class SkippedFile:
-    path: str
-    reason: str
-
-
-@dataclass(frozen=True, slots=True)
-class ContextResponse:
-    schema_version: int
-    mode: str
-    query: str | None
-    roots: tuple[str, ...]
-    results: tuple[ContextResult, ...]
-    skipped: tuple[SkippedFile, ...]
-    truncated: bool
 
 
 def search_text_context(
@@ -160,114 +136,42 @@ def _collect_context(
             continue
 
         if mode == "search":
-            folded_text = text.casefold()
-            counts = tuple(folded_text.count(term) for term in terms)
-            if not all(counts):
-                continue
-            match_count = sum(counts)
-            filename = repository_file.path.name.casefold()
-            filename_hits = sum(term in filename for term in terms)
-            score = filename_hits * 1000 + match_count
-            snippets, omitted = _extract_snippets(
-                text, terms, max_snippets, max_snippet_chars
+            result, omitted = build_search_result(
+                path=normalized_path,
+                root=_normalized_path(repository_file.root.path),
+                relative_path=repository_file.relative_path,
+                size_bytes=size_bytes,
+                text=text,
+                terms=terms,
+                max_snippets=max_snippets,
+                max_snippet_chars=max_snippet_chars,
             )
+            if result is None:
+                continue
             snippets_truncated = snippets_truncated or omitted
         else:
-            match_count = 0
-            score = 0
-            snippets = ()
+            result = ContextResult(
+                path=normalized_path,
+                root=_normalized_path(repository_file.root.path),
+                relative_path=repository_file.relative_path,
+                size_bytes=size_bytes,
+                score=0,
+                match_count=0,
+                snippets=(),
+            )
 
-        results.append(ContextResult(
-            path=normalized_path,
-            root=_normalized_path(repository_file.root.path),
-            relative_path=repository_file.relative_path,
-            size_bytes=size_bytes,
-            score=score,
-            match_count=match_count,
-            snippets=snippets,
-        ))
+        results.append(result)
 
-    if mode == "search":
-        results.sort(key=lambda item: (-item.score, item.path.casefold(), item.path))
-    else:
-        results.sort(key=lambda item: (item.path.casefold(), item.path))
-    sorted_skipped = tuple(
-        sorted(skipped, key=lambda item: (item.path.casefold(), item.path))
-    )
-    results_truncated = len(results) > max_results
-    skipped_truncated = len(sorted_skipped) > max_results
-    return ContextResponse(
-        schema_version=1,
+    return finalize_response(
         mode=mode,
         query=query,
         roots=normalized_roots,
-        results=tuple(results[:max_results]),
-        skipped=sorted_skipped[:max_results],
-        truncated=results_truncated or skipped_truncated or snippets_truncated,
+        results=results,
+        skipped=skipped,
+        max_results=max_results,
+        snippets_truncated=snippets_truncated,
     )
-
-
-def _extract_snippets(text, terms, max_snippets, max_snippet_chars):
-    matching = []
-    characters_truncated = False
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        folded_line = line.casefold()
-        if any(term in folded_line for term in terms):
-            matching.append(ContextSnippet(
-                line_number,
-                _snippet_window(line, folded_line, terms, max_snippet_chars),
-            ))
-            characters_truncated = characters_truncated or len(line) > max_snippet_chars
-    return (
-        tuple(matching[:max_snippets]),
-        len(matching) > max_snippets or characters_truncated,
-    )
-
-
-def _snippet_window(line, folded_line, terms, max_snippet_chars):
-    if len(line) <= max_snippet_chars:
-        return line
-    occurrences = [
-        (folded_line.find(term), term)
-        for term in terms
-        if folded_line.find(term) >= 0
-    ]
-    first_match, term = min(occurrences, key=lambda item: item[0])
-    leading_context = max(0, max_snippet_chars - len(term)) // 2
-    start = max(0, first_match - leading_context)
-    start = min(start, len(line) - max_snippet_chars)
-    return line[start:start + max_snippet_chars]
 
 
 def _normalized_path(value):
     return NativePath(os.fspath(value)).absolute().as_posix()
-
-
-def context_response_to_dict(response):
-    """Convert a context response into the stable JSON schema version 1."""
-    return {
-        "schema_version": response.schema_version,
-        "mode": response.mode,
-        "query": response.query,
-        "roots": list(response.roots),
-        "results": [
-            {
-                "path": item.path,
-                "root": item.root,
-                "relative_path": item.relative_path,
-                "size_bytes": item.size_bytes,
-                "score": item.score,
-                "match_count": item.match_count,
-                "snippets": [
-                    {"line": snippet.line, "text": snippet.text}
-                    for snippet in item.snippets
-                ],
-            }
-            for item in response.results
-        ],
-        "skipped": [
-            {"path": item.path, "reason": item.reason}
-            for item in response.skipped
-        ],
-        "truncated": response.truncated,
-    }

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -1,18 +1,26 @@
 """Compatibility facade for bounded textual context search."""
 
 from cereja.system._context import (
+    ContextCacheClearReport,
+    ContextCacheInfo,
     ContextCacheWarning,
+    CacheDatabaseUnavailable,
     ContextResponse,
     ContextResult,
     ContextSnippet,
     SkippedFile,
+    clear_context_cache,
     context_response_to_dict,
+    get_context_cache_info,
     list_text_context,
     search_text_context,
 )
 
 __all__ = [
+    "ContextCacheInfo",
+    "ContextCacheClearReport",
     "ContextCacheWarning",
+    "CacheDatabaseUnavailable",
     "ContextSnippet",
     "ContextResult",
     "SkippedFile",
@@ -20,4 +28,6 @@ __all__ = [
     "search_text_context",
     "list_text_context",
     "context_response_to_dict",
+    "get_context_cache_info",
+    "clear_context_cache",
 ]

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -1,6 +1,7 @@
 """Compatibility facade for bounded textual context search."""
 
 from cereja.system._context import (
+    ContextCacheWarning,
     ContextResponse,
     ContextResult,
     ContextSnippet,
@@ -11,6 +12,7 @@ from cereja.system._context import (
 )
 
 __all__ = [
+    "ContextCacheWarning",
     "ContextSnippet",
     "ContextResult",
     "SkippedFile",

--- a/cereja/system/_context_search.py
+++ b/cereja/system/_context_search.py
@@ -1,20 +1,14 @@
-"""Bounded textual context search for explicit repository roots."""
+"""Compatibility facade for bounded textual context search."""
 
-import os
-from pathlib import Path as NativePath
-
-from cereja.system._context.models import (
+from cereja.system._context import (
     ContextResponse,
     ContextResult,
     ContextSnippet,
     SkippedFile,
-)
-from cereja.system._context.query import (
-    build_search_result,
     context_response_to_dict,
-    finalize_response,
+    list_text_context,
+    search_text_context,
 )
-from cereja.system._repository_files import iter_repository_files
 
 __all__ = [
     "ContextSnippet",
@@ -25,153 +19,3 @@ __all__ = [
     "list_text_context",
     "context_response_to_dict",
 ]
-
-
-def search_text_context(
-        roots,
-        query,
-        *,
-        extensions=None,
-        max_results=10,
-        max_snippets=2,
-        max_snippet_chars=240,
-        max_file_bytes=1_048_576,
-):
-    """Search UTF-8 text using AND terms and bounded result snippets."""
-    terms = tuple(str(query).split())
-    if not terms:
-        raise ValueError("query must not be empty")
-    _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes)
-    normalized_terms = tuple(term.casefold() for term in terms)
-    return _collect_context(
-        roots,
-        mode="search",
-        query=str(query),
-        terms=normalized_terms,
-        extensions=extensions,
-        max_results=max_results,
-        max_snippets=max_snippets,
-        max_snippet_chars=max_snippet_chars,
-        max_file_bytes=max_file_bytes,
-    )
-
-
-def list_text_context(
-        roots,
-        *,
-        extensions=None,
-        max_results=10,
-        max_file_bytes=1_048_576,
-):
-    """List bounded metadata for UTF-8 text files without returning content."""
-    _validate_limits(max_results, 1, 1, max_file_bytes)
-    return _collect_context(
-        roots,
-        mode="list",
-        query=None,
-        terms=(),
-        extensions=extensions,
-        max_results=max_results,
-        max_snippets=1,
-        max_snippet_chars=1,
-        max_file_bytes=max_file_bytes,
-    )
-
-
-def _validate_limits(max_results, max_snippets, max_snippet_chars, max_file_bytes):
-    values = {
-        "max_results": max_results,
-        "max_snippets": max_snippets,
-        "max_snippet_chars": max_snippet_chars,
-        "max_file_bytes": max_file_bytes,
-    }
-    for name, value in values.items():
-        if value <= 0:
-            raise ValueError(f"{name} must be greater than zero")
-
-
-def _collect_context(
-        roots,
-        *,
-        mode,
-        query,
-        terms,
-        extensions,
-        max_results,
-        max_snippets,
-        max_snippet_chars,
-        max_file_bytes,
-):
-    root_values = tuple(roots)
-    normalized_roots = tuple(_normalized_path(root) for root in root_values)
-    results = []
-    skipped = []
-    snippets_truncated = False
-    for repository_file in iter_repository_files(root_values, extensions=extensions):
-        path = repository_file.path.path
-        normalized_path = _normalized_path(path)
-        try:
-            size_bytes = os.path.getsize(path)
-            if size_bytes > max_file_bytes:
-                skipped.append(SkippedFile(normalized_path, "file_too_large"))
-                continue
-            with open(path, "rb") as file:
-                data = file.read(max_file_bytes + 1)
-        except PermissionError:
-            skipped.append(SkippedFile(normalized_path, "permission_denied"))
-            continue
-        except FileNotFoundError:
-            skipped.append(SkippedFile(normalized_path, "disappeared"))
-            continue
-        if len(data) > max_file_bytes:
-            skipped.append(SkippedFile(normalized_path, "file_too_large"))
-            continue
-        if b"\x00" in data:
-            skipped.append(SkippedFile(normalized_path, "binary_file"))
-            continue
-        try:
-            text = data.decode("utf-8-sig", errors="strict")
-        except UnicodeDecodeError:
-            skipped.append(SkippedFile(normalized_path, "invalid_utf8"))
-            continue
-
-        if mode == "search":
-            result, omitted = build_search_result(
-                path=normalized_path,
-                root=_normalized_path(repository_file.root.path),
-                relative_path=repository_file.relative_path,
-                size_bytes=size_bytes,
-                text=text,
-                terms=terms,
-                max_snippets=max_snippets,
-                max_snippet_chars=max_snippet_chars,
-            )
-            if result is None:
-                continue
-            snippets_truncated = snippets_truncated or omitted
-        else:
-            result = ContextResult(
-                path=normalized_path,
-                root=_normalized_path(repository_file.root.path),
-                relative_path=repository_file.relative_path,
-                size_bytes=size_bytes,
-                score=0,
-                match_count=0,
-                snippets=(),
-            )
-
-        results.append(result)
-
-    return finalize_response(
-        mode=mode,
-        query=query,
-        roots=normalized_roots,
-        results=results,
-        skipped=skipped,
-        max_results=max_results,
-        snippets_truncated=snippets_truncated,
-    )
-
-
-def _normalized_path(value):
-    return NativePath(os.fspath(value)).absolute().as_posix()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,12 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from cereja.cli import main
+from cereja.system import (
+    CacheDatabaseUnavailable,
+    ContextCacheClearReport,
+    ContextCacheInfo,
+    ContextResponse,
+)
 
 
 def compression_stats():
@@ -537,6 +543,83 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("--query", result.stderr)
+
+    def test_context_search_forwards_cache_flags(self):
+        response = ContextResponse(1, "search", "needle", ("C:/repo",), (), (), False)
+        with patch("cereja.cli.search_text_context", return_value=response) as search:
+            self.assertEqual(main([
+                "context", "search", "--root", ".", "--query", "needle",
+                "--cache", "--refresh-cache",
+            ]), 0)
+
+        self.assertTrue(search.call_args.kwargs["cache"])
+        self.assertTrue(search.call_args.kwargs["refresh_cache"])
+
+    def test_context_list_forwards_cache_flags(self):
+        response = ContextResponse(1, "list", None, ("C:/repo",), (), (), False)
+        with patch("cereja.cli.list_text_context", return_value=response) as list_context:
+            self.assertEqual(main([
+                "context", "list", "--root", ".", "--cache", "--refresh-cache",
+            ]), 0)
+
+        self.assertTrue(list_context.call_args.kwargs["cache"])
+        self.assertTrue(list_context.call_args.kwargs["refresh_cache"])
+
+    def test_context_cache_info_emits_json(self):
+        info = ContextCacheInfo(
+            "C:/cache/context.sqlite3", 1, "default", 10, 0, 0, 1, 2, 2, 0, 123
+        )
+        stdout = io.StringIO()
+
+        with patch("cereja.cli.get_context_cache_info", return_value=info), redirect_stdout(stdout):
+            exit_code = main(["context", "cache", "info", "--format", "json"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["schema_version"], 1)
+
+    def test_context_cache_info_emits_text_by_default(self):
+        info = ContextCacheInfo(
+            "C:/cache/context.sqlite3", 1, "default", 10, 0, 0, 1, 2, 2, 0, 123
+        )
+        stdout = io.StringIO()
+
+        with patch("cereja.cli.get_context_cache_info", return_value=info), redirect_stdout(stdout):
+            exit_code = main(["context", "cache", "info"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("path: C:/cache/context.sqlite3", stdout.getvalue())
+
+    def test_context_cache_clear_emits_json(self):
+        report = ContextCacheClearReport(3, 2, 5, 100, 20)
+        stdout = io.StringIO()
+
+        with patch("cereja.cli.clear_context_cache", return_value=report), redirect_stdout(stdout):
+            exit_code = main(["context", "cache", "clear", "--format", "json"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["files_removed"], 5)
+
+    def test_context_cache_clear_emits_text_by_default(self):
+        report = ContextCacheClearReport(3, 2, 5, 100, 20)
+        stdout = io.StringIO()
+
+        with patch("cereja.cli.clear_context_cache", return_value=report), redirect_stdout(stdout):
+            exit_code = main(["context", "cache", "clear"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("files_removed: 5", stdout.getvalue())
+
+    def test_context_cache_clear_reports_lock_failure(self):
+        stderr = io.StringIO()
+
+        with patch(
+            "cereja.cli.clear_context_cache",
+            side_effect=CacheDatabaseUnavailable("locked"),
+        ), redirect_stderr(stderr):
+            exit_code = main(["context", "cache", "clear"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("locked", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import tempfile
 import unittest
 import warnings
@@ -286,10 +287,16 @@ class ContextCacheTest(unittest.TestCase):
             (outer / "outer.txt").write_text("needle", encoding="utf-8")
             (inner / "inner.txt").write_text("needle", encoding="utf-8")
             cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                baseline = database.aggregate_size_bytes()
             with patch(
                 "cereja.system._context.cache.default_cache_path",
                 return_value=cache_path,
-            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", 0):
+            ), patch(
+                "cereja.system._context.cache.DEFAULT_MAX_BYTES",
+                baseline * 2 + 100_000,
+            ):
                 cached = search_text_context([outer, inner], "needle", cache=True)
             direct = search_text_context([outer, inner], "needle")
             self.assertEqual(cached, direct)
@@ -364,6 +371,132 @@ class ContextCacheTest(unittest.TestCase):
                 )
             self.assertEqual(warm, direct)
             self.assertEqual(reads, names[len(persisted):])
+
+    def test_busy_checkpoint_repeated_calls_do_not_mutate_cache(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.txt").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                reader = sqlite3.connect(cache_path)
+                try:
+                    reader.execute("BEGIN")
+                    reader.execute("SELECT COUNT(*) FROM roots").fetchone()
+                    seed = database.begin_scan(DEFAULT_NAMESPACE, "C:/seed")
+                    database.commit_scan(seed, [])
+                    baseline = database.aggregate_size_bytes()
+
+                    with patch(
+                        "cereja.system._context.cache.default_cache_path",
+                        return_value=cache_path,
+                    ), patch(
+                        "cereja.system._context.cache.DEFAULT_MAX_BYTES",
+                        baseline + 1_000_000,
+                    ):
+                        for _ in range(8):
+                            response = search_text_context(
+                                [root], "needle", cache=True
+                            )
+                            self.assertEqual(
+                                response.results[0].relative_path, "guide.txt"
+                            )
+
+                    self.assertEqual(database.aggregate_size_bytes(), baseline)
+                    self.assertIsNone(database.connection.execute(
+                        "SELECT id FROM roots WHERE canonical_path = ?",
+                        (cache_module._canonical_path(root),),
+                    ).fetchone())
+                finally:
+                    reader.close()
+
+    def test_full_overhead_skips_hundreds_of_empty_root_scans(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                quota = database.aggregate_size_bytes()
+            roots = []
+            for index in range(200):
+                root = Path(temp_dir) / "roots" / str(index)
+                root.mkdir(parents=True)
+                roots.append(root)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", quota):
+                for root in roots:
+                    response = list_text_context([root], cache=True)
+                    self.assertEqual(response.results, ())
+
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM roots"
+                    ).fetchone()[0],
+                    0,
+                )
+                self.assertLessEqual(database.aggregate_size_bytes(), quota)
+
+    def test_warm_empty_root_is_read_only_when_quota_has_space(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "empty"
+            root.mkdir()
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                list_text_context([root], cache=True)
+                with ContextCacheDatabase(cache_path) as database:
+                    database._checkpoint_wal()
+                    baseline = database.aggregate_size_bytes()
+                    generation = database.connection.execute(
+                        "SELECT scan_generation FROM roots WHERE canonical_path = ?",
+                        (cache_module._canonical_path(root),),
+                    ).fetchone()[0]
+
+                for _ in range(8):
+                    list_text_context([root], cache=True)
+
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                self.assertEqual(database.aggregate_size_bytes(), baseline)
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT scan_generation FROM roots WHERE canonical_path = ?",
+                        (cache_module._canonical_path(root),),
+                    ).fetchone()[0],
+                    generation,
+                )
+
+    def test_quota_below_unavoidable_overhead_uses_memory_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.txt").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path):
+                pass
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", 1):
+                cached = search_text_context([root], "needle", cache=True)
+            direct = search_text_context([root], "needle")
+            self.assertEqual(cached, direct)
+
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM roots"
+                    ).fetchone()[0],
+                    0,
+                )
 
     def test_list_cache_matches_direct_and_reuses_text_state(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -100,6 +100,41 @@ class ContextCacheTest(unittest.TestCase):
             CacheDatabaseUnavailable,
         )
 
+    def test_cache_path_inside_searched_root_warns_without_creating_cache(self):
+        for cache_relative_path in (
+                Path("context.sqlite3"),
+                Path(".cereja-cache") / "context.sqlite3",
+        ):
+            with self.subTest(cache_relative_path=cache_relative_path), \
+                    tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir) / "repo"
+                nested = root / "nested"
+                nested.mkdir(parents=True)
+                (root / "guide.md").write_text("needle", encoding="utf-8")
+                cache_path = root / cache_relative_path
+                if os.name == "nt":
+                    searched_root = Path(os.fspath(root).swapcase())
+                else:
+                    searched_root = nested / ".."
+
+                direct = search_text_context([searched_root], "needle")
+                with patch(
+                    "cereja.system._context.cache.default_cache_path",
+                    return_value=cache_path,
+                ), warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    cached = search_text_context(
+                        [searched_root], "needle", cache=True
+                    )
+
+                self.assertEqual(cached, direct)
+                self.assertTrue(any(
+                    item.category is ContextCacheWarning for item in caught
+                ))
+                self.assertFalse(cache_path.exists())
+                self.assertFalse(Path(f"{cache_path}-wal").exists())
+                self.assertFalse(Path(f"{cache_path}-shm").exists())
+
     def test_info_reports_metadata_without_content(self):
         self.assertTrue(hasattr(system_module, "get_context_cache_info"))
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -422,7 +457,7 @@ class ContextCacheTest(unittest.TestCase):
             self.assertEqual(owner.exitcode, 0)
             self.assertEqual(searcher.exitcode, 0)
 
-    def test_clear_succeeds_when_post_commit_checkpoint_reports_busy(self):
+    def test_clear_reports_post_commit_checkpoint_busy(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
@@ -438,9 +473,11 @@ class ContextCacheTest(unittest.TestCase):
                     "_checkpoint_wal",
                     return_value=(1, 0, 0),
                 ):
-                    report = system_module.clear_context_cache()
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
 
-            self.assertEqual(report.associations_removed, 1)
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(
                     database.connection.execute(
@@ -449,7 +486,7 @@ class ContextCacheTest(unittest.TestCase):
                     0,
                 )
 
-    def test_clear_succeeds_when_post_commit_checkpoint_raises_locked(self):
+    def test_clear_reports_post_commit_checkpoint_lock_failure(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
@@ -465,9 +502,11 @@ class ContextCacheTest(unittest.TestCase):
                     "_checkpoint_wal",
                     side_effect=sqlite3.OperationalError("database is locked"),
                 ):
-                    report = system_module.clear_context_cache()
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
 
-            self.assertEqual(report.associations_removed, 1)
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(
                     database.connection.execute(
@@ -476,7 +515,7 @@ class ContextCacheTest(unittest.TestCase):
                     0,
                 )
 
-    def test_clear_succeeds_when_lock_restore_fails_after_commit(self):
+    def test_clear_reports_lock_restore_failure_after_commit(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
@@ -492,9 +531,11 @@ class ContextCacheTest(unittest.TestCase):
                     "_restore_normal_locking",
                     side_effect=sqlite3.OperationalError("restore failed"),
                 ):
-                    report = system_module.clear_context_cache()
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
 
-            self.assertEqual(report.associations_removed, 1)
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(
                     database.connection.execute(
@@ -503,7 +544,7 @@ class ContextCacheTest(unittest.TestCase):
                     0,
                 )
 
-    def test_clear_succeeds_when_post_commit_maintenance_has_io_error(self):
+    def test_clear_reports_post_commit_maintenance_io_error(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
@@ -519,10 +560,11 @@ class ContextCacheTest(unittest.TestCase):
                     "_checkpoint_wal",
                     side_effect=sqlite3.OperationalError("disk I/O error"),
                 ):
-                    report = system_module.clear_context_cache()
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
 
-            self.assertEqual(report.associations_removed, 1)
-            self.assertGreater(report.before_bytes, 0)
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(
                     database.connection.execute(
@@ -531,7 +573,40 @@ class ContextCacheTest(unittest.TestCase):
                     0,
                 )
 
-    def test_clear_uses_before_size_when_post_commit_measurement_fails(self):
+    def test_clear_reports_post_commit_vacuum_failure(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_freelist_pages",
+                    return_value=1,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "_run_bounded_vacuum",
+                    side_effect=sqlite3.OperationalError("vacuum failed"),
+                ):
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
+
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
+    def test_clear_reports_post_commit_measurement_failure(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
@@ -559,10 +634,11 @@ class ContextCacheTest(unittest.TestCase):
                         OSError("measurement failed"),
                     ),
                 ):
-                    report = system_module.clear_context_cache()
+                    with self.assertRaisesRegex(
+                        CacheDatabaseUnavailable, "clear was committed"
+                    ):
+                        system_module.clear_context_cache()
 
-            self.assertEqual(report.before_bytes, before_bytes)
-            self.assertEqual(report.after_bytes, before_bytes)
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(
                     database.connection.execute(
@@ -632,6 +708,34 @@ class ContextCacheTest(unittest.TestCase):
                 [root], "ss", max_snippet_chars=1
             )
             self.assertEqual(cached, direct)
+
+    def test_cached_match_score_and_selection_characterization(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "b-auth.txt").write_text(
+                "AUTH cache\nauth cache", encoding="utf-8"
+            )
+            (root / "A-auth.txt").write_text(
+                "auth cache\nauth cache", encoding="utf-8"
+            )
+            (root / "ignored.txt").write_text("auth only", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                response = search_text_context(
+                    [root], "auth cache", cache=True, max_results=1
+                )
+
+            self.assertEqual(len(response.results), 1)
+            result = response.results[0]
+            self.assertEqual(result.relative_path, "A-auth.txt")
+            self.assertEqual(result.score, 1004)
+            self.assertEqual(result.match_count, 4)
+            self.assertTrue(response.truncated)
 
     def test_file_shared_by_multiple_roots_remains_a_warm_hit(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -957,6 +1061,58 @@ class ContextCacheTest(unittest.TestCase):
                     cache_module._canonical_path(inner),
                 },
             )
+
+    def test_quota_pressure_evicts_old_root_and_protects_active_new_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            old_root = base / "old"
+            new_root = base / "new"
+            old_root.mkdir()
+            new_root.mkdir()
+            (old_root / "old.txt").write_text(
+                "old " + "x" * 2_000_000, encoding="utf-8"
+            )
+            (new_root / "new.txt").write_text("new", encoding="utf-8")
+            cache_path = base / "cache" / "context.sqlite3"
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context(
+                    [old_root], "old", cache=True, max_file_bytes=3_000_000
+                )
+                search_text_context([new_root], "new", cache=True)
+
+                with ContextCacheDatabase(cache_path) as database:
+                    database._checkpoint_wal()
+                    quota = database.aggregate_size_bytes() - 1
+
+                with patch(
+                    "cereja.system._context.cache.DEFAULT_MAX_BYTES", quota
+                ):
+                    response = search_text_context(
+                        [new_root], "new", cache=True
+                    )
+
+            self.assertEqual(response.results[0].relative_path, "new.txt")
+            with ContextCacheDatabase(cache_path) as database:
+                database._checkpoint_wal()
+                roots = [
+                    row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots ORDER BY canonical_path"
+                    )
+                ]
+                files = [
+                    row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM files ORDER BY canonical_path"
+                    )
+                ]
+                aggregate = database.aggregate_size_bytes()
+
+            self.assertEqual(roots, [cache_module._canonical_path(new_root)])
+            self.assertEqual(files, [cache_module._canonical_path(new_root / "new.txt")])
+            self.assertLessEqual(aggregate, quota)
 
     def test_quota_admits_deterministic_prefix_and_keeps_cold_response_complete(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -3,9 +3,11 @@ import sqlite3
 import tempfile
 import unittest
 import warnings
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import patch
 
+import cereja.system as system_module
 from cereja.system import list_text_context, search_text_context
 from cereja.system._context import cache as cache_module
 from cereja.system._context.cache_db import (
@@ -17,6 +19,324 @@ from cereja.system._context.models import ContextCacheWarning
 
 
 class ContextCacheTest(unittest.TestCase):
+    def test_cache_unavailable_is_exported_through_public_facade(self):
+        self.assertIs(
+            system_module.CacheDatabaseUnavailable,
+            CacheDatabaseUnavailable,
+        )
+
+    def test_info_reports_metadata_without_content(self):
+        self.assertTrue(hasattr(system_module, "get_context_cache_info"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_path = Path(temp_dir) / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                info = system_module.get_context_cache_info()
+            self.assertEqual(info.path, cache_path.absolute().as_posix())
+            self.assertEqual(info.schema_version, 1)
+            self.assertEqual(info.namespace, "default")
+            self.assertEqual(info.database_bytes, 0)
+            self.assertEqual(info.wal_bytes, 0)
+            self.assertEqual(info.shm_bytes, 0)
+            self.assertEqual(info.roots, 0)
+            self.assertEqual(info.files, 0)
+            self.assertEqual(info.text_files, 0)
+            self.assertEqual(info.skipped_files, 0)
+            self.assertIsNone(info.last_access_ns)
+            self.assertFalse(hasattr(info, "folded_text"))
+            self.assertFalse(cache_path.exists())
+            with self.assertRaises(FrozenInstanceError):
+                info.files = 1
+
+    def test_info_reads_existing_cache_without_mutating_storage(self):
+        self.assertTrue(hasattr(system_module, "get_context_cache_info"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            (root / "binary.bin").write_bytes(b"\x00binary")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                storage_paths = (
+                    cache_path,
+                    Path(f"{cache_path}-wal"),
+                    Path(f"{cache_path}-shm"),
+                )
+                before = tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                )
+                info = system_module.get_context_cache_info()
+                after = tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                )
+            self.assertIsInstance(info, system_module.ContextCacheInfo)
+            self.assertEqual(info.database_bytes, cache_path.stat().st_size)
+            self.assertEqual(info.wal_bytes, 0)
+            self.assertEqual(info.shm_bytes, 0)
+            self.assertEqual(info.roots, 1)
+            self.assertEqual(info.files, 2)
+            self.assertEqual(info.text_files, 1)
+            self.assertEqual(info.skipped_files, 1)
+            self.assertIsInstance(info.last_access_ns, int)
+            self.assertEqual(after, before)
+
+    def test_info_rejects_unknown_main_before_creating_shared_memory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            cache_path = directory / "context.sqlite3"
+            with ContextCacheDatabase(source_path):
+                source_wal = Path(f"{source_path}-wal").read_bytes()
+                connection = sqlite3.connect(cache_path)
+                connection.execute("PRAGMA application_id = 12345")
+                connection.execute("CREATE TABLE foreign_data (value TEXT)")
+                connection.commit()
+                connection.close()
+                cache_wal = Path(f"{cache_path}-wal")
+                cache_wal.write_bytes(source_wal)
+                if os.name != "nt":
+                    cache_path.chmod(0o600)
+                    cache_wal.chmod(0o600)
+                before = (cache_path.read_bytes(), cache_wal.read_bytes())
+                with patch(
+                    "cereja.system._context.cache.default_cache_path",
+                    return_value=cache_path,
+                ), self.assertRaises(CacheDatabaseUnavailable):
+                    system_module.get_context_cache_info()
+
+                self.assertEqual(
+                    (cache_path.read_bytes(), cache_wal.read_bytes()), before
+                )
+                self.assertFalse(Path(f"{cache_path}-shm").exists())
+
+    def test_info_with_wal_uses_private_snapshot_without_storage_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            cache_path = directory / "context.sqlite3"
+            with ContextCacheDatabase(source_path) as source:
+                source.connection.execute(
+                    "INSERT INTO metadata VALUES ('marker', 'value')"
+                )
+                source.connection.commit()
+                cache_path.write_bytes(source_path.read_bytes())
+                cache_wal = Path(f"{cache_path}-wal")
+                cache_wal.write_bytes(
+                    Path(f"{source_path}-wal").read_bytes()
+                )
+            if os.name != "nt":
+                cache_path.chmod(0o600)
+                cache_wal.chmod(0o600)
+            before = {
+                item.name: item.read_bytes()
+                for item in directory.iterdir()
+                if item.name.startswith(cache_path.name)
+            }
+
+            info = ContextCacheDatabase.read_info(cache_path)
+
+            after = {
+                item.name: item.read_bytes()
+                for item in directory.iterdir()
+                if item.name.startswith(cache_path.name)
+            }
+            self.assertEqual(info.wal_bytes, len(before[cache_wal.name]))
+            self.assertEqual(after, before)
+
+    def test_clear_returns_physical_size_report(self):
+        self.assertTrue(hasattr(system_module, "clear_context_cache"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                report = system_module.clear_context_cache()
+            self.assertIsInstance(report, system_module.ContextCacheClearReport)
+            self.assertGreaterEqual(report.before_bytes, report.after_bytes)
+            self.assertGreaterEqual(report.associations_removed, 1)
+            self.assertGreaterEqual(report.roots_removed, 1)
+            self.assertGreaterEqual(report.files_removed, 1)
+            with self.assertRaises(FrozenInstanceError):
+                report.files_removed = 0
+
+    def test_clear_missing_cache_returns_zero_report_without_creating_it(self):
+        self.assertTrue(hasattr(system_module, "clear_context_cache"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_path = Path(temp_dir) / "missing" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                report = system_module.clear_context_cache()
+            self.assertEqual(
+                report,
+                system_module.ContextCacheClearReport(0, 0, 0, 0, 0),
+            )
+            self.assertFalse(cache_path.exists())
+
+    def test_clear_removes_only_default_namespace_associations(self):
+        self.assertTrue(hasattr(system_module, "clear_context_cache"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with ContextCacheDatabase(cache_path) as database:
+                    database.connection.execute(
+                        "INSERT INTO namespaces (name, last_access_ns) VALUES ('other', 1)"
+                    )
+                    database.connection.execute(
+                        """INSERT INTO namespace_roots (namespace_id, root_id)
+                           SELECT n.id, r.id FROM namespaces AS n, roots AS r
+                           WHERE n.name = 'other'"""
+                    )
+                    database.connection.commit()
+                report = system_module.clear_context_cache()
+            with ContextCacheDatabase(cache_path) as database:
+                associations = database.connection.execute(
+                    """SELECT n.name, COUNT(nr.root_id)
+                       FROM namespaces AS n
+                       LEFT JOIN namespace_roots AS nr ON nr.namespace_id = n.id
+                       GROUP BY n.name ORDER BY n.name"""
+                ).fetchall()
+                roots = database.connection.execute(
+                    "SELECT COUNT(*) FROM roots"
+                ).fetchone()[0]
+                files = database.connection.execute(
+                    "SELECT COUNT(*) FROM files"
+                ).fetchone()[0]
+            self.assertEqual(report.associations_removed, 1)
+            self.assertEqual(report.roots_removed, 0)
+            self.assertEqual(report.files_removed, 0)
+            self.assertEqual(associations, [("default", 0), ("other", 1)])
+            self.assertEqual(roots, 1)
+            self.assertEqual(files, 1)
+
+    def test_clear_lock_failure_raises_without_cache_warning(self):
+        self.assertTrue(hasattr(system_module, "clear_context_cache"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                blocker = sqlite3.connect(cache_path, timeout=0)
+                try:
+                    blocker.execute("BEGIN IMMEDIATE")
+                    with warnings.catch_warnings(record=True) as caught:
+                        warnings.simplefilter("always")
+                        with self.assertRaises(CacheDatabaseUnavailable):
+                            system_module.clear_context_cache()
+                finally:
+                    blocker.rollback()
+                    blocker.close()
+            self.assertFalse(any(
+                item.category is ContextCacheWarning for item in caught
+            ))
+
+    def test_clear_succeeds_when_post_commit_checkpoint_reports_busy(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_checkpoint_wal",
+                    return_value=(1, 0, 0),
+                ):
+                    report = system_module.clear_context_cache()
+
+            self.assertEqual(report.associations_removed, 1)
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
+    def test_clear_succeeds_when_post_commit_checkpoint_raises_locked(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_checkpoint_wal",
+                    side_effect=sqlite3.OperationalError("database is locked"),
+                ):
+                    report = system_module.clear_context_cache()
+
+            self.assertEqual(report.associations_removed, 1)
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
+    def test_clear_succeeds_when_lock_restore_fails_after_commit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_restore_normal_locking",
+                    side_effect=sqlite3.OperationalError("restore failed"),
+                ):
+                    report = system_module.clear_context_cache()
+
+            self.assertEqual(report.associations_removed, 1)
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
     def test_cold_and_warm_cache_equal_direct_response(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -1,0 +1,350 @@
+import os
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+from cereja.system import list_text_context, search_text_context
+from cereja.system._context import cache as cache_module
+from cereja.system._context.cache_db import (
+    DEFAULT_NAMESPACE,
+    CacheDatabaseUnavailable,
+    ContextCacheDatabase,
+)
+from cereja.system._context.models import ContextCacheWarning
+
+
+class ContextCacheTest(unittest.TestCase):
+    def test_cold_and_warm_cache_equal_direct_response(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("Auth cache\n", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                direct = search_text_context([root], "auth cache")
+                cold = search_text_context([root], "auth cache", cache=True)
+                warm = search_text_context([root], "auth cache", cache=True)
+            self.assertEqual(cold, direct)
+            self.assertEqual(warm, direct)
+            self.assertTrue(cache_path.exists())
+
+    def test_warm_cache_reopens_only_selected_winner_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "auth.txt").write_text("Auth cache", encoding="utf-8")
+            (root / "other.txt").write_text("unrelated", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "auth", cache=True)
+                original_read = cache_module._read_original_text
+                reads = []
+
+                def recording_read(path, max_file_bytes):
+                    reads.append(Path(path).name)
+                    return original_read(path, max_file_bytes)
+
+                with patch(
+                    "cereja.system._context.cache._read_original_text",
+                    side_effect=recording_read,
+                ):
+                    response = search_text_context([root], "auth", cache=True)
+            self.assertEqual(response.results[0].snippets[0].text, "Auth cache")
+            self.assertEqual(reads, ["auth.txt"])
+
+    def test_casefold_length_change_preserves_direct_truncation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "eszett.txt").write_text("ß", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                cached = search_text_context(
+                    [root], "ss", cache=True, max_snippet_chars=1
+                )
+            direct = search_text_context(
+                [root], "ss", max_snippet_chars=1
+            )
+            self.assertEqual(cached, direct)
+
+    def test_file_shared_by_multiple_roots_remains_a_warm_hit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "repo"
+            inner = outer / "nested"
+            inner.mkdir(parents=True)
+            (inner / "shared.txt").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([outer], "missing", cache=True)
+                search_text_context([inner], "missing", cache=True)
+                reads = self._record_cache_reads(
+                    lambda: search_text_context([outer], "missing", cache=True)
+                )
+            self.assertEqual(reads, [])
+
+    def test_database_lock_warns_and_falls_back_to_direct_search(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            with patch(
+                "cereja.system._context.cache.ContextCacheDatabase.__enter__",
+                side_effect=CacheDatabaseUnavailable("locked"),
+            ), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                response = search_text_context([root], "needle", cache=True)
+            self.assertEqual(
+                [item.relative_path for item in response.results], ["guide.md"]
+            )
+            self.assertTrue(
+                any(item.category is ContextCacheWarning for item in caught)
+            )
+
+    def test_database_fallback_reuses_materialized_root_generator(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            roots = (item for item in [root])
+            with patch(
+                "cereja.system._context.cache.ContextCacheDatabase.__enter__",
+                side_effect=CacheDatabaseUnavailable("locked"),
+            ), warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                response = search_text_context(roots, "needle", cache=True)
+            self.assertEqual(
+                [item.relative_path for item in response.results], ["guide.md"]
+            )
+
+    def test_mutation_lifecycle_remains_equal_to_direct_search(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            guide = root / "guide.md"
+            guide.write_text("alpha", encoding="utf-8")
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                self._assert_cached_equals_direct(root, "alpha")
+
+                added = root / "added.txt"
+                added.write_text("alpha added", encoding="utf-8")
+                self._assert_cached_equals_direct(root, "alpha")
+
+                guide.write_text("bravo", encoding="utf-8")
+                self._assert_cached_equals_direct(root, "bravo")
+
+                renamed = root / "renamed.txt"
+                added.rename(renamed)
+                self._assert_cached_equals_direct(root, "alpha")
+
+                renamed.unlink()
+                self._assert_cached_equals_direct(root, "alpha")
+
+                ignored = root / "ignored.txt"
+                ignored.write_text("alpha ignored", encoding="utf-8")
+                self._assert_cached_equals_direct(root, "alpha")
+                (root / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+                self._assert_cached_equals_direct(root, "alpha")
+
+                extension_response = search_text_context(
+                    [root], "bravo", cache=True, extensions=["txt"]
+                )
+                extension_direct = search_text_context(
+                    [root], "bravo", extensions=["txt"]
+                )
+                self.assertEqual(extension_response, extension_direct)
+
+    def test_same_size_timestamp_change_and_refresh_force_reprocessing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            changed = root / "changed.txt"
+            stable = root / "stable.txt"
+            changed.write_text("alpha", encoding="utf-8")
+            stable.write_text("stable", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "missing", cache=True)
+                previous = changed.stat().st_mtime_ns
+                changed.write_text("bravo", encoding="utf-8")
+                os.utime(changed, ns=(previous + 1_000_000, previous + 1_000_000))
+                reads = self._record_cache_reads(
+                    lambda: search_text_context([root], "missing", cache=True)
+                )
+                self.assertEqual(reads, ["changed.txt"])
+
+                refreshed_reads = self._record_cache_reads(
+                    lambda: search_text_context(
+                        [root], "missing", cache=True, refresh_cache=True
+                    )
+                )
+                self.assertEqual(refreshed_reads, ["changed.txt", "stable.txt"])
+
+    def test_transient_read_failure_is_reported_but_not_persisted(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_read = cache_module._read_cacheable_file
+            failed_once = False
+
+            def transient_read(path, signature, max_file_bytes):
+                nonlocal failed_once
+                if Path(path).name == "target.txt" and not failed_once:
+                    failed_once = True
+                    raise FileNotFoundError(path)
+                return original_read(path, signature, max_file_bytes)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache._read_cacheable_file",
+                side_effect=transient_read,
+            ):
+                first = search_text_context([root], "needle", cache=True)
+                second = search_text_context([root], "needle", cache=True)
+            self.assertEqual(first.results, ())
+            self.assertEqual(first.skipped[0].reason, "disappeared")
+            self.assertEqual(second.results[0].relative_path, "target.txt")
+
+    def test_failed_inventory_does_not_destructively_synchronize_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                target.unlink()
+
+                def failing_inventory(*args, **kwargs):
+                    raise OSError("inventory failed")
+                    yield
+
+                with patch(
+                    "cereja.system._context.cache.iter_repository_files",
+                    side_effect=failing_inventory,
+                ):
+                    with self.assertRaisesRegex(OSError, "inventory failed"):
+                        search_text_context([root], "needle", cache=True)
+
+            with ContextCacheDatabase(cache_path) as database:
+                cached = tuple(database.iter_root_files(
+                    DEFAULT_NAMESPACE, cache_module._canonical_path(root)
+                ))
+            self.assertEqual([item.relative_path for item in cached], ["target.txt"])
+
+    def test_quota_preserves_all_active_overlapping_roots(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "repo"
+            inner = outer / "nested"
+            inner.mkdir(parents=True)
+            (outer / "outer.txt").write_text("needle", encoding="utf-8")
+            (inner / "inner.txt").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", 0):
+                cached = search_text_context([outer, inner], "needle", cache=True)
+            direct = search_text_context([outer, inner], "needle")
+            self.assertEqual(cached, direct)
+
+            with ContextCacheDatabase(cache_path) as database:
+                roots = {
+                    row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots"
+                    )
+                }
+            self.assertEqual(
+                roots,
+                {
+                    cache_module._canonical_path(outer),
+                    cache_module._canonical_path(inner),
+                },
+            )
+
+    def test_list_cache_matches_direct_and_reuses_text_state(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("guide", encoding="utf-8-sig")
+            (root / "data.bin").write_bytes(b"binary\x00data")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                cold = list_text_context([root], cache=True)
+                reads = self._record_cache_reads(
+                    lambda: list_text_context([root], cache=True)
+                )
+            self.assertEqual(cold, list_text_context([root]))
+            self.assertEqual(reads, [])
+
+    def test_external_input_and_interrupt_errors_are_not_masked(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "missing"
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with self.assertRaises(FileNotFoundError):
+                    search_text_context([missing], "needle", cache=True)
+            self.assertFalse(caught)
+
+            with patch(
+                "cereja.system._context.cache.iter_repository_files",
+                side_effect=KeyboardInterrupt,
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    search_text_context([Path(temp_dir)], "needle", cache=True)
+
+    def _assert_cached_equals_direct(self, root, query):
+        self.assertEqual(
+            search_text_context([root], query, cache=True),
+            search_text_context([root], query),
+        )
+
+    def _record_cache_reads(self, action):
+        original_read = cache_module._read_cacheable_file
+        reads = []
+
+        def recording_read(path, signature, max_file_bytes):
+            reads.append(Path(path).name)
+            return original_read(path, signature, max_file_bytes)
+
+        with patch(
+            "cereja.system._context.cache._read_cacheable_file",
+            side_effect=recording_read,
+        ):
+            action()
+        return reads
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -128,6 +128,24 @@ class ContextCacheTest(unittest.TestCase):
                 [item.relative_path for item in response.results], ["guide.md"]
             )
 
+    def test_database_fallback_reuses_materialized_extensions_generator(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            (root / "other.txt").write_text("needle", encoding="utf-8")
+            extensions = (item for item in ["md"])
+            with patch(
+                "cereja.system._context.cache.ContextCacheDatabase.__enter__",
+                side_effect=CacheDatabaseUnavailable("locked"),
+            ), warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                response = search_text_context(
+                    [root], "needle", cache=True, extensions=extensions
+                )
+            self.assertEqual(
+                [item.relative_path for item in response.results], ["guide.md"]
+            )
+
     def test_mutation_lifecycle_remains_equal_to_direct_search(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
@@ -289,6 +307,63 @@ class ContextCacheTest(unittest.TestCase):
                     cache_module._canonical_path(inner),
                 },
             )
+
+    def test_quota_admits_deterministic_prefix_and_keeps_cold_response_complete(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            names = [f"{index}.txt" for index in range(8)]
+            for index, name in enumerate(names):
+                (root / name).write_text(
+                    ("unrelated" if index < 4 else "needle")
+                    + f" {index} " + chr(65 + index) * 12_000,
+                    encoding="utf-8",
+                )
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path) as database:
+                database.enforce_quota((), max_bytes=10 ** 9)
+                baseline = database.aggregate_size_bytes()
+            quota = baseline * 2 + 40_000
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", quota):
+                cold = search_text_context(
+                    [root], "needle", cache=True, max_results=20
+                )
+                direct = search_text_context([root], "needle", max_results=20)
+                self.assertEqual(cold, direct)
+
+                with ContextCacheDatabase(cache_path) as database:
+                    persisted = tuple(row[0] for row in database.connection.execute(
+                        """SELECT rf.relative_path
+                           FROM root_files AS rf
+                           JOIN roots AS r ON r.id = rf.root_id
+                           WHERE r.canonical_path = ?
+                           ORDER BY rf.relative_path""",
+                        (cache_module._canonical_path(root),),
+                    ))
+                    database._checkpoint_wal()
+                    aggregate = database.aggregate_size_bytes()
+                self.assertGreater(len(persisted), 0)
+                self.assertLess(len(persisted), len(names))
+                self.assertLessEqual(aggregate, quota)
+                self.assertEqual(
+                    list(persisted),
+                    names[:len(persisted)],
+                )
+
+                reads = self._record_cache_reads(
+                    lambda: search_text_context(
+                        [root], "needle", cache=True, max_results=20
+                    )
+                )
+                warm = search_text_context(
+                    [root], "needle", cache=True, max_results=20
+                )
+            self.assertEqual(warm, direct)
+            self.assertEqual(reads, names[len(persisted):])
 
     def test_list_cache_matches_direct_and_reuses_text_state(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -1,6 +1,8 @@
+import multiprocessing
 import os
 import sqlite3
 import tempfile
+import time
 import unittest
 import warnings
 from dataclasses import FrozenInstanceError
@@ -16,6 +18,79 @@ from cereja.system._context.cache_db import (
     ContextCacheDatabase,
 )
 from cereja.system._context.models import ContextCacheWarning
+
+
+def _active_sidecar_snapshot(sidecars, modes=None):
+    """Read active sidecars, using stable metadata for locked Windows SHM."""
+    snapshots = []
+    selected_modes = []
+    for index, sidecar in enumerate(sidecars):
+        mode = None if modes is None else modes[index]
+        if mode != "metadata":
+            try:
+                snapshots.append(("bytes", sidecar.read_bytes()))
+                selected_modes.append("bytes")
+                continue
+            except PermissionError:
+                if (mode == "bytes" or os.name != "nt"
+                        or not sidecar.name.endswith("-shm")):
+                    raise
+        result = sidecar.stat(follow_symlinks=False)
+        snapshots.append((
+            "metadata",
+            result.st_dev,
+            result.st_ino,
+            result.st_size,
+            result.st_mtime_ns,
+        ))
+        selected_modes.append("metadata")
+    return tuple(snapshots), tuple(selected_modes)
+
+
+def _hold_cache_write_transaction(
+        cache_path, ready, observe, release, result_queue):
+    """Hold a real SQLite write transaction until the parent releases it."""
+    try:
+        with ContextCacheDatabase(cache_path) as database:
+            database.connection.execute("BEGIN IMMEDIATE")
+            sidecars = tuple(
+                Path(f"{cache_path}{suffix}")
+                for suffix in ("-wal", "-shm")
+            )
+            if not all(path.exists() for path in sidecars):
+                raise RuntimeError("write transaction did not create WAL/SHM")
+            before, modes = _active_sidecar_snapshot(sidecars)
+            ready.set()
+            if not observe.wait(10):
+                raise TimeoutError("parent did not request sidecar observation")
+            after, _ = _active_sidecar_snapshot(sidecars, modes)
+            result_queue.put(("ok", before, after, modes))
+            if not release.wait(10):
+                raise TimeoutError("parent did not release write transaction")
+            database.connection.rollback()
+    except BaseException as error:
+        ready.set()
+        result_queue.put(("error", repr(error)))
+
+
+def _search_with_cache_in_process(cache_path, root, result_queue):
+    """Run one public cached search in an importable spawned worker."""
+    try:
+        started = time.perf_counter()
+        with patch(
+            "cereja.system._context.cache.default_cache_path",
+            return_value=Path(cache_path),
+        ), warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            response = search_text_context([Path(root)], "needle", cache=True)
+        result_queue.put((
+            "ok",
+            time.perf_counter() - started,
+            tuple(item.category.__name__ for item in caught),
+            response,
+        ))
+    except BaseException as error:
+        result_queue.put(("error", repr(error)))
 
 
 class ContextCacheTest(unittest.TestCase):
@@ -272,6 +347,80 @@ class ContextCacheTest(unittest.TestCase):
             self.assertFalse(any(
                 item.category is ContextCacheWarning for item in caught
             ))
+
+    def test_concurrent_writer_sidecars_force_fast_read_only_fallback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.txt").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            direct = search_text_context([root], "needle")
+            context = multiprocessing.get_context("spawn")
+            ready = context.Event()
+            observe = context.Event()
+            release = context.Event()
+            owner_results = context.Queue()
+            search_results = context.Queue()
+            owner = context.Process(
+                target=_hold_cache_write_transaction,
+                args=(cache_path, ready, observe, release, owner_results),
+            )
+            searcher = context.Process(
+                target=_search_with_cache_in_process,
+                args=(cache_path, root, search_results),
+            )
+
+            owner.start()
+            try:
+                self.assertTrue(ready.wait(10), "writer process did not start")
+                sidecars = tuple(
+                    Path(f"{cache_path}{suffix}")
+                    for suffix in ("-wal", "-shm")
+                )
+                if not all(path.exists() for path in sidecars):
+                    observe.set()
+                    self.fail(owner_results.get(timeout=2))
+
+                searcher_started = time.perf_counter()
+                searcher.start()
+                searcher.join(10)
+                process_elapsed = time.perf_counter() - searcher_started
+                self.assertFalse(
+                    searcher.is_alive(), "cached search process did not finish"
+                )
+                self.assertLess(process_elapsed, 5)
+                result = search_results.get(timeout=2)
+                self.assertEqual(result[0], "ok", result)
+                _, elapsed, warning_categories, response = result
+                self.assertLess(elapsed, 5)
+                self.assertEqual(
+                    warning_categories, (ContextCacheWarning.__name__,)
+                )
+                self.assertEqual(response, direct)
+                observe.set()
+                owner_result = owner_results.get(timeout=2)
+                self.assertEqual(owner_result[0], "ok", owner_result)
+                _, before, after, modes = owner_result
+                self.assertEqual(modes[0], "bytes")
+                if os.name != "nt":
+                    self.assertEqual(modes, ("bytes", "bytes"))
+                self.assertEqual(after, before)
+            finally:
+                observe.set()
+                release.set()
+                if searcher.pid is not None:
+                    if searcher.is_alive():
+                        searcher.terminate()
+                    searcher.join(10)
+                owner.join(10)
+                if owner.is_alive():
+                    owner.terminate()
+                    owner.join(10)
+                owner_results.close()
+                search_results.close()
+
+            self.assertEqual(owner.exitcode, 0)
+            self.assertEqual(searcher.exitcode, 0)
 
     def test_clear_succeeds_when_post_commit_checkpoint_reports_busy(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -751,17 +900,21 @@ class ContextCacheTest(unittest.TestCase):
             ):
                 search_text_context([root], "needle", cache=True)
                 target.unlink()
+                (root / "partial.txt").write_text("needle", encoding="utf-8")
+                original_inventory = cache_module.iter_repository_files
 
                 def failing_inventory(*args, **kwargs):
+                    yield next(iter(original_inventory(*args, **kwargs)))
                     raise OSError("inventory failed")
-                    yield
 
                 with patch(
                     "cereja.system._context.cache.iter_repository_files",
                     side_effect=failing_inventory,
-                ):
+                ), warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
                     with self.assertRaisesRegex(OSError, "inventory failed"):
                         search_text_context([root], "needle", cache=True)
+                self.assertFalse(caught)
 
             with ContextCacheDatabase(cache_path) as database:
                 cached = tuple(database.iter_root_files(
@@ -968,11 +1121,15 @@ class ContextCacheTest(unittest.TestCase):
                     generation,
                 )
 
-    def test_quota_below_unavoidable_overhead_uses_memory_without_mutation(self):
+    def test_active_root_over_quota_stays_searchable_without_admission(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
             root.mkdir()
-            (root / "guide.txt").write_text("needle", encoding="utf-8")
+            for index in range(4):
+                (root / f"{index}.txt").write_text(
+                    f"needle {index} " + "x" * 4_096,
+                    encoding="utf-8",
+                )
             cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
             with ContextCacheDatabase(cache_path):
                 pass
@@ -980,10 +1137,16 @@ class ContextCacheTest(unittest.TestCase):
             with patch(
                 "cereja.system._context.cache.default_cache_path",
                 return_value=cache_path,
-            ), patch("cereja.system._context.cache.DEFAULT_MAX_BYTES", 1):
+            ), patch(
+                "cereja.system._context.cache.DEFAULT_MAX_BYTES", 8 * 1024
+            ):
                 cached = search_text_context([root], "needle", cache=True)
             direct = search_text_context([root], "needle")
             self.assertEqual(cached, direct)
+            self.assertEqual(
+                [result.relative_path for result in cached.results],
+                ["0.txt", "1.txt", "2.txt", "3.txt"],
+            )
 
             with ContextCacheDatabase(cache_path) as database:
                 self.assertEqual(

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -117,38 +117,32 @@ class ContextCacheTest(unittest.TestCase):
                 )
                 self.assertFalse(Path(f"{cache_path}-shm").exists())
 
-    def test_info_with_wal_uses_private_snapshot_without_storage_mutation(self):
+    def test_info_rejects_legitimate_active_wal_without_storage_mutation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            directory = Path(temp_dir)
-            source_path = directory / "source.sqlite3"
-            cache_path = directory / "context.sqlite3"
-            with ContextCacheDatabase(source_path) as source:
-                source.connection.execute(
+            cache_path = Path(temp_dir) / "context.sqlite3"
+            owner = ContextCacheDatabase(cache_path)
+            owner.__enter__()
+            try:
+                owner.connection.execute(
                     "INSERT INTO metadata VALUES ('marker', 'value')"
                 )
-                source.connection.commit()
-                cache_path.write_bytes(source_path.read_bytes())
-                cache_wal = Path(f"{cache_path}-wal")
-                cache_wal.write_bytes(
-                    Path(f"{source_path}-wal").read_bytes()
-                )
-            if os.name != "nt":
-                cache_path.chmod(0o600)
-                cache_wal.chmod(0o600)
-            before = {
-                item.name: item.read_bytes()
-                for item in directory.iterdir()
-                if item.name.startswith(cache_path.name)
-            }
+                owner.connection.commit()
+                before = {
+                    item.name: item.read_bytes()
+                    for item in cache_path.parent.iterdir()
+                    if item.name.startswith(cache_path.name)
+                }
 
-            info = ContextCacheDatabase.read_info(cache_path)
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    ContextCacheDatabase.read_info(cache_path)
 
-            after = {
-                item.name: item.read_bytes()
-                for item in directory.iterdir()
-                if item.name.startswith(cache_path.name)
-            }
-            self.assertEqual(info.wal_bytes, len(before[cache_wal.name]))
+                after = {
+                    item.name: item.read_bytes()
+                    for item in cache_path.parent.iterdir()
+                    if item.name.startswith(cache_path.name)
+                }
+            finally:
+                owner.__exit__(None, None, None)
             self.assertEqual(after, before)
 
     def test_clear_returns_physical_size_report(self):
@@ -186,6 +180,29 @@ class ContextCacheTest(unittest.TestCase):
                 system_module.ContextCacheClearReport(0, 0, 0, 0, 0),
             )
             self.assertFalse(cache_path.exists())
+
+    def test_info_and_clear_reject_orphan_sqlite_sidecars(self):
+        for suffix in ("-wal", "-shm", "-journal"):
+            with self.subTest(suffix=suffix), \
+                 tempfile.TemporaryDirectory() as temp_dir:
+                cache_path = Path(temp_dir) / "context.sqlite3"
+                sidecar = Path(f"{cache_path}{suffix}")
+                sidecar.write_bytes(b"orphan cache sentinel")
+                if os.name != "nt":
+                    sidecar.chmod(0o600)
+                before = sidecar.read_bytes()
+
+                with patch(
+                    "cereja.system._context.cache.default_cache_path",
+                    return_value=cache_path,
+                ):
+                    with self.assertRaises(CacheDatabaseUnavailable):
+                        system_module.get_context_cache_info()
+                    with self.assertRaises(CacheDatabaseUnavailable):
+                        system_module.clear_context_cache()
+
+                self.assertFalse(cache_path.exists())
+                self.assertEqual(sidecar.read_bytes(), before)
 
     def test_clear_removes_only_default_namespace_associations(self):
         self.assertTrue(hasattr(system_module, "clear_context_cache"))
@@ -337,6 +354,74 @@ class ContextCacheTest(unittest.TestCase):
                     0,
                 )
 
+    def test_clear_succeeds_when_post_commit_maintenance_has_io_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_checkpoint_wal",
+                    side_effect=sqlite3.OperationalError("disk I/O error"),
+                ):
+                    report = system_module.clear_context_cache()
+
+            self.assertEqual(report.associations_removed, 1)
+            self.assertGreater(report.before_bytes, 0)
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
+    def test_clear_uses_before_size_when_post_commit_measurement_fails(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                before_bytes = sum(
+                    path.stat().st_size
+                    for path in (
+                        cache_path,
+                        Path(f"{cache_path}-wal"),
+                        Path(f"{cache_path}-shm"),
+                    )
+                    if path.exists()
+                )
+                with patch.object(
+                    ContextCacheDatabase,
+                    "aggregate_size_bytes",
+                    side_effect=(
+                        before_bytes,
+                        OSError("measurement failed"),
+                    ),
+                ):
+                    report = system_module.clear_context_cache()
+
+            self.assertEqual(report.before_bytes, before_bytes)
+            self.assertEqual(report.after_bytes, before_bytes)
+            with ContextCacheDatabase(cache_path) as database:
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM namespace_roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
     def test_cold_and_warm_cache_equal_direct_response(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
@@ -433,6 +518,91 @@ class ContextCacheTest(unittest.TestCase):
             self.assertTrue(
                 any(item.category is ContextCacheWarning for item in caught)
             )
+
+    def test_recognized_corruption_warns_and_falls_back_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with ContextCacheDatabase(cache_path):
+                pass
+            cache_path.write_bytes(cache_path.read_bytes()[:128])
+            storage_paths = (
+                cache_path,
+                Path(f"{cache_path}-wal"),
+                Path(f"{cache_path}-shm"),
+                Path(f"{cache_path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            )
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                response = search_text_context([root], "needle", cache=True)
+
+            self.assertEqual(
+                [item.relative_path for item in response.results], ["guide.md"]
+            )
+            self.assertTrue(
+                any(item.category is ContextCacheWarning for item in caught)
+            )
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            ), before)
+
+    def test_active_sidecars_warn_and_fall_back_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            owner = ContextCacheDatabase(cache_path)
+            owner.__enter__()
+            try:
+                owner.connection.execute(
+                    "INSERT INTO metadata VALUES ('marker', 'value')"
+                )
+                owner.connection.commit()
+                storage_paths = (
+                    cache_path,
+                    Path(f"{cache_path}-wal"),
+                    Path(f"{cache_path}-shm"),
+                    Path(f"{cache_path}-journal"),
+                )
+                before = tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                )
+
+                with patch(
+                    "cereja.system._context.cache.default_cache_path",
+                    return_value=cache_path,
+                ), warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    response = search_text_context(
+                        [root], "needle", cache=True
+                    )
+
+                self.assertEqual(
+                    [item.relative_path for item in response.results],
+                    ["guide.md"],
+                )
+                self.assertTrue(any(
+                    item.category is ContextCacheWarning for item in caught
+                ))
+                self.assertEqual(tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                ), before)
+            finally:
+                owner.__exit__(None, None, None)
 
     def test_database_fallback_reuses_materialized_root_generator(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -715,13 +885,18 @@ class ContextCacheTest(unittest.TestCase):
                         "cereja.system._context.cache.DEFAULT_MAX_BYTES",
                         baseline + 1_000_000,
                     ):
-                        for _ in range(8):
-                            response = search_text_context(
-                                [root], "needle", cache=True
+                        with warnings.catch_warnings():
+                            warnings.simplefilter(
+                                "ignore", ContextCacheWarning
                             )
-                            self.assertEqual(
-                                response.results[0].relative_path, "guide.txt"
-                            )
+                            for _ in range(8):
+                                response = search_text_context(
+                                    [root], "needle", cache=True
+                                )
+                                self.assertEqual(
+                                    response.results[0].relative_path,
+                                    "guide.txt",
+                                )
 
                     self.assertEqual(database.aggregate_size_bytes(), baseline)
                     self.assertIsNone(database.connection.execute(

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -123,6 +123,27 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 rows = list(database.iter_root_files("default", "C:/repo"))
             self.assertEqual([row.folded_text for row in rows], ["new"])
 
+    def test_new_scan_in_another_connection_invalidates_older_token(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            old_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 10, 11),
+                "text", "old", None,
+            )
+            new_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 12, 13),
+                "text", "new", None,
+            )
+            with ContextCacheDatabase(database_path) as first, \
+                 ContextCacheDatabase(database_path) as second:
+                old_scan = first.begin_scan("default", "C:/repo")
+                new_scan = second.begin_scan("default", "C:/repo")
+                second.commit_scan(new_scan, [new_file])
+                with self.assertRaises(CacheDatabaseError):
+                    first.commit_scan(old_scan, [old_file])
+                rows = list(first.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.folded_text for row in rows], ["new"])
+
     def test_commit_scan_materializes_input_before_starting_transaction(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
@@ -364,11 +385,15 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     1,
                 )
 
-    def test_enforce_quota_checkpoints_after_incremental_vacuum(self):
+    def test_enforce_quota_uses_one_bounded_vacuum_after_checkpoint(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(database_path) as database:
-                for root, text in (("C:/old", "x"), ("C:/protected", "y")):
+                for root, text in (
+                    ("C:/oldest", "x"),
+                    ("C:/old", "z"),
+                    ("C:/protected", "y"),
+                ):
                     scan = database.begin_scan("default", root)
                     database.commit_scan(scan, [CachedFile(
                         f"{root}/large.txt",
@@ -378,15 +403,20 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                         text * 2_000_000,
                         None,
                     )])
-                database.connection.execute(
-                    "PRAGMA wal_checkpoint(TRUNCATE)"
-                ).fetchone()
-                before = database.aggregate_size_bytes()
+                statements = []
+                database.connection.set_trace_callback(statements.append)
 
                 report = database.enforce_quota("C:/protected", max_bytes=0)
 
-                self.assertEqual(report.roots_removed, 1)
-                self.assertLess(report.after_bytes, before)
+                self.assertEqual(report.roots_removed, 2)
+                maintenance = [
+                    statement.casefold() for statement in statements
+                    if "wal_checkpoint" in statement or "incremental_vacuum" in statement
+                ]
+                self.assertEqual(
+                    maintenance,
+                    ["pragma wal_checkpoint(truncate)", "pragma incremental_vacuum(128)"],
+                )
 
     def test_windows_rejects_any_reparse_point_attribute(self):
         path = Path("reparse-target")
@@ -708,21 +738,21 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             path.touch()
             if os.name != "nt":
                 path.chmod(0o600)
-            original_stat = Path.stat
+            original_identity = ContextCacheDatabase._identity
             calls = 0
 
-            def changed_stat(candidate, *args, **kwargs):
+            def changed_identity(candidate):
                 nonlocal calls
-                result = original_stat(candidate, *args, **kwargs)
+                identity = original_identity(candidate)
                 if candidate == path:
                     calls += 1
                     if calls > 1:
-                        values = list(result)
-                        values[1] += 1
-                        return os.stat_result(values)
-                return result
+                        return identity[0], identity[1] + 1
+                return identity
 
-            with patch("cereja.system._context.cache_db.Path.stat", changed_stat):
+            with patch.object(
+                ContextCacheDatabase, "_identity", side_effect=changed_identity
+            ):
                 with self.assertRaisesRegex(CacheDatabaseError, "identity"):
                     with ContextCacheDatabase(path):
                         pass

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -241,17 +241,71 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     pass
             umask.assert_not_called()
 
-    @unittest.skipIf(os.name == "nt", "POSIX sidecar modes are not portable on Windows")
-    def test_posix_new_sidecars_are_restricted_immediately(self):
+    @unittest.skipIf(os.name == "nt", "POSIX file modes are not portable on Windows")
+    def test_posix_bootstrap_fchmods_database_before_sqlite_open(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
-            path.touch()
+            with patch("cereja.system._context.cache_db.os.fchmod",
+                       wraps=os.fchmod) as fchmod:
+                with ContextCacheDatabase(path):
+                    pass
+            self.assertTrue(any(call.args[1] == 0o600 for call in fchmod.call_args_list))
+
+    @unittest.skipIf(os.name == "nt", "POSIX sidecar modes are not portable on Windows")
+    def test_posix_bootstrap_restricts_real_sqlite_sidecars(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                sidecars = [item for item in (
+                    Path(f"{path}-wal"), Path(f"{path}-shm")
+                ) if item.exists()]
+                self.assertTrue(sidecars)
+                self.assertTrue(all(
+                    stat.S_IMODE(item.stat().st_mode) == 0o600
+                    for item in sidecars
+                ))
+
+    def test_open_rejects_preexisting_sidecar_replaced_during_open(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
             sidecar = Path(f"{path}-wal")
             sidecar.touch()
-            sidecar.chmod(0o666)
-            database = ContextCacheDatabase(path)
-            database._secure_new_sidecars(set())
-            self.assertEqual(stat.S_IMODE(sidecar.stat().st_mode), 0o600)
+            if os.name != "nt":
+                sidecar.chmod(0o600)
+
+            def replace_sidecar(database, database_is_empty):
+                replacement = path.parent / "replacement-wal"
+                replacement.touch()
+                if os.name != "nt":
+                    replacement.chmod(0o600)
+                replacement.replace(sidecar)
+
+            with patch.object(ContextCacheDatabase, "_configure_connection",
+                              replace_sidecar):
+                with self.assertRaisesRegex(CacheDatabaseError, "sidecar.*identity"):
+                    with ContextCacheDatabase(path):
+                        pass
+
+    def test_open_rejects_unexpected_sqlite_schema_objects(self):
+        statements = (
+            "CREATE VIEW unexpected_view AS SELECT 1",
+            "CREATE TRIGGER unexpected_trigger AFTER INSERT ON metadata BEGIN SELECT 1; END",
+            "CREATE INDEX unexpected_index ON namespaces(last_access_ns)",
+        )
+        for statement in statements:
+            with self.subTest(statement=statement), tempfile.TemporaryDirectory() as temp_dir:
+                path = Path(temp_dir) / "context.sqlite3"
+                with ContextCacheDatabase(path):
+                    pass
+                connection = sqlite3.connect(path)
+                connection.execute(statement)
+                connection.commit()
+                connection.close()
+                with self.assertRaisesRegex(CacheDatabaseError, "schema"):
+                    with ContextCacheDatabase(path):
+                        pass
 
     def test_open_rejects_symlink_cache_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -21,6 +21,70 @@ from cereja.system._context.cache_db import (
 
 
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_quota_admission_stops_at_first_rejected_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database._checkpoint_wal()
+                baseline = database.aggregate_size_bytes()
+                quota = baseline * 2 + 24_000
+                sizes = (8_000, 8_000, 50_000, 10)
+                candidates = [
+                    CachedFile(
+                        f"C:/repo/{index}.txt",
+                        f"{index}.txt",
+                        FileSignature(None, None, size, index, index),
+                        "text",
+                        chr(65 + index) * size,
+                        None,
+                    )
+                    for index, size in enumerate(sizes)
+                ]
+
+                admitted = database.commit_scan(
+                    scan, candidates, max_bytes=quota
+                )
+
+                self.assertGreater(len(admitted), 0)
+                self.assertLess(len(admitted), len(candidates))
+                self.assertEqual(admitted, tuple(candidates[:len(admitted)]))
+
+    def test_quota_admission_refuses_content_when_checkpoint_is_busy(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                database._checkpoint_wal()
+                reader = sqlite3.connect(database_path)
+                try:
+                    reader.execute("BEGIN")
+                    reader.execute("SELECT COUNT(*) FROM files").fetchone()
+                    scan = database.begin_scan("default", "C:/repo")
+                    candidate = CachedFile(
+                        "C:/repo/file.txt",
+                        "file.txt",
+                        FileSignature(None, None, 1_000, 1, 1),
+                        "text",
+                        "x" * 1_000,
+                        None,
+                    )
+
+                    admitted = database.commit_scan(
+                        scan,
+                        [candidate],
+                        max_bytes=database.aggregate_size_bytes() + 100_000,
+                    )
+                finally:
+                    reader.close()
+
+                self.assertEqual(admitted, ())
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM root_files"
+                    ).fetchone()[0],
+                    0,
+                )
+
     def test_windows_treats_missing_reparse_attributes_as_not_a_link(self):
         path = Path("regular-target")
         result = SimpleNamespace(st_file_attributes=None)

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -12,12 +12,382 @@ from cereja.system._context.cache_db import (
     BUSY_TIMEOUT_MS,
     SCHEMA_VERSION,
     CacheDatabaseError,
+    CacheMaintenanceReport,
+    CachedFile,
     ContextCacheDatabase,
+    FileSignature,
     default_cache_path,
 )
 
 
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_windows_treats_missing_reparse_attributes_as_not_a_link(self):
+        path = Path("regular-target")
+        result = SimpleNamespace(st_file_attributes=None)
+        with patch("cereja.system._context.cache_db.os.name", "nt"), \
+             patch.object(Path, "lstat", return_value=result), \
+             patch.object(Path, "is_symlink", return_value=False), \
+             patch.object(Path, "is_junction", return_value=False, create=True):
+            self.assertFalse(ContextCacheDatabase._is_link(path))
+
+    def test_commit_scan_upserts_files_and_removes_only_stale_associations(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                first_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(first_scan, [
+                    CachedFile(
+                        "C:/repo/a.txt",
+                        "a.txt",
+                        FileSignature(None, None, 1, 10, 11),
+                        "text",
+                        "a",
+                        None,
+                    ),
+                    CachedFile(
+                        "C:/repo/b.txt",
+                        "b.txt",
+                        FileSignature(None, None, 1, 10, 11),
+                        "text",
+                        "b",
+                        None,
+                    ),
+                ])
+                other_scan = database.begin_scan("default", "C:/other")
+                database.commit_scan(other_scan, [CachedFile(
+                    "C:/other/kept.txt",
+                    "kept.txt",
+                    FileSignature(None, None, 1, 10, 11),
+                    "text",
+                    "kept",
+                    None,
+                )])
+                second_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(second_scan, [
+                    CachedFile(
+                        "C:/repo/a.txt",
+                        "a.txt",
+                        FileSignature(None, None, 1, 12, 13),
+                        "text",
+                        "changed",
+                        None,
+                    ),
+                ])
+                rows = list(database.iter_root_files("default", "C:/repo"))
+                other_rows = list(database.iter_root_files("default", "C:/other"))
+            self.assertEqual(
+                [(row.relative_path, row.folded_text) for row in rows],
+                [("a.txt", "changed")],
+            )
+            self.assertEqual(
+                [(row.relative_path, row.folded_text) for row in other_rows],
+                [("kept.txt", "kept")],
+            )
+
+    def test_abandoned_scan_does_not_delete_existing_associations(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            seeded = CachedFile(
+                "C:/repo/a.txt",
+                "a.txt",
+                FileSignature(None, None, 1, 10, 11),
+                "text",
+                "a",
+                None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                completed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(completed, [seeded])
+                database.begin_scan("default", "C:/repo")
+            with ContextCacheDatabase(database_path) as database:
+                rows = list(database.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.relative_path for row in rows], ["a.txt"])
+
+    def test_new_scan_invalidates_older_token_for_the_same_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            old_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 10, 11),
+                "text", "old", None,
+            )
+            new_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 12, 13),
+                "text", "new", None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                old_scan = database.begin_scan("default", "C:/repo")
+                new_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(new_scan, [new_file])
+                with self.assertRaises(CacheDatabaseError):
+                    database.commit_scan(old_scan, [old_file])
+                rows = list(database.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.folded_text for row in rows], ["new"])
+
+    def test_commit_scan_materializes_input_before_starting_transaction(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            seeded = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 10, 11),
+                "text", "seeded", None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(seed_scan, [seeded])
+                failed_scan = database.begin_scan("default", "C:/repo")
+
+                def failing_files():
+                    yield CachedFile(
+                        "C:/repo/b.txt", "b.txt",
+                        FileSignature(None, None, 1, 12, 13),
+                        "text", "partial", None,
+                    )
+                    database.get_cached_file(
+                        "C:/repo/a.txt", FileSignature(None, None, 1, 10, 11), 100
+                    )
+                    raise RuntimeError("scan failed")
+
+                with self.assertRaisesRegex(RuntimeError, "scan failed"):
+                    database.commit_scan(failed_scan, failing_files())
+                rows = list(database.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.folded_text for row in rows], ["seeded"])
+
+    def test_get_cached_file_requires_every_signature_field_to_match(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/a.txt",
+                "a.txt",
+                FileSignature(2, 3, 4, 5, 6),
+                "text",
+                "cached",
+                "digest",
+            )
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, [cached_file])
+                self.assertEqual(
+                    database.get_cached_file(
+                        "C:/repo/a.txt", FileSignature(2, 3, 4, 5, 6), 100
+                    ),
+                    cached_file,
+                )
+                mismatches = (
+                    FileSignature(9, 3, 4, 5, 6),
+                    FileSignature(2, 9, 4, 5, 6),
+                    FileSignature(2, 3, 9, 5, 6),
+                    FileSignature(2, 3, 4, 9, 6),
+                    FileSignature(2, 3, 4, 5, 9),
+                )
+                for signature in mismatches:
+                    with self.subTest(signature=signature):
+                        self.assertIsNone(
+                            database.get_cached_file(
+                                "C:/repo/a.txt", signature, 100
+                            )
+                        )
+
+    def test_file_too_large_cache_is_reused_only_above_current_limit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/large.txt",
+                "large.txt",
+                FileSignature(None, None, 20, 30, 40),
+                "file_too_large",
+                None,
+                None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, [cached_file])
+                self.assertEqual(
+                    database.get_cached_file(
+                        "C:/repo/large.txt",
+                        FileSignature(None, None, 20, 30, 40),
+                        19,
+                    ),
+                    cached_file,
+                )
+                self.assertIsNone(
+                    database.get_cached_file(
+                        "C:/repo/large.txt",
+                        FileSignature(None, None, 20, 30, 40),
+                        20,
+                    )
+                )
+
+    def test_text_cache_is_not_reused_above_current_file_limit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 20, 30, 40),
+                "text", "cached", None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, [cached_file])
+                self.assertIsNone(database.get_cached_file(
+                    "C:/repo/a.txt", FileSignature(None, None, 20, 30, 40), 19
+                ))
+
+    def test_get_cached_file_rejects_ambiguous_relative_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            signature = FileSignature(None, None, 1, 10, 11)
+            with ContextCacheDatabase(database_path) as database:
+                parent_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(parent_scan, [CachedFile(
+                    "C:/repo/sub/a.txt", "sub/a.txt", signature,
+                    "text", "a", None,
+                )])
+                child_scan = database.begin_scan("default", "C:/repo/sub")
+                database.commit_scan(child_scan, [CachedFile(
+                    "C:/repo/sub/a.txt", "a.txt", signature,
+                    "text", "a", None,
+                )])
+                self.assertIsNone(database.get_cached_file(
+                    "C:/repo/sub/a.txt", signature, 100
+                ))
+
+    def test_iter_root_files_refreshes_root_lru_timestamp(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, [CachedFile(
+                    "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 10, 11),
+                    "text", "a", None,
+                )])
+                database.connection.execute(
+                    "UPDATE roots SET last_access_ns = 1 WHERE canonical_path = 'C:/repo'"
+                )
+                database.connection.commit()
+                list(database.iter_root_files("default", "C:/repo"))
+                refreshed = database.connection.execute(
+                    "SELECT last_access_ns FROM roots WHERE canonical_path = 'C:/repo'"
+                ).fetchone()[0]
+            self.assertGreater(refreshed, 1)
+
+    def test_aggregate_size_counts_database_and_existing_sidecars(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                expected = sum(
+                    path.stat().st_size
+                    for path in (
+                        database_path,
+                        Path(f"{database_path}-wal"),
+                        Path(f"{database_path}-shm"),
+                    )
+                    if path.exists()
+                )
+                self.assertEqual(database.aggregate_size_bytes(), expected)
+
+    def test_enforce_quota_preserves_protected_root_and_collects_orphans(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                for root, name in (
+                    ("C:/old", "old.txt"),
+                    ("C:/new", "new.txt"),
+                    ("C:/protected", "protected.txt"),
+                ):
+                    scan = database.begin_scan("default", root)
+                    database.commit_scan(scan, [CachedFile(
+                        f"{root}/{name}",
+                        name,
+                        FileSignature(None, None, 1, 10, 11),
+                        "text",
+                        name,
+                        None,
+                    )])
+                database.connection.execute(
+                    "UPDATE roots SET last_access_ns = CASE canonical_path "
+                    "WHEN 'C:/old' THEN 1 WHEN 'C:/new' THEN 2 ELSE 3 END"
+                )
+                database.connection.commit()
+
+                report = database.enforce_quota("C:/protected", max_bytes=0)
+
+                self.assertEqual(
+                    report,
+                    CacheMaintenanceReport(
+                        associations_removed=2,
+                        roots_removed=2,
+                        files_removed=2,
+                        before_bytes=report.before_bytes,
+                        after_bytes=report.after_bytes,
+                    ),
+                )
+                self.assertGreater(report.before_bytes, 0)
+                self.assertEqual(report.after_bytes, database.aggregate_size_bytes())
+                self.assertEqual(
+                    [row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots ORDER BY canonical_path"
+                    )],
+                    ["C:/protected"],
+                )
+                self.assertEqual(
+                    [row.relative_path for row in database.iter_root_files(
+                        "default", "C:/protected"
+                    )],
+                    ["protected.txt"],
+                )
+
+    def test_enforce_quota_collects_orphans_without_evictable_roots(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            first_files = [
+                CachedFile(
+                    f"C:/protected/{name}",
+                    name,
+                    FileSignature(None, None, 1, 10, 11),
+                    "text",
+                    name,
+                    None,
+                )
+                for name in ("kept.txt", "orphan.txt")
+            ]
+            with ContextCacheDatabase(database_path) as database:
+                first_scan = database.begin_scan("default", "C:/protected")
+                database.commit_scan(first_scan, first_files)
+                second_scan = database.begin_scan("default", "C:/protected")
+                database.commit_scan(second_scan, first_files[:1])
+
+                report = database.enforce_quota("C:/protected", max_bytes=0)
+
+                self.assertEqual(report.associations_removed, 0)
+                self.assertEqual(report.roots_removed, 0)
+                self.assertEqual(report.files_removed, 1)
+                self.assertEqual(
+                    database.connection.execute("SELECT COUNT(*) FROM files").fetchone()[0],
+                    1,
+                )
+
+    def test_enforce_quota_checkpoints_after_incremental_vacuum(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                for root, text in (("C:/old", "x"), ("C:/protected", "y")):
+                    scan = database.begin_scan("default", root)
+                    database.commit_scan(scan, [CachedFile(
+                        f"{root}/large.txt",
+                        "large.txt",
+                        FileSignature(None, None, 2_000_000, 10, 11),
+                        "text",
+                        text * 2_000_000,
+                        None,
+                    )])
+                database.connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                before = database.aggregate_size_bytes()
+
+                report = database.enforce_quota("C:/protected", max_bytes=0)
+
+                self.assertEqual(report.roots_removed, 1)
+                self.assertLess(report.after_bytes, before)
+
     def test_windows_rejects_any_reparse_point_attribute(self):
         path = Path("reparse-target")
         result = SimpleNamespace(st_file_attributes=0x400)

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -13,6 +13,7 @@ from cereja.system._context.cache_db import (
     BUSY_TIMEOUT_MS,
     SCHEMA_VERSION,
     CacheDatabaseError,
+    CacheDatabaseUnavailable,
     CacheMaintenanceReport,
     CachedFile,
     ContextCacheDatabase,
@@ -29,6 +30,14 @@ def _storage_snapshot(database):
         for path in paths
     )
     return (*sizes, database.aggregate_size_bytes())
+
+
+def _truncate_recognized_database(path):
+    with ContextCacheDatabase(path):
+        pass
+    original = path.read_bytes()
+    path.write_bytes(original[:128])
+    return path.read_bytes()
 
 
 class _FailingPragmaConnection:
@@ -1190,6 +1199,444 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 [("default",)],
             )
             connection.close()
+
+    def test_open_leaves_unknown_application_database_byte_for_byte_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            connection = sqlite3.connect(path)
+            connection.execute(f"PRAGMA application_id = {APPLICATION_ID + 1}")
+            connection.execute("CREATE TABLE foreign_data (value TEXT)")
+            connection.execute("INSERT INTO foreign_data VALUES ('keep me')")
+            connection.commit()
+            connection.close()
+            if os.name != "nt":
+                path.chmod(0o600)
+            before = path.read_bytes()
+
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
+
+    def test_open_does_not_mutate_unknown_database_active_wal_or_shm(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            writer = sqlite3.connect(path)
+            try:
+                writer.execute("PRAGMA journal_mode = WAL")
+                writer.execute("PRAGMA wal_autocheckpoint = 0")
+                writer.execute(f"PRAGMA application_id = {APPLICATION_ID + 1}")
+                writer.execute("CREATE TABLE foreign_data (value TEXT)")
+                writer.commit()
+                storage_paths = (
+                    path,
+                    Path(f"{path}-wal"),
+                    Path(f"{path}-shm"),
+                )
+                if os.name != "nt":
+                    for item in storage_paths:
+                        item.chmod(0o600)
+                before = tuple(item.read_bytes() for item in storage_paths)
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                after = tuple(item.read_bytes() for item in storage_paths)
+            finally:
+                writer.close()
+
+            self.assertEqual(after, before)
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
+
+    def test_known_wal_cannot_override_unknown_main_database_identity(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            foreign_path = directory / "context.sqlite3"
+            with ContextCacheDatabase(source_path):
+                source_wal = Path(f"{source_path}-wal").read_bytes()
+                connection = sqlite3.connect(foreign_path)
+                connection.execute(
+                    f"PRAGMA application_id = {APPLICATION_ID + 1}"
+                )
+                connection.execute("CREATE TABLE foreign_data (value TEXT)")
+                connection.execute(
+                    "INSERT INTO foreign_data VALUES ('keep me')"
+                )
+                connection.commit()
+                connection.close()
+                foreign_wal = Path(f"{foreign_path}-wal")
+                foreign_wal.write_bytes(source_wal)
+                if os.name != "nt":
+                    foreign_path.chmod(0o600)
+                    foreign_wal.chmod(0o600)
+                before = (foreign_path.read_bytes(), foreign_wal.read_bytes())
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(foreign_path):
+                        pass
+
+                self.assertEqual(
+                    (foreign_path.read_bytes(), foreign_wal.read_bytes()),
+                    before,
+                )
+                self.assertFalse(Path(f"{foreign_path}-shm").exists())
+                self.assertEqual(
+                    list(directory.glob(f"{foreign_path.name}.quarantine-*")),
+                    [],
+                )
+
+    def test_open_leaves_future_schema_version_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+            connection.commit()
+            connection.close()
+            before = path.read_bytes()
+
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
+
+    def test_known_wal_cannot_downgrade_future_main_database_version(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            future_path = directory / "context.sqlite3"
+            with ContextCacheDatabase(future_path):
+                pass
+            connection = sqlite3.connect(future_path)
+            connection.execute(
+                f"PRAGMA user_version = {SCHEMA_VERSION + 1}"
+            )
+            connection.commit()
+            connection.close()
+            with ContextCacheDatabase(source_path):
+                source_wal = Path(f"{source_path}-wal").read_bytes()
+                future_wal = Path(f"{future_path}-wal")
+                future_wal.write_bytes(source_wal)
+                if os.name != "nt":
+                    future_wal.chmod(0o600)
+                before = (future_path.read_bytes(), future_wal.read_bytes())
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(future_path):
+                        pass
+
+                self.assertEqual(
+                    (future_path.read_bytes(), future_wal.read_bytes()),
+                    before,
+                )
+                self.assertFalse(Path(f"{future_path}-shm").exists())
+                self.assertEqual(
+                    list(directory.glob(f"{future_path.name}.quarantine-*")),
+                    [],
+                )
+
+    def test_open_rebuilds_recognized_version_zero_database(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            connection.execute("CREATE TABLE legacy_payload (value TEXT)")
+            connection.execute("INSERT INTO legacy_payload VALUES ('obsolete')")
+            connection.execute("PRAGMA user_version = 0")
+            connection.commit()
+            connection.close()
+
+            with ContextCacheDatabase(path) as database:
+                version = database.connection.execute(
+                    "PRAGMA user_version"
+                ).fetchone()[0]
+                tables = database.table_names()
+
+            self.assertEqual(version, SCHEMA_VERSION)
+            self.assertEqual(tables, {
+                "metadata", "namespaces", "namespace_roots",
+                "roots", "root_files", "files",
+            })
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
+
+    def test_recovery_waits_for_active_cache_opener_before_quarantine(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path) as active:
+                active.connection.execute("PRAGMA user_version = 0")
+                active.connection.commit()
+                storage_paths = (
+                    path,
+                    Path(f"{path}-wal"),
+                    Path(f"{path}-shm"),
+                )
+                before = tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                )
+                original_move = ContextCacheDatabase._move_to_quarantine
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_move_to_quarantine",
+                    autospec=True,
+                    side_effect=original_move,
+                ) as move:
+                    with self.assertRaises(CacheDatabaseUnavailable):
+                        with ContextCacheDatabase(path):
+                            pass
+                after = tuple(
+                    item.read_bytes() if item.exists() else None
+                    for item in storage_paths
+                )
+                move.assert_not_called()
+                self.assertEqual(after, before)
+
+            with ContextCacheDatabase(path) as recovered:
+                self.assertEqual(
+                    recovered.connection.execute(
+                        "PRAGMA user_version"
+                    ).fetchone()[0],
+                    SCHEMA_VERSION,
+                )
+
+    def test_open_quarantines_and_replaces_recognized_corrupt_database(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            corrupt_bytes = _truncate_recognized_database(path)
+
+            with ContextCacheDatabase(path) as database:
+                version = database.connection.execute(
+                    "PRAGMA user_version"
+                ).fetchone()[0]
+
+            self.assertEqual(version, SCHEMA_VERSION)
+            self.assertNotEqual(path.read_bytes(), corrupt_bytes)
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
+
+    def test_open_recovers_recognized_database_with_invalid_wal_header(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            wal_path = Path(f"{path}-wal")
+            wal_path.write_bytes(b"invalid WAL header".ljust(33, b"!"))
+            if os.name != "nt":
+                wal_path.chmod(0o600)
+
+            with ContextCacheDatabase(path) as database:
+                version = database.connection.execute(
+                    "PRAGMA user_version"
+                ).fetchone()[0]
+
+            self.assertEqual(version, SCHEMA_VERSION)
+            self.assertEqual(
+                list(path.parent.glob(f"{path.name}.quarantine-*")), []
+            )
+
+    def test_failed_replacement_keeps_timestamped_random_quarantine(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            corrupt_bytes = _truncate_recognized_database(path)
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_create_schema",
+                side_effect=sqlite3.OperationalError("replacement failed"),
+            ):
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+
+            quarantines = list(
+                path.parent.glob(f"{path.name}.quarantine-[0-9]*-[0-9a-f]*")
+            )
+            self.assertEqual(len(quarantines), 1)
+            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
+            self.assertFalse(path.exists())
+            self.assertEqual(
+                list(path.parent.glob(f"{path.name}.replacement-*")), []
+            )
+
+    def test_recovery_never_clobbers_path_recreated_before_publication(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            corrupt_bytes = _truncate_recognized_database(path)
+            foreign_bytes = None
+            original_publish = ContextCacheDatabase._publish_replacement
+
+            def recreate_then_publish(
+                database, replacement_path, replacement_identity=None
+            ):
+                nonlocal foreign_bytes
+                connection = sqlite3.connect(path)
+                connection.execute("PRAGMA application_id = 12345")
+                connection.execute("CREATE TABLE foreign_data (value TEXT)")
+                connection.execute(
+                    "INSERT INTO foreign_data VALUES ('keep me')"
+                )
+                connection.commit()
+                connection.close()
+                if os.name != "nt":
+                    path.chmod(0o600)
+                foreign_bytes = path.read_bytes()
+                if replacement_identity is None:
+                    return original_publish(database, replacement_path)
+                return original_publish(
+                    database, replacement_path, replacement_identity
+                )
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_publish_replacement",
+                autospec=True,
+                side_effect=recreate_then_publish,
+            ), self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(path.read_bytes(), foreign_bytes)
+            quarantines = list(
+                path.parent.glob(f"{path.name}.quarantine-*-")
+            )
+            if not quarantines:
+                quarantines = list(
+                    path.parent.glob(f"{path.name}.quarantine-*")
+                )
+            self.assertEqual(len(quarantines), 1)
+            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
+            replacements = list(
+                path.parent.glob(f"{path.name}.replacement-*")
+            )
+            self.assertEqual(len(replacements), 1)
+
+    def test_recovery_rejects_replacement_swapped_after_validation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            corrupt_bytes = _truncate_recognized_database(path)
+            foreign_bytes = None
+            original_publish = ContextCacheDatabase._publish_replacement
+
+            def swap_then_publish(
+                database, replacement_path, replacement_identity=None
+            ):
+                nonlocal foreign_bytes
+                replacement_path.unlink()
+                connection = sqlite3.connect(replacement_path)
+                connection.execute("PRAGMA application_id = 12345")
+                connection.execute("CREATE TABLE foreign_data (value TEXT)")
+                connection.execute(
+                    "INSERT INTO foreign_data VALUES ('keep me')"
+                )
+                connection.commit()
+                connection.close()
+                if os.name != "nt":
+                    replacement_path.chmod(0o600)
+                foreign_bytes = replacement_path.read_bytes()
+                if replacement_identity is None:
+                    return original_publish(database, replacement_path)
+                return original_publish(
+                    database, replacement_path, replacement_identity
+                )
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_publish_replacement",
+                autospec=True,
+                side_effect=swap_then_publish,
+            ), self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertFalse(path.exists())
+            quarantines = list(
+                path.parent.glob(f"{path.name}.quarantine-*")
+            )
+            self.assertEqual(len(quarantines), 1)
+            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
+            replacements = list(
+                path.parent.glob(f"{path.name}.replacement-*")
+            )
+            self.assertEqual(len(replacements), 1)
+            self.assertEqual(replacements[0].read_bytes(), foreign_bytes)
+
+    def test_quarantine_move_failure_restores_every_original_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            wal_path = Path(f"{path}-wal")
+            shm_path = Path(f"{path}-shm")
+            wal_path.write_bytes(b"wal sentinel")
+            shm_path.write_bytes(b"shm sentinel")
+            if os.name != "nt":
+                wal_path.chmod(0o600)
+                shm_path.chmod(0o600)
+            before = {
+                item: item.read_bytes() for item in (path, wal_path, shm_path)
+            }
+            database = ContextCacheDatabase(path)
+            prepared = database._prepare_path()
+            directory = path.parent.resolve(strict=True)
+            quarantine_paths = database._quarantine_paths(
+                prepared[3], directory
+            )
+            original_rename = os.rename
+            calls = 0
+
+            def fail_second_rename(source, target):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("injected quarantine move failure")
+                return original_rename(source, target)
+
+            with patch(
+                "cereja.system._context.cache_db.os.rename",
+                side_effect=fail_second_rename,
+            ), self.assertRaisesRegex(
+                OSError, "injected quarantine move failure"
+            ):
+                database._move_to_quarantine(
+                    quarantine_paths, prepared[2], prepared[3]
+                )
+
+            self.assertEqual(
+                {item: item.read_bytes() for item in before}, before
+            )
+            self.assertEqual(
+                list(path.parent.glob(f"{path.name}.quarantine-*")), []
+            )
+
+    def test_recovery_leaves_symlink_and_non_regular_targets_untouched(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            target = directory / "target.sqlite3"
+            corrupt_bytes = _truncate_recognized_database(target)
+            symlink = directory / "linked.sqlite3"
+            try:
+                symlink.symlink_to(target)
+            except OSError as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(symlink):
+                    pass
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(directory):
+                    pass
+
+            self.assertTrue(symlink.is_symlink())
+            self.assertEqual(target.read_bytes(), corrupt_bytes)
+            self.assertTrue(directory.is_dir())
+            self.assertEqual(list(directory.glob("*.quarantine-*")), [])
 
     def test_open_migrates_valid_previous_layout(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -93,6 +93,165 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 with ContextCacheDatabase(path):
                     pass
 
+    def test_open_does_not_chmod_existing_cache_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir) / "existing"
+            directory.mkdir()
+            path = directory / "context.sqlite3"
+            with patch("cereja.system._context.cache_db.os.chmod") as chmod:
+                with ContextCacheDatabase(path):
+                    pass
+            chmod.assert_not_called()
+
+    def test_open_does_not_create_missing_directory_ancestors(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "missing" / "cereja" / "context.sqlite3"
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+            self.assertFalse(path.parent.parent.exists())
+
+    def test_open_creates_only_default_windows_application_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir, \
+             patch("cereja.system._context.cache_db.os.name", "nt"), \
+             patch.dict(os.environ, {"LOCALAPPDATA": temp_dir}):
+            path = default_cache_path()
+            with ContextCacheDatabase(path):
+                pass
+            self.assertTrue(path.is_file())
+            self.assertEqual(path.parent.parent.parent, Path(temp_dir))
+
+    def test_open_bootstraps_preexisting_empty_file_with_incremental_vacuum(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            path.touch()
+            if os.name != "nt":
+                path.chmod(0o600)
+            with ContextCacheDatabase(path) as database:
+                self.assertEqual(
+                    database.connection.execute("PRAGMA auto_vacuum").fetchone()[0], 2
+                )
+
+    def test_open_rejects_schema_with_altered_column(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            connection.execute("ALTER TABLE files RENAME COLUMN folded_text TO changed_text")
+            connection.commit()
+            connection.close()
+            with self.assertRaisesRegex(CacheDatabaseError, "schema"):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_rejects_schema_without_default_namespace(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            connection.execute("DELETE FROM namespaces WHERE name = 'default'")
+            connection.commit()
+            connection.close()
+            with self.assertRaisesRegex(CacheDatabaseError, "namespace"):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_rejects_schema_without_declared_unique_constraint(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            sql = connection.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'namespaces'"
+            ).fetchone()[0]
+            connection.execute("PRAGMA writable_schema = ON")
+            connection.execute(
+                "UPDATE sqlite_master SET sql = ? WHERE name = 'namespaces'",
+                (sql.replace("name TEXT NOT NULL UNIQUE", "name TEXT NOT NULL"),),
+            )
+            version = connection.execute("PRAGMA schema_version").fetchone()[0]
+            connection.execute(f"PRAGMA schema_version = {version + 1}")
+            connection.commit()
+            connection.close()
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_rejects_schema_with_altered_state_constraint(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            sql = connection.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'files'"
+            ).fetchone()[0]
+            connection.execute("PRAGMA writable_schema = ON")
+            connection.execute(
+                "UPDATE sqlite_master SET sql = ? WHERE name = 'files'",
+                (sql.replace("'file_too_large')", "'file_too_large', 'extra')"),),
+            )
+            version = connection.execute("PRAGMA schema_version").fetchone()[0]
+            connection.execute(f"PRAGMA schema_version = {version + 1}")
+            connection.commit()
+            connection.close()
+            with self.assertRaisesRegex(CacheDatabaseError, "schema"):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_rejects_symlink_cache_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "target"
+            target.mkdir()
+            directory = root / "cache"
+            try:
+                directory.symlink_to(target, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(directory / "context.sqlite3"):
+                    pass
+
+    def test_open_rejects_schema_with_non_incremental_vacuum(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            connection = sqlite3.connect(path)
+            connection.execute(f"PRAGMA application_id = {APPLICATION_ID}")
+            connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            connection.close()
+            with self.assertRaisesRegex(CacheDatabaseError, "auto_vacuum"):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_aborts_when_file_identity_changes_after_connect(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            path.touch()
+            if os.name != "nt":
+                path.chmod(0o600)
+            original_stat = Path.stat
+            calls = 0
+
+            def changed_stat(candidate, *args, **kwargs):
+                nonlocal calls
+                result = original_stat(candidate, *args, **kwargs)
+                if candidate == path:
+                    calls += 1
+                    if calls > 1:
+                        values = list(result)
+                        values[1] += 1
+                        return os.stat_result(values)
+                return result
+
+            with patch("cereja.system._context.cache_db.Path.stat", changed_stat):
+                with self.assertRaisesRegex(CacheDatabaseError, "identity"):
+                    with ContextCacheDatabase(path):
+                        pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -413,9 +413,50 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     statement.casefold() for statement in statements
                     if "wal_checkpoint" in statement or "incremental_vacuum" in statement
                 ]
+                self.assertEqual(maintenance.count("pragma incremental_vacuum(128)"), 1)
+                vacuum_index = maintenance.index("pragma incremental_vacuum(128)")
                 self.assertEqual(
-                    maintenance,
-                    ["pragma wal_checkpoint(truncate)", "pragma incremental_vacuum(128)"],
+                    maintenance[vacuum_index - 1], "pragma wal_checkpoint(truncate)"
+                )
+                self.assertEqual(maintenance[-1], "pragma wal_checkpoint(truncate)")
+
+    def test_enforce_quota_stops_after_one_root_reaches_physical_quota(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                for root, text in (
+                    ("C:/oldest", "x"),
+                    ("C:/newer", "z"),
+                    ("C:/protected", "y"),
+                ):
+                    scan = database.begin_scan("default", root)
+                    database.commit_scan(scan, [CachedFile(
+                        f"{root}/large.txt",
+                        "large.txt",
+                        FileSignature(None, None, 2_000_000, 10, 11),
+                        "text",
+                        text * 2_000_000,
+                        None,
+                    )])
+                database.connection.execute(
+                    "UPDATE roots SET last_access_ns = CASE canonical_path "
+                    "WHEN 'C:/oldest' THEN 1 WHEN 'C:/newer' THEN 2 ELSE 3 END"
+                )
+                database.connection.commit()
+                database.connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                quota = database.aggregate_size_bytes() - 1
+
+                report = database.enforce_quota("C:/protected", max_bytes=quota)
+
+                self.assertEqual(report.roots_removed, 1)
+                self.assertLessEqual(report.after_bytes, quota)
+                self.assertEqual(
+                    [row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots ORDER BY canonical_path"
+                    )],
+                    ["C:/newer", "C:/protected"],
                 )
 
     def test_windows_rejects_any_reparse_point_attribute(self):

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -41,6 +41,8 @@ def _create_legacy_database(path):
         """
     )
     connection.close()
+    if os.name != "nt":
+        path.chmod(0o600)
 
 
 def _storage_snapshot(database):
@@ -1213,6 +1215,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
              patch.object(Path, "is_symlink", return_value=False):
             self.assertTrue(ContextCacheDatabase._is_link(path))
 
+    @unittest.skipUnless(os.name == "nt", "Windows cache path test")
     def test_windows_default_path_uses_local_app_data(self):
         with patch("cereja.system._context.cache_db.os.name", "nt"), \
              patch.dict(os.environ, {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}):
@@ -1800,6 +1803,8 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 """
             )
             connection.close()
+            if os.name != "nt":
+                path.chmod(0o600)
 
             with ContextCacheDatabase(path) as database:
                 root = database.connection.execute(
@@ -2002,6 +2007,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     pass
             self.assertFalse(path.parent.parent.exists())
 
+    @unittest.skipUnless(os.name == "nt", "Windows cache path test")
     def test_open_creates_only_default_windows_application_directories(self):
         with tempfile.TemporaryDirectory() as temp_dir, \
              patch("cereja.system._context.cache_db.os.name", "nt"), \
@@ -2418,6 +2424,8 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
             connection.execute("PRAGMA journal_mode = WAL")
             connection.close()
+            if os.name != "nt":
+                path.chmod(0o600)
             with self.assertRaisesRegex(CacheDatabaseError, "auto_vacuum"):
                 with ContextCacheDatabase(path):
                     pass

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -1,0 +1,98 @@
+import os
+import sqlite3
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cereja.system._context.cache_db import (
+    APPLICATION_ID,
+    BUSY_TIMEOUT_MS,
+    SCHEMA_VERSION,
+    CacheDatabaseError,
+    ContextCacheDatabase,
+    default_cache_path,
+)
+
+
+class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_windows_default_path_uses_local_app_data(self):
+        with patch("cereja.system._context.cache_db.os.name", "nt"), \
+             patch.dict(os.environ, {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}):
+            self.assertEqual(
+                default_cache_path(),
+                Path("C:/Users/test/AppData/Local/Cereja/cache/context.sqlite3"),
+            )
+
+    def test_open_creates_identified_versioned_schema(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path) as database:
+                table_names = database.table_names()
+                self.assertEqual(
+                    database.connection.execute("PRAGMA foreign_keys").fetchone()[0], 1
+                )
+                self.assertEqual(
+                    database.connection.execute("PRAGMA busy_timeout").fetchone()[0],
+                    BUSY_TIMEOUT_MS,
+                )
+                self.assertEqual(
+                    database.connection.execute("PRAGMA journal_mode").fetchone()[0],
+                    "wal",
+                )
+                self.assertEqual(
+                    database.connection.execute("PRAGMA auto_vacuum").fetchone()[0], 2
+                )
+            connection = sqlite3.connect(path)
+            self.assertEqual(
+                connection.execute("PRAGMA application_id").fetchone()[0],
+                APPLICATION_ID,
+            )
+            self.assertEqual(
+                connection.execute("PRAGMA user_version").fetchone()[0],
+                SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                table_names,
+                {"metadata", "namespaces", "namespace_roots", "roots", "root_files", "files"},
+            )
+            self.assertEqual(
+                connection.execute("SELECT name FROM namespaces").fetchall(),
+                [("default",)],
+            )
+            connection.close()
+
+    @unittest.skipIf(os.name == "nt", "POSIX permissions are not portable on Windows")
+    def test_open_restricts_new_database_and_cache_directory_permissions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "cereja" / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_open_rejects_symlink_database_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            target = directory / "target.sqlite3"
+            target.write_text("not a database", encoding="utf-8")
+            path = directory / "context.sqlite3"
+            try:
+                path.symlink_to(target)
+            except OSError as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_open_rejects_non_regular_database_target(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir)
+            with self.assertRaises(CacheDatabaseError):
+                with ContextCacheDatabase(path):
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -21,6 +21,94 @@ from cereja.system._context.cache_db import (
 
 
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_commit_scan_at_physical_quota_is_read_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                scans = database.begin_scans_if_admitted(
+                    "default", ["C:/repo"], 10 ** 9
+                )
+                database._checkpoint_wal()
+                quota = database.aggregate_size_bytes()
+
+                admitted = database.commit_scan(
+                    scans["C:/repo"], [], max_bytes=quota
+                )
+
+                self.assertIsNone(admitted)
+
+    def test_stale_deletion_rolls_back_when_projected_wal_exceeds_quota(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                files = [
+                    CachedFile(
+                        f"C:/repo/{index}.txt",
+                        f"{index}.txt",
+                        FileSignature(None, None, 1_000, index, index),
+                        "text",
+                        "x" * 1_000,
+                        None,
+                    )
+                    for index in range(20)
+                ]
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(seed, files)
+                database._checkpoint_wal()
+                scan = database.begin_scan("default", "C:/repo")
+                database._checkpoint_wal()
+                quota = database.aggregate_size_bytes() + 1
+
+                admitted = database.commit_scan(
+                    scan, [], max_bytes=quota
+                )
+
+                self.assertIsNone(admitted)
+                self.assertEqual(
+                    len(tuple(database.iter_root_files("default", "C:/repo"))),
+                    len(files),
+                )
+
+    def test_busy_commit_does_not_remove_existing_snapshot(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached = CachedFile(
+                "C:/repo/file.txt",
+                "file.txt",
+                FileSignature(None, None, 4, 1, 1),
+                "text",
+                "text",
+                None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(seed, [cached])
+                database._checkpoint_wal()
+                scan = database.begin_scan("default", "C:/repo")
+                database._checkpoint_wal()
+                reader = sqlite3.connect(database_path)
+                try:
+                    reader.execute("BEGIN")
+                    reader.execute("SELECT COUNT(*) FROM files").fetchone()
+                    database.connection.execute(
+                        "UPDATE roots SET last_access_ns = last_access_ns + 1"
+                    )
+                    database.connection.commit()
+
+                    admitted = database.commit_scan(
+                        scan, [], max_bytes=10 ** 9
+                    )
+                finally:
+                    reader.close()
+
+                self.assertIsNone(admitted)
+                self.assertEqual(
+                    [item.relative_path for item in database.iter_root_files(
+                        "default", "C:/repo"
+                    )],
+                    ["file.txt"],
+                )
+
     def test_quota_admission_stops_at_first_rejected_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
@@ -77,7 +165,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 finally:
                     reader.close()
 
-                self.assertEqual(admitted, ())
+                self.assertIsNone(admitted)
                 self.assertEqual(
                     database.connection.execute(
                         "SELECT COUNT(*) FROM root_files"

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -4,6 +4,7 @@ import stat
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from cereja.system._context.cache_db import (
@@ -17,6 +18,14 @@ from cereja.system._context.cache_db import (
 
 
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_windows_rejects_any_reparse_point_attribute(self):
+        path = Path("reparse-target")
+        result = SimpleNamespace(st_file_attributes=0x400)
+        with patch("cereja.system._context.cache_db.os.name", "nt"), \
+             patch.object(Path, "lstat", return_value=result), \
+             patch.object(Path, "is_symlink", return_value=False):
+            self.assertTrue(ContextCacheDatabase._is_link(path))
+
     def test_windows_default_path_uses_local_app_data(self):
         with patch("cereja.system._context.cache_db.os.name", "nt"), \
              patch.dict(os.environ, {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}):
@@ -201,6 +210,48 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             with self.assertRaisesRegex(CacheDatabaseError, "schema"):
                 with ContextCacheDatabase(path):
                     pass
+
+    def test_open_rejects_schema_with_altered_collation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            sql = connection.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'metadata'"
+            ).fetchone()[0]
+            connection.execute("PRAGMA writable_schema = ON")
+            connection.execute(
+                "UPDATE sqlite_master SET sql = ? WHERE name = 'metadata'",
+                (sql.replace("value TEXT NOT NULL", "value TEXT COLLATE NOCASE NOT NULL"),),
+            )
+            version = connection.execute("PRAGMA schema_version").fetchone()[0]
+            connection.execute(f"PRAGMA schema_version = {version + 1}")
+            connection.commit()
+            connection.close()
+            with self.assertRaisesRegex(CacheDatabaseError, "schema"):
+                with ContextCacheDatabase(path):
+                    pass
+
+    def test_posix_open_does_not_change_process_umask(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with patch("cereja.system._context.cache_db.os.umask") as umask:
+                with ContextCacheDatabase(path):
+                    pass
+            umask.assert_not_called()
+
+    @unittest.skipIf(os.name == "nt", "POSIX sidecar modes are not portable on Windows")
+    def test_posix_new_sidecars_are_restricted_immediately(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            path.touch()
+            sidecar = Path(f"{path}-wal")
+            sidecar.touch()
+            sidecar.chmod(0o666)
+            database = ContextCacheDatabase(path)
+            database._secure_new_sidecars(set())
+            self.assertEqual(stat.S_IMODE(sidecar.stat().st_mode), 0o600)
 
     def test_open_rejects_symlink_cache_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -459,6 +459,69 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     ["C:/newer", "C:/protected"],
                 )
 
+    def test_enforce_quota_stops_when_reader_blocks_physical_measurement(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                for root, text in (
+                    ("C:/oldest", "x"),
+                    ("C:/newer", "z"),
+                    ("C:/protected", "y"),
+                ):
+                    scan = database.begin_scan("default", root)
+                    database.commit_scan(scan, [CachedFile(
+                        f"{root}/large.txt",
+                        "large.txt",
+                        FileSignature(None, None, 2_000_000, 10, 11),
+                        "text",
+                        text * 2_000_000,
+                        None,
+                    )])
+                database.connection.execute(
+                    "UPDATE roots SET last_access_ns = CASE canonical_path "
+                    "WHEN 'C:/oldest' THEN 1 WHEN 'C:/newer' THEN 2 ELSE 3 END"
+                )
+                database.connection.commit()
+                database.connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                quota = database.aggregate_size_bytes() - 1
+
+                reader = sqlite3.connect(database_path)
+                try:
+                    reader.execute("BEGIN")
+                    reader.execute("SELECT COUNT(*) FROM files").fetchone()
+                    statements = []
+                    database.connection.set_trace_callback(statements.append)
+                    report = database.enforce_quota(
+                        "C:/protected", max_bytes=quota
+                    )
+                    roots = [row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots ORDER BY canonical_path"
+                    )]
+                    database.connection.set_trace_callback(None)
+                finally:
+                    reader.close()
+
+                checkpoint = database.connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                database.connection.execute("PRAGMA incremental_vacuum(128)")
+                checkpoint = database.connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                settled_size = database.aggregate_size_bytes()
+
+                self.assertEqual(report.roots_removed, 1)
+                self.assertGreater(report.after_bytes, quota)
+                self.assertFalse(any(
+                    "incremental_vacuum" in statement.casefold()
+                    for statement in statements
+                ))
+                self.assertEqual(roots, ["C:/newer", "C:/protected"])
+                self.assertEqual(checkpoint[0], 0)
+                self.assertLessEqual(settled_size, quota)
+
     def test_windows_rejects_any_reparse_point_attribute(self):
         path = Path("reparse-target")
         result = SimpleNamespace(st_file_attributes=0x400)

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -19,8 +19,28 @@ from cereja.system._context.cache_db import (
     ContextCacheDatabase,
     FileSignature,
     ScanToken,
+    _CachePathLock,
+    _LEGACY_SCHEMA_DDL,
     default_cache_path,
 )
+
+
+def _create_legacy_database(path):
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
+    connection.execute("VACUUM")
+    connection.execute("PRAGMA journal_mode = WAL")
+    ddl = ";\n".join(_LEGACY_SCHEMA_DDL.values())
+    connection.executescript(
+        f"""
+        PRAGMA application_id = {APPLICATION_ID};
+        PRAGMA user_version = {SCHEMA_VERSION};
+        {ddl};
+        INSERT INTO namespaces (id, name, last_access_ns)
+            VALUES (1, 'default', 1);
+        """
+    )
+    connection.close()
 
 
 def _storage_snapshot(database):
@@ -222,9 +242,9 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             with ContextCacheDatabase(database_path) as first:
                 scan = first.begin_scan("default", "C:/repo")
                 self.assertEqual(first.commit_scan(scan, [], max_bytes=10 ** 9), ())
-                with ContextCacheDatabase(database_path) as second:
-                    second.connection.execute("BEGIN IMMEDIATE")
-                    second.connection.rollback()
+                shared = _CachePathLock(database_path)
+                shared.acquire(False, wait=False)
+                shared.release()
 
     def test_first_published_token_wins_when_scan_timestamps_are_equal(self):
         nonce_pairs = (
@@ -252,31 +272,30 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     FileSignature(None, None, 1, 1, 1),
                     "text", "loser", None,
                 )
-                with ContextCacheDatabase(database_path) as first, \
-                     ContextCacheDatabase(database_path) as second:
+                with ContextCacheDatabase(database_path) as database:
                     winning_scan = ScanToken(
                         "default", "C:/repo", 7, winning_nonce
                     )
                     losing_scan = ScanToken(
                         "default", "C:/repo", 7, losing_nonce
                     )
-                    first.commit_scan(winning_scan, [winning_file])
-                    baseline = _storage_snapshot(first)
-                    generation = first.connection.execute(
+                    database.commit_scan(winning_scan, [winning_file])
+                    baseline = _storage_snapshot(database)
+                    generation = database.connection.execute(
                         "SELECT scan_generation FROM roots"
                     ).fetchone()[0]
 
                     with self.assertRaises(CacheDatabaseError):
-                        second.commit_scan(losing_scan, [losing_file])
+                        database.commit_scan(losing_scan, [losing_file])
 
-                    self.assertEqual(_storage_snapshot(first), baseline)
+                    self.assertEqual(_storage_snapshot(database), baseline)
                     self.assertEqual(
-                        first.connection.execute(
+                        database.connection.execute(
                             "SELECT scan_generation FROM roots"
                         ).fetchone()[0],
                         generation,
                     )
-                    rows = list(first.iter_root_files("default", "C:/repo"))
+                    rows = list(database.iter_root_files("default", "C:/repo"))
                 self.assertEqual(
                     [row.folded_text for row in rows], ["winner"]
                 )
@@ -747,7 +766,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 rows = list(database.iter_root_files("default", "C:/repo"))
             self.assertEqual([row.folded_text for row in rows], ["new"])
 
-    def test_new_scan_in_another_connection_invalidates_older_token(self):
+    def test_new_scan_in_later_connection_invalidates_older_token(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
             old_file = CachedFile(
@@ -758,14 +777,15 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 12, 13),
                 "text", "new", None,
             )
-            with ContextCacheDatabase(database_path) as first, \
-                 ContextCacheDatabase(database_path) as second:
+            with ContextCacheDatabase(database_path) as first:
                 old_scan = first.begin_scan("default", "C:/repo")
+            with ContextCacheDatabase(database_path) as second:
                 new_scan = second.begin_scan("default", "C:/repo")
                 second.commit_scan(new_scan, [new_file])
+            with ContextCacheDatabase(database_path) as third:
                 with self.assertRaises(CacheDatabaseError):
-                    first.commit_scan(old_scan, [old_file])
-                rows = list(first.iter_root_files("default", "C:/repo"))
+                    third.commit_scan(old_scan, [old_file])
+                rows = list(third.iter_root_files("default", "C:/repo"))
             self.assertEqual([row.folded_text for row in rows], ["new"])
 
     def test_commit_scan_materializes_input_before_starting_transaction(self):
@@ -1342,7 +1362,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     [],
                 )
 
-    def test_open_rebuilds_recognized_version_zero_database(self):
+    def test_open_leaves_recognized_version_zero_database_unchanged(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(path):
@@ -1353,21 +1373,29 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             connection.execute("PRAGMA user_version = 0")
             connection.commit()
             connection.close()
+            storage_paths = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                Path(f"{path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            )
 
-            with ContextCacheDatabase(path) as database:
-                version = database.connection.execute(
-                    "PRAGMA user_version"
-                ).fetchone()[0]
-                tables = database.table_names()
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
 
-            self.assertEqual(version, SCHEMA_VERSION)
-            self.assertEqual(tables, {
-                "metadata", "namespaces", "namespace_roots",
-                "roots", "root_files", "files",
-            })
+            after = tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            )
+            self.assertEqual(after, before)
             self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
 
-    def test_recovery_waits_for_active_cache_opener_before_quarantine(self):
+    def test_unsupported_version_stays_unavailable_after_active_opener_closes(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(path) as active:
@@ -1377,245 +1405,269 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     path,
                     Path(f"{path}-wal"),
                     Path(f"{path}-shm"),
+                    Path(f"{path}-journal"),
                 )
                 before = tuple(
                     item.read_bytes() if item.exists() else None
                     for item in storage_paths
                 )
-                original_move = ContextCacheDatabase._move_to_quarantine
-                with patch.object(
-                    ContextCacheDatabase,
-                    "_move_to_quarantine",
-                    autospec=True,
-                    side_effect=original_move,
-                ) as move:
-                    with self.assertRaises(CacheDatabaseUnavailable):
-                        with ContextCacheDatabase(path):
-                            pass
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
                 after = tuple(
                     item.read_bytes() if item.exists() else None
                     for item in storage_paths
                 )
-                move.assert_not_called()
                 self.assertEqual(after, before)
 
-            with ContextCacheDatabase(path) as recovered:
-                self.assertEqual(
-                    recovered.connection.execute(
-                        "PRAGMA user_version"
-                    ).fetchone()[0],
-                    SCHEMA_VERSION,
-                )
+            before = tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            )
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            ), before)
 
-    def test_open_quarantines_and_replaces_recognized_corrupt_database(self):
+    def test_open_leaves_recognized_corrupt_database_and_journal_unchanged(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             corrupt_bytes = _truncate_recognized_database(path)
-
-            with ContextCacheDatabase(path) as database:
-                version = database.connection.execute(
-                    "PRAGMA user_version"
-                ).fetchone()[0]
-
-            self.assertEqual(version, SCHEMA_VERSION)
-            self.assertNotEqual(path.read_bytes(), corrupt_bytes)
-            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
-
-    def test_open_recovers_recognized_database_with_invalid_wal_header(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            path = Path(temp_dir) / "context.sqlite3"
-            with ContextCacheDatabase(path):
-                pass
-            wal_path = Path(f"{path}-wal")
-            wal_path.write_bytes(b"invalid WAL header".ljust(33, b"!"))
+            journal_path = Path(f"{path}-journal")
+            journal_path.write_bytes(b"foreign journal sentinel")
             if os.name != "nt":
-                wal_path.chmod(0o600)
+                journal_path.chmod(0o600)
+            storage_paths = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                journal_path,
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            )
+            directory_before = {
+                item.name: item.read_bytes()
+                for item in path.parent.iterdir()
+                if item.is_file()
+            }
 
-            with ContextCacheDatabase(path) as database:
-                version = database.connection.execute(
-                    "PRAGMA user_version"
-                ).fetchone()[0]
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
 
-            self.assertEqual(version, SCHEMA_VERSION)
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None
+                for item in storage_paths
+            ), before)
+            self.assertEqual({
+                item.name: item.read_bytes()
+                for item in path.parent.iterdir()
+                if item.is_file()
+            }, directory_before)
+            self.assertEqual(path.read_bytes(), corrupt_bytes)
+            self.assertEqual(list(path.parent.glob(f"{path.name}.quarantine-*")), [])
             self.assertEqual(
-                list(path.parent.glob(f"{path.name}.quarantine-*")), []
+                list(path.parent.glob(".cereja-context-cache-retired-*")),
+                [],
             )
 
-    def test_failed_replacement_keeps_timestamped_random_quarantine(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            path = Path(temp_dir) / "context.sqlite3"
-            corrupt_bytes = _truncate_recognized_database(path)
+    def test_open_leaves_invalid_wal_and_shm_unchanged(self):
+        for wal_bytes in (b"", b"!"):
+            with self.subTest(wal_bytes=wal_bytes), \
+                 tempfile.TemporaryDirectory() as temp_dir:
+                path = Path(temp_dir) / "context.sqlite3"
+                with ContextCacheDatabase(path):
+                    pass
+                wal_path = Path(f"{path}-wal")
+                shm_path = Path(f"{path}-shm")
+                wal_path.write_bytes(wal_bytes)
+                shm_path.write_bytes(b"foreign shm sentinel")
+                if os.name != "nt":
+                    for item in (wal_path, shm_path):
+                        item.chmod(0o600)
+                storage_paths = (path, wal_path, shm_path)
+                before = tuple(item.read_bytes() for item in storage_paths)
 
-            with patch.object(
-                ContextCacheDatabase,
-                "_create_schema",
-                side_effect=sqlite3.OperationalError("replacement failed"),
-            ):
                 with self.assertRaises(CacheDatabaseUnavailable):
                     with ContextCacheDatabase(path):
                         pass
 
-            quarantines = list(
-                path.parent.glob(f"{path.name}.quarantine-[0-9]*-[0-9a-f]*")
-            )
-            self.assertEqual(len(quarantines), 1)
-            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
-            self.assertFalse(path.exists())
-            self.assertEqual(
-                list(path.parent.glob(f"{path.name}.replacement-*")), []
-            )
+                self.assertEqual(
+                    tuple(item.read_bytes() for item in storage_paths),
+                    before,
+                )
+                self.assertEqual(
+                    list(path.parent.glob(f"{path.name}.quarantine-*")), []
+                )
 
-    def test_recovery_never_clobbers_path_recreated_before_publication(self):
+    def test_open_leaves_valid_wal_with_invalid_shm_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            path = directory / "context.sqlite3"
+            source = ContextCacheDatabase(source_path)
+            source.__enter__()
+            try:
+                source.connection.execute(
+                    "UPDATE namespaces SET last_access_ns = last_access_ns + 1"
+                )
+                source.connection.commit()
+                path.write_bytes(source_path.read_bytes())
+                wal_path = Path(f"{path}-wal")
+                wal_path.write_bytes(Path(f"{source_path}-wal").read_bytes())
+                shm_path = Path(f"{path}-shm")
+                shm_path.write_bytes(b"S" * 32768)
+                if os.name != "nt":
+                    for item in (path, wal_path, shm_path):
+                        item.chmod(0o600)
+                before = tuple(
+                    item.read_bytes() for item in (path, wal_path, shm_path)
+                )
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                self.assertEqual(
+                    tuple(item.read_bytes() for item in (path, wal_path, shm_path)),
+                    before,
+                )
+            finally:
+                source.__exit__(None, None, None)
+
+    def test_open_rejects_legitimate_active_wal_and_shm_without_mutation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
-            corrupt_bytes = _truncate_recognized_database(path)
-            foreign_bytes = None
-            original_publish = ContextCacheDatabase._publish_replacement
-
-            def recreate_then_publish(
-                database, replacement_path, replacement_identity=None
-            ):
-                nonlocal foreign_bytes
-                connection = sqlite3.connect(path)
-                connection.execute("PRAGMA application_id = 12345")
-                connection.execute("CREATE TABLE foreign_data (value TEXT)")
-                connection.execute(
-                    "INSERT INTO foreign_data VALUES ('keep me')"
-                )
-                connection.commit()
-                connection.close()
-                if os.name != "nt":
-                    path.chmod(0o600)
-                foreign_bytes = path.read_bytes()
-                if replacement_identity is None:
-                    return original_publish(database, replacement_path)
-                return original_publish(
-                    database, replacement_path, replacement_identity
+            owner = ContextCacheDatabase(path)
+            owner.__enter__()
+            try:
+                owner.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                wal_path = Path(f"{path}-wal")
+                shm_path = Path(f"{path}-shm")
+                self.assertEqual(wal_path.stat().st_size, 0)
+                self.assertGreaterEqual(shm_path.stat().st_size, 136)
+                before = (
+                    path.read_bytes(),
+                    wal_path.read_bytes(),
+                    shm_path.read_bytes(),
                 )
 
-            with patch.object(
-                ContextCacheDatabase,
-                "_publish_replacement",
-                autospec=True,
-                side_effect=recreate_then_publish,
-            ), self.assertRaises(CacheDatabaseError):
-                with ContextCacheDatabase(path):
-                    pass
+                real_connect = sqlite3.connect
+                with patch(
+                    "cereja.system._context.cache_db.sqlite3.connect",
+                    wraps=real_connect,
+                ) as connect, self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
 
-            self.assertEqual(path.read_bytes(), foreign_bytes)
-            quarantines = list(
-                path.parent.glob(f"{path.name}.quarantine-*-")
-            )
-            if not quarantines:
-                quarantines = list(
-                    path.parent.glob(f"{path.name}.quarantine-*")
+                self.assertEqual(
+                    (
+                        path.read_bytes(),
+                        wal_path.read_bytes(),
+                        shm_path.read_bytes(),
+                    ),
+                    before,
                 )
-            self.assertEqual(len(quarantines), 1)
-            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
-            replacements = list(
-                path.parent.glob(f"{path.name}.replacement-*")
-            )
-            self.assertEqual(len(replacements), 1)
+                self.assertFalse(any(
+                    call.args and call.args[0] == str(path)
+                    for call in connect.call_args_list
+                ))
+            finally:
+                owner.__exit__(None, None, None)
 
-    def test_recovery_rejects_replacement_swapped_after_validation(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            path = Path(temp_dir) / "context.sqlite3"
-            corrupt_bytes = _truncate_recognized_database(path)
-            foreign_bytes = None
-            original_publish = ContextCacheDatabase._publish_replacement
-
-            def swap_then_publish(
-                database, replacement_path, replacement_identity=None
-            ):
-                nonlocal foreign_bytes
-                replacement_path.unlink()
-                connection = sqlite3.connect(replacement_path)
-                connection.execute("PRAGMA application_id = 12345")
-                connection.execute("CREATE TABLE foreign_data (value TEXT)")
-                connection.execute(
-                    "INSERT INTO foreign_data VALUES ('keep me')"
-                )
-                connection.commit()
-                connection.close()
-                if os.name != "nt":
-                    replacement_path.chmod(0o600)
-                foreign_bytes = replacement_path.read_bytes()
-                if replacement_identity is None:
-                    return original_publish(database, replacement_path)
-                return original_publish(
-                    database, replacement_path, replacement_identity
-                )
-
-            with patch.object(
-                ContextCacheDatabase,
-                "_publish_replacement",
-                autospec=True,
-                side_effect=swap_then_publish,
-            ), self.assertRaises(CacheDatabaseError):
-                with ContextCacheDatabase(path):
-                    pass
-
-            self.assertFalse(path.exists())
-            quarantines = list(
-                path.parent.glob(f"{path.name}.quarantine-*")
-            )
-            self.assertEqual(len(quarantines), 1)
-            self.assertEqual(quarantines[0].read_bytes(), corrupt_bytes)
-            replacements = list(
-                path.parent.glob(f"{path.name}.replacement-*")
-            )
-            self.assertEqual(len(replacements), 1)
-            self.assertEqual(replacements[0].read_bytes(), foreign_bytes)
-
-    def test_quarantine_move_failure_restores_every_original_path(self):
+    def test_shared_lock_does_not_bypass_existing_sidecar_rejection(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(path):
                 pass
             wal_path = Path(f"{path}-wal")
             shm_path = Path(f"{path}-shm")
-            wal_path.write_bytes(b"wal sentinel")
-            shm_path.write_bytes(b"shm sentinel")
+            wal_path.write_bytes(b"")
+            shm_path.write_bytes(b"S" * 32768)
             if os.name != "nt":
                 wal_path.chmod(0o600)
                 shm_path.chmod(0o600)
-            before = {
-                item: item.read_bytes() for item in (path, wal_path, shm_path)
-            }
-            database = ContextCacheDatabase(path)
-            prepared = database._prepare_path()
-            directory = path.parent.resolve(strict=True)
-            quarantine_paths = database._quarantine_paths(
-                prepared[3], directory
+            before = (path.read_bytes(), wal_path.read_bytes(), shm_path.read_bytes())
+            lock = _CachePathLock(path)
+            lock.acquire(False)
+            try:
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+            finally:
+                lock.release()
+
+            self.assertEqual(
+                (path.read_bytes(), wal_path.read_bytes(), shm_path.read_bytes()),
+                before,
             )
-            original_rename = os.rename
-            calls = 0
 
-            def fail_second_rename(source, target):
-                nonlocal calls
-                calls += 1
-                if calls == 2:
-                    raise OSError("injected quarantine move failure")
-                return original_rename(source, target)
+    def test_open_leaves_orphan_shm_beside_valid_database_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            shm_path = Path(f"{path}-shm")
+            shm_path.write_bytes(b"foreign shm sentinel")
+            if os.name != "nt":
+                shm_path.chmod(0o600)
+            before = (path.read_bytes(), shm_path.read_bytes())
 
-            with patch(
-                "cereja.system._context.cache_db.os.rename",
-                side_effect=fail_second_rename,
-            ), self.assertRaisesRegex(
-                OSError, "injected quarantine move failure"
-            ):
-                database._move_to_quarantine(
-                    quarantine_paths, prepared[2], prepared[3]
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(
+                (path.read_bytes(), shm_path.read_bytes()),
+                before,
+            )
+
+    def test_open_leaves_orphan_sidecar_without_creating_database(self):
+        for suffix in ("-wal", "-shm", "-journal"):
+            with self.subTest(suffix=suffix), \
+                 tempfile.TemporaryDirectory() as temp_dir:
+                path = Path(temp_dir) / "context.sqlite3"
+                sidecar = Path(f"{path}{suffix}")
+                sidecar.write_bytes(b"orphan sidecar sentinel")
+                if os.name != "nt":
+                    sidecar.chmod(0o600)
+                before = sidecar.read_bytes()
+
+                with self.assertRaises(CacheDatabaseError):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                self.assertFalse(path.exists())
+                self.assertEqual(sidecar.read_bytes(), before)
+
+    def test_open_leaves_empty_database_with_existing_sidecar_unchanged(self):
+        for suffix in ("-wal", "-shm", "-journal"):
+            with self.subTest(suffix=suffix), \
+                 tempfile.TemporaryDirectory() as temp_dir:
+                path = Path(temp_dir) / "context.sqlite3"
+                path.touch()
+                sidecar = Path(f"{path}{suffix}")
+                sidecar.write_bytes(b"preexisting sidecar sentinel")
+                if os.name != "nt":
+                    path.chmod(0o600)
+                    sidecar.chmod(0o600)
+                before = (path.read_bytes(), sidecar.read_bytes())
+
+                with self.assertRaises(CacheDatabaseError):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                self.assertEqual(
+                    (path.read_bytes(), sidecar.read_bytes()),
+                    before,
                 )
 
-            self.assertEqual(
-                {item: item.read_bytes() for item in before}, before
-            )
-            self.assertEqual(
-                list(path.parent.glob(f"{path.name}.quarantine-*")), []
-            )
-
-    def test_recovery_leaves_symlink_and_non_regular_targets_untouched(self):
+    def test_open_leaves_symlink_and_non_regular_targets_untouched(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             directory = Path(temp_dir)
             target = directory / "target.sqlite3"
@@ -1644,6 +1696,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             connection = sqlite3.connect(path)
             connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
             connection.execute("VACUUM")
+            connection.execute("PRAGMA journal_mode = WAL")
             connection.executescript(
                 f"""
                 PRAGMA application_id = {APPLICATION_ID};
@@ -1717,6 +1770,119 @@ class ContextCacheDatabaseTest(unittest.TestCase):
 
             self.assertEqual(root, (4, 0, ""))
 
+    def test_failed_supported_migration_rolls_back_storage_byte_for_byte(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            _create_legacy_database(path)
+            storage = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                Path(f"{path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            )
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_validate_schema_structure",
+                side_effect=CacheDatabaseUnavailable("validation failed"),
+            ), self.assertRaisesRegex(CacheDatabaseUnavailable, "validation failed"):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            ), before)
+            connection = sqlite3.connect(f"file:{path}?immutable=1", uri=True)
+            try:
+                columns = {
+                    row[1] for row in connection.execute("PRAGMA table_info(roots)")
+                }
+            finally:
+                connection.close()
+            self.assertNotIn("scan_started_ns", columns)
+            self.assertNotIn("scan_nonce", columns)
+
+    def test_supported_migration_validates_only_before_commit(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            _create_legacy_database(path)
+            original = ContextCacheDatabase._validate_schema_structure
+            calls = 0
+
+            def validate(database):
+                nonlocal calls
+                calls += 1
+                return original(database)
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_validate_schema_structure",
+                validate,
+            ):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(calls, 1)
+
+    def test_migration_with_existing_wal_fails_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            path = directory / "context.sqlite3"
+            _create_legacy_database(source_path)
+            source = sqlite3.connect(source_path)
+            source.execute("PRAGMA wal_autocheckpoint = 0")
+            source.execute("UPDATE namespaces SET last_access_ns = 2")
+            source.commit()
+            try:
+                path.write_bytes(source_path.read_bytes())
+                wal_path = Path(f"{path}-wal")
+                wal_path.write_bytes(Path(f"{source_path}-wal").read_bytes())
+                if os.name != "nt":
+                    path.chmod(0o600)
+                    wal_path.chmod(0o600)
+                before = (path.read_bytes(), wal_path.read_bytes())
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                self.assertEqual((path.read_bytes(), wal_path.read_bytes()), before)
+            finally:
+                source.close()
+
+    def test_open_leaves_current_schema_in_delete_mode_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            self.assertEqual(
+                connection.execute("PRAGMA journal_mode = DELETE").fetchone()[0],
+                "delete",
+            )
+            connection.close()
+            storage = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                Path(f"{path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            )
+
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            ), before)
+
     @unittest.skipIf(os.name == "nt", "POSIX permissions are not portable on Windows")
     def test_open_restricts_new_database_and_cache_directory_permissions(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1775,18 +1941,86 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             self.assertTrue(path.is_file())
             self.assertEqual(path.parent.parent.parent, Path(temp_dir))
 
-    def test_open_bootstraps_preexisting_empty_file_with_incremental_vacuum(self):
+    def test_open_leaves_preexisting_empty_file_unchanged(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             path.touch()
             if os.name != "nt":
                 path.chmod(0o600)
-            with ContextCacheDatabase(path) as database:
-                self.assertEqual(
-                    database.connection.execute("PRAGMA auto_vacuum").fetchone()[0], 2
-                )
+            before = path.read_bytes()
 
-    def test_open_rejects_schema_with_altered_column(self):
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(path.read_bytes(), before)
+            self.assertFalse(Path(f"{path}-wal").exists())
+            self.assertFalse(Path(f"{path}-shm").exists())
+            self.assertFalse(Path(f"{path}-journal").exists())
+
+    def test_bootstrap_lock_failure_does_not_publish_empty_database(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            lock = _CachePathLock(path)
+            lock.acquire(True)
+            try:
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+                self.assertFalse(path.exists())
+            finally:
+                lock.release()
+
+            with ContextCacheDatabase(path):
+                pass
+            self.assertTrue(path.is_file())
+
+    def test_bootstrap_connect_failure_does_not_poison_next_open(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache_db.sqlite3.connect",
+                side_effect=sqlite3.OperationalError("temporary failure"),
+            ), self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+            self.assertFalse(path.exists())
+
+            with ContextCacheDatabase(path):
+                pass
+            self.assertTrue(path.is_file())
+
+    def test_bootstrap_does_not_remove_database_that_appears_before_lock(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            original = ContextCacheDatabase._acquire_cache_lock
+            published = []
+
+            def acquire(database, exclusive):
+                connection = sqlite3.connect(path)
+                connection.execute("PRAGMA application_id = 12345")
+                connection.execute("CREATE TABLE foreign_data(value TEXT)")
+                connection.execute(
+                    "INSERT INTO foreign_data VALUES ('keep')"
+                )
+                connection.commit()
+                connection.close()
+                if os.name != "nt":
+                    path.chmod(0o600)
+                published.append(path.read_bytes())
+                original(database, exclusive)
+
+            with patch.object(
+                ContextCacheDatabase,
+                "_acquire_cache_lock",
+                acquire,
+            ), self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(path.read_bytes(), published[0])
+
+    def test_open_and_info_reject_altered_schema_without_mutation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(path):
@@ -1795,9 +2029,75 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             connection.execute("ALTER TABLE files RENAME COLUMN folded_text TO changed_text")
             connection.commit()
             connection.close()
-            with self.assertRaisesRegex(CacheDatabaseError, "schema"):
+            storage = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                Path(f"{path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            )
+
+            with self.assertRaisesRegex(CacheDatabaseUnavailable, "schema"):
                 with ContextCacheDatabase(path):
                     pass
+            with self.assertRaisesRegex(CacheDatabaseUnavailable, "schema"):
+                ContextCacheDatabase.read_info(path)
+
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            ), before)
+
+    def test_read_info_queries_private_snapshot_even_without_wal(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            queried_paths = []
+            original = ContextCacheDatabase._query_info
+
+            def query(database, *args):
+                queried_paths.append(database.path)
+                return original(database, *args)
+
+            with patch.object(ContextCacheDatabase, "_query_info", query):
+                info = ContextCacheDatabase.read_info(path)
+
+            self.assertEqual(info.path, path.absolute().as_posix())
+            self.assertEqual(len(queried_paths), 1)
+            self.assertNotEqual(queried_paths[0], path)
+
+    def test_open_rejects_foreign_key_corruption_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(path):
+                pass
+            connection = sqlite3.connect(path)
+            connection.execute("PRAGMA foreign_keys = OFF")
+            connection.execute(
+                "INSERT INTO namespace_roots (namespace_id, root_id) "
+                "VALUES (999, 999)"
+            )
+            connection.commit()
+            connection.close()
+            storage = (
+                path,
+                Path(f"{path}-wal"),
+                Path(f"{path}-shm"),
+                Path(f"{path}-journal"),
+            )
+            before = tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            )
+
+            with self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(tuple(
+                item.read_bytes() if item.exists() else None for item in storage
+            ), before)
 
     def test_open_rejects_schema_without_default_namespace(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1910,28 +2210,101 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     for item in sidecars
                 ))
 
-    def test_open_rejects_preexisting_sidecar_replaced_during_open(self):
+    def test_open_rejects_existing_valid_wal_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            source_path = directory / "source.sqlite3"
+            path = directory / "context.sqlite3"
+            owner = ContextCacheDatabase(source_path)
+            owner.__enter__()
+            try:
+                owner.connection.execute(
+                    "UPDATE namespaces SET last_access_ns = last_access_ns + 1"
+                )
+                owner.connection.commit()
+                sidecar = Path(f"{path}-wal")
+                path.write_bytes(source_path.read_bytes())
+                sidecar.write_bytes(Path(f"{source_path}-wal").read_bytes())
+                if os.name != "nt":
+                    path.chmod(0o600)
+                    sidecar.chmod(0o600)
+                before = (path.read_bytes(), sidecar.read_bytes())
+
+                with self.assertRaises(CacheDatabaseUnavailable):
+                    with ContextCacheDatabase(path):
+                        pass
+
+                self.assertEqual(
+                    (path.read_bytes(), sidecar.read_bytes()), before
+                )
+            finally:
+                owner.__exit__(None, None, None)
+
+    def test_open_prevents_rollback_journal_injection_before_connect(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
             with ContextCacheDatabase(path):
                 pass
-            sidecar = Path(f"{path}-wal")
-            sidecar.touch()
-            if os.name != "nt":
-                sidecar.chmod(0o600)
+            before = path.read_bytes()
+            journal = Path(f"{path}-journal")
+            real_connect = sqlite3.connect
+            attempted = False
 
-            def replace_sidecar(database, database_is_empty):
-                replacement = path.parent / "replacement-wal"
-                replacement.touch()
-                if os.name != "nt":
-                    replacement.chmod(0o600)
-                replacement.replace(sidecar)
+            def connect(*args, **kwargs):
+                nonlocal attempted
+                if args and args[0] == str(path):
+                    attempted = True
+                    journal.write_bytes(b"J" * 512)
+                return real_connect(*args, **kwargs)
 
-            with patch.object(ContextCacheDatabase, "_configure_connection",
-                              replace_sidecar):
-                with self.assertRaisesRegex(CacheDatabaseError, "sidecar.*identity"):
+            with patch(
+                "cereja.system._context.cache_db.sqlite3.connect",
+                side_effect=connect,
+            ), self.assertRaises(CacheDatabaseUnavailable):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertTrue(attempted)
+            self.assertEqual(path.read_bytes(), before)
+            self.assertFalse(journal.exists())
+
+    def test_open_rejects_sidecar_created_after_preflight_before_connect(self):
+        for suffix in ("-wal", "-shm"):
+            with self.subTest(suffix=suffix), \
+                 tempfile.TemporaryDirectory() as temp_dir:
+                path = Path(temp_dir) / "context.sqlite3"
+                with ContextCacheDatabase(path):
+                    pass
+                main_before = path.read_bytes()
+                sidecar = Path(f"{path}{suffix}")
+                sentinel = f"injected {suffix}".encode()
+                reserve = ContextCacheDatabase._reserve_rollback_journal
+
+                def reserve_then_inject(database):
+                    reservation = reserve(database)
+                    sidecar.write_bytes(sentinel)
+                    if os.name != "nt":
+                        sidecar.chmod(0o600)
+                    return reservation
+
+                real_connect = sqlite3.connect
+                with patch.object(
+                    ContextCacheDatabase,
+                    "_reserve_rollback_journal",
+                    reserve_then_inject,
+                ), patch(
+                    "cereja.system._context.cache_db.sqlite3.connect",
+                    wraps=real_connect,
+                ) as connect, self.assertRaises(CacheDatabaseUnavailable):
                     with ContextCacheDatabase(path):
                         pass
+
+                self.assertEqual(path.read_bytes(), main_before)
+                self.assertEqual(sidecar.read_bytes(), sentinel)
+                self.assertFalse(any(
+                    call.args and call.args[0] == str(path)
+                    for call in connect.call_args_list
+                ))
 
     def test_open_rejects_unexpected_sqlite_schema_objects(self):
         statements = (
@@ -1972,6 +2345,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
             connection = sqlite3.connect(path)
             connection.execute(f"PRAGMA application_id = {APPLICATION_ID}")
             connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            connection.execute("PRAGMA journal_mode = WAL")
             connection.close()
             with self.assertRaisesRegex(CacheDatabaseError, "auto_vacuum"):
                 with ContextCacheDatabase(path):
@@ -1980,27 +2354,33 @@ class ContextCacheDatabaseTest(unittest.TestCase):
     def test_open_aborts_when_file_identity_changes_after_connect(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "context.sqlite3"
-            path.touch()
-            if os.name != "nt":
-                path.chmod(0o600)
+            with ContextCacheDatabase(path):
+                pass
             original_identity = ContextCacheDatabase._identity
-            calls = 0
+            real_connect = sqlite3.connect
+            source_connected = False
 
             def changed_identity(candidate):
-                nonlocal calls
                 identity = original_identity(candidate)
-                if candidate == path:
-                    calls += 1
-                    if calls > 1:
-                        return identity[0], identity[1] + 1
+                if candidate == path and source_connected:
+                    return identity[0], identity[1] + 1
                 return identity
 
-            with patch.object(
-                ContextCacheDatabase, "_identity", side_effect=changed_identity
-            ):
+            def connect(*args, **kwargs):
+                nonlocal source_connected
+                connection = real_connect(*args, **kwargs)
+                if args and args[0] == str(path):
+                    source_connected = True
+                return connection
+
+            with patch.object(ContextCacheDatabase, "_identity",
+                              side_effect=changed_identity), \
+                 patch("cereja.system._context.cache_db.sqlite3.connect",
+                       side_effect=connect):
                 with self.assertRaisesRegex(CacheDatabaseError, "identity"):
                     with ContextCacheDatabase(path):
                         pass
+            self.assertTrue(source_connected)
 
 
 if __name__ == "__main__":

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -17,11 +17,52 @@ from cereja.system._context.cache_db import (
     CachedFile,
     ContextCacheDatabase,
     FileSignature,
+    ScanToken,
     default_cache_path,
 )
 
 
+def _storage_snapshot(database):
+    paths = (database.path, *database._sidecar_paths())
+    sizes = tuple(
+        path.stat(follow_symlinks=False).st_size if path.exists() else 0
+        for path in paths
+    )
+    return (*sizes, database.aggregate_size_bytes())
+
+
+class _FailingPragmaConnection:
+    def __init__(self, connection, statement, error, *, after=False):
+        self._connection = connection
+        self._statement = " ".join(statement.casefold().split())
+        self._error = error
+        self._after = after
+        self._failed = False
+
+    def execute(self, statement, *args, **kwargs):
+        normalized = " ".join(statement.casefold().split())
+        if not self._failed and normalized == self._statement:
+            self._failed = True
+            if self._after:
+                self._connection.execute(statement, *args, **kwargs)
+            raise self._error
+        return self._connection.execute(statement, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_connection_disables_automatic_wal_checkpointing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                automatic_checkpoint_pages = database.connection.execute(
+                    "PRAGMA wal_autocheckpoint"
+                ).fetchone()[0]
+
+            self.assertEqual(automatic_checkpoint_pages, 0)
+
     def test_begin_scan_is_in_memory_only(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
@@ -54,10 +95,84 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 old_scan = database.begin_scan("default", "C:/repo")
                 new_scan = database.begin_scan("default", "C:/repo")
 
-            self.assertLess(
-                (old_scan.started_ns, old_scan.nonce),
-                (new_scan.started_ns, new_scan.nonce),
-            )
+            self.assertLess(old_scan.started_ns, new_scan.started_ns)
+
+    def test_refused_scan_preflight_does_not_change_physical_storage(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                database.connection.execute(
+                    "UPDATE namespaces SET last_access_ns = last_access_ns + 1"
+                )
+                database.connection.commit()
+                baseline = _storage_snapshot(database)
+                self.assertGreater(baseline[1], 0)
+
+                scans = database.begin_scans_if_admitted(
+                    "default", ["C:/repo"], max_bytes=0
+                )
+
+                self.assertIsNone(scans)
+                self.assertEqual(_storage_snapshot(database), baseline)
+
+    def test_scan_preflight_includes_conservative_physical_projection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                database._checkpoint_wal()
+                aggregate = database.aggregate_size_bytes()
+                projected = database._projected_aggregate_size()
+                self.assertGreater(projected, aggregate)
+                max_bytes = aggregate + (projected - aggregate) // 2
+                baseline = _storage_snapshot(database)
+
+                scans = database.begin_scans_if_admitted(
+                    "default", ["C:/repo"], max_bytes=max_bytes
+                )
+
+                self.assertIsNone(scans)
+                self.assertEqual(_storage_snapshot(database), baseline)
+
+    def test_refused_bounded_commit_does_not_change_physical_storage(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.connection.execute(
+                    "UPDATE namespaces SET last_access_ns = last_access_ns + 1"
+                )
+                database.connection.commit()
+                baseline = _storage_snapshot(database)
+                self.assertGreater(baseline[1], 0)
+
+                admitted = database.commit_scan(scan, [], max_bytes=0)
+
+                self.assertIsNone(admitted)
+                self.assertEqual(_storage_snapshot(database), baseline)
+
+    def test_preflight_and_bounded_commit_never_run_maintenance(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                statements = []
+                database.connection.set_trace_callback(statements.append)
+                scans = database.begin_scans_if_admitted(
+                    "default", ["C:/repo"], max_bytes=10 ** 9
+                )
+
+                admitted = database.commit_scan(
+                    scans["C:/repo"], [], max_bytes=10 ** 9
+                )
+                database.connection.set_trace_callback(None)
+
+                self.assertEqual(admitted, ())
+                maintenance = [
+                    statement
+                    for statement in statements
+                    if "wal_checkpoint" in statement.casefold()
+                    or "incremental_vacuum" in statement.casefold()
+                ]
+                self.assertEqual(maintenance, [])
 
     def test_reader_after_preflight_leaves_root_generation_and_storage_unchanged(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -102,32 +217,256 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     second.connection.execute("BEGIN IMMEDIATE")
                     second.connection.rollback()
 
-    def test_equal_timestamp_uses_nonce_for_cross_connection_scan_order(self):
+    def test_first_published_token_wins_when_scan_timestamps_are_equal(self):
+        nonce_pairs = (
+            (
+                "00000000-0000-0000-0000-000000000001",
+                "00000000-0000-0000-0000-000000000002",
+            ),
+            (
+                "00000000-0000-0000-0000-000000000002",
+                "00000000-0000-0000-0000-000000000001",
+            ),
+        )
+        for winning_nonce, losing_nonce in nonce_pairs:
+            with self.subTest(
+                    winning_nonce=winning_nonce, losing_nonce=losing_nonce), \
+                    tempfile.TemporaryDirectory() as temp_dir:
+                database_path = Path(temp_dir) / "context.sqlite3"
+                winning_file = CachedFile(
+                    "C:/repo/a.txt", "a.txt",
+                    FileSignature(None, None, 1, 2, 2),
+                    "text", "winner", None,
+                )
+                losing_file = CachedFile(
+                    "C:/repo/a.txt", "a.txt",
+                    FileSignature(None, None, 1, 1, 1),
+                    "text", "loser", None,
+                )
+                with ContextCacheDatabase(database_path) as first, \
+                     ContextCacheDatabase(database_path) as second:
+                    winning_scan = ScanToken(
+                        "default", "C:/repo", 7, winning_nonce
+                    )
+                    losing_scan = ScanToken(
+                        "default", "C:/repo", 7, losing_nonce
+                    )
+                    first.commit_scan(winning_scan, [winning_file])
+                    baseline = _storage_snapshot(first)
+                    generation = first.connection.execute(
+                        "SELECT scan_generation FROM roots"
+                    ).fetchone()[0]
+
+                    with self.assertRaises(CacheDatabaseError):
+                        second.commit_scan(losing_scan, [losing_file])
+
+                    self.assertEqual(_storage_snapshot(first), baseline)
+                    self.assertEqual(
+                        first.connection.execute(
+                            "SELECT scan_generation FROM roots"
+                        ).fetchone()[0],
+                        generation,
+                    )
+                    rows = list(first.iter_root_files("default", "C:/repo"))
+                self.assertEqual(
+                    [row.folded_text for row in rows], ["winner"]
+                )
+
+    def test_replayed_token_cannot_publish_a_different_payload(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
-            old_file = CachedFile(
+            first_file = CachedFile(
                 "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 1, 1),
-                "text", "old", None,
+                "text", "first", None,
             )
-            new_file = CachedFile(
+            changed_file = CachedFile(
                 "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 2, 2),
-                "text", "new", None,
+                "text", "changed", None,
             )
-            nonces = [
-                uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                uuid.UUID("00000000-0000-0000-0000-000000000002"),
-            ]
-            with ContextCacheDatabase(database_path) as first, \
-                 ContextCacheDatabase(database_path) as second, \
-                 patch("cereja.system._context.cache_db.time.time_ns", return_value=7), \
-                 patch("cereja.system._context.cache_db.uuid.uuid4", side_effect=nonces):
-                old_scan = first.begin_scan("default", "C:/repo")
-                new_scan = second.begin_scan("default", "C:/repo")
-                second.commit_scan(new_scan, [new_file])
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, [first_file])
+                baseline = _storage_snapshot(database)
+
                 with self.assertRaises(CacheDatabaseError):
-                    first.commit_scan(old_scan, [old_file])
-                rows = list(first.iter_root_files("default", "C:/repo"))
-            self.assertEqual([row.folded_text for row in rows], ["new"])
+                    database.commit_scan(scan, [changed_file])
+
+                self.assertEqual(_storage_snapshot(database), baseline)
+                rows = list(database.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.folded_text for row in rows], ["first"])
+
+    def test_bounded_commit_restores_normal_locking_when_size_check_fails(
+            self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                scan = database.begin_scan("default", "C:/repo")
+                current_size = database.aggregate_size_bytes()
+                with patch.object(
+                    database,
+                    "aggregate_size_bytes",
+                    side_effect=(
+                        current_size,
+                        RuntimeError("size check failed"),
+                    ),
+                ), self.assertRaisesRegex(RuntimeError, "size check failed"):
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                self.assertEqual(
+                    connection.execute("PRAGMA locking_mode").fetchone()[0],
+                    "normal",
+                )
+                self.assertNotEqual(
+                    connection.execute("PRAGMA cache_spill").fetchone()[0],
+                    0,
+                )
+
+    def test_bounded_commit_restores_normal_locking_when_cache_spill_fails(
+            self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                database._connection = _FailingPragmaConnection(
+                    connection,
+                    "PRAGMA cache_spill = OFF",
+                    RuntimeError("cache spill setup failed"),
+                    after=True,
+                )
+                scan = database.begin_scan("default", "C:/repo")
+                with self.assertRaisesRegex(
+                    RuntimeError, "cache spill setup failed"
+                ):
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                self.assertEqual(
+                    connection.execute("PRAGMA locking_mode").fetchone()[0],
+                    "normal",
+                )
+                self.assertNotEqual(
+                    connection.execute("PRAGMA cache_spill").fetchone()[0],
+                    0,
+                )
+
+    def test_cache_spill_restore_failure_does_not_skip_lock_restore(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                database._connection = _FailingPragmaConnection(
+                    connection,
+                    "PRAGMA cache_spill = ON",
+                    RuntimeError("cache spill restore failed"),
+                )
+                scan = database.begin_scan("default", "C:/repo")
+                with self.assertRaisesRegex(
+                    RuntimeError, "cache spill restore failed"
+                ):
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                self.assertEqual(
+                    connection.execute("PRAGMA locking_mode").fetchone()[0],
+                    "normal",
+                )
+
+    def test_commit_error_is_preserved_when_cache_spill_restore_also_fails(
+            self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                database._connection = _FailingPragmaConnection(
+                    connection,
+                    "PRAGMA cache_spill = ON",
+                    RuntimeError("cache spill restore failed"),
+                )
+                scan = database.begin_scan("default", "C:/repo")
+                initial_projection = database._projected_aggregate_size()
+                with patch.object(
+                    database,
+                    "_projected_aggregate_size",
+                    side_effect=(
+                        initial_projection,
+                        ValueError("projection failed"),
+                    ),
+                ), self.assertRaisesRegex(
+                    ValueError, "projection failed"
+                ) as caught:
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                self.assertIsInstance(
+                    caught.exception.__cause__, RuntimeError
+                )
+                self.assertEqual(
+                    connection.execute("PRAGMA locking_mode").fetchone()[0],
+                    "normal",
+                )
+
+    def test_primary_error_chains_both_pragma_restoration_errors(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                database._connection = _FailingPragmaConnection(
+                    connection,
+                    "PRAGMA cache_spill = ON",
+                    RuntimeError("cache spill restore failed"),
+                )
+                scan = database.begin_scan("default", "C:/repo")
+                initial_projection = database._projected_aggregate_size()
+                with patch.object(
+                    database,
+                    "_projected_aggregate_size",
+                    side_effect=(
+                        initial_projection,
+                        ValueError("projection failed"),
+                    ),
+                ), patch.object(
+                    database,
+                    "_restore_normal_locking",
+                    side_effect=RuntimeError("locking restore failed"),
+                ), self.assertRaisesRegex(
+                    ValueError, "projection failed"
+                ) as caught:
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                cleanup_group = caught.exception.__cause__
+                self.assertIsInstance(cleanup_group, BaseExceptionGroup)
+                self.assertEqual(
+                    [str(error) for error in cleanup_group.exceptions],
+                    [
+                        "cache spill restore failed",
+                        "locking restore failed",
+                    ],
+                )
+                database._restore_normal_locking()
+
+    def test_exclusive_setup_error_restores_normal_locking(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                connection = database.connection
+                database._connection = _FailingPragmaConnection(
+                    connection,
+                    "PRAGMA locking_mode = EXCLUSIVE",
+                    RuntimeError("exclusive setup failed"),
+                    after=True,
+                )
+                scan = database.begin_scan("default", "C:/repo")
+                with self.assertRaisesRegex(
+                    RuntimeError, "exclusive setup failed"
+                ):
+                    database.commit_scan(scan, [], max_bytes=10 ** 9)
+
+                self.assertEqual(
+                    connection.execute("PRAGMA locking_mode").fetchone()[0],
+                    "normal",
+                )
+                self.assertNotEqual(
+                    connection.execute("PRAGMA cache_spill").fetchone()[0],
+                    0,
+                )
 
     def test_commit_scan_at_physical_quota_is_read_only(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -165,13 +504,27 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 database._checkpoint_wal()
                 scan = database.begin_scan("default", "C:/repo")
                 database._checkpoint_wal()
-                quota = database.aggregate_size_bytes() + 1
+                quota = 10 ** 9
+                baseline = _storage_snapshot(database)
+                statements = []
+                database.connection.set_trace_callback(statements.append)
 
-                admitted = database.commit_scan(
-                    scan, [], max_bytes=quota
-                )
+                with patch.object(
+                    database,
+                    "_projected_aggregate_size",
+                    side_effect=(0, 0, quota + 1),
+                ):
+                    admitted = database.commit_scan(
+                        scan, [], max_bytes=quota
+                    )
+                database.connection.set_trace_callback(None)
 
                 self.assertIsNone(admitted)
+                self.assertTrue(any(
+                    "delete from root_files" in statement.casefold()
+                    for statement in statements
+                ))
+                self.assertEqual(_storage_snapshot(database), baseline)
                 self.assertEqual(
                     len(tuple(database.iter_root_files("default", "C:/repo"))),
                     len(files),
@@ -202,6 +555,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                         "UPDATE roots SET last_access_ns = last_access_ns + 1"
                     )
                     database.connection.commit()
+                    baseline = _storage_snapshot(database)
 
                     admitted = database.commit_scan(
                         scan, [], max_bytes=10 ** 9
@@ -210,6 +564,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     reader.close()
 
                 self.assertIsNone(admitted)
+                self.assertEqual(_storage_snapshot(database), baseline)
                 self.assertEqual(
                     [item.relative_path for item in database.iter_root_files(
                         "default", "C:/repo"

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -746,13 +746,9 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 rows = list(database.iter_root_files("default", "C:/repo"))
             self.assertEqual([row.relative_path for row in rows], ["a.txt"])
 
-    def test_new_scan_invalidates_older_token_for_the_same_root(self):
+    def test_older_scan_cannot_delete_newer_scan_associations(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
-            old_file = CachedFile(
-                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 10, 11),
-                "text", "old", None,
-            )
             new_file = CachedFile(
                 "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 12, 13),
                 "text", "new", None,
@@ -762,7 +758,7 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 new_scan = database.begin_scan("default", "C:/repo")
                 database.commit_scan(new_scan, [new_file])
                 with self.assertRaises(CacheDatabaseError):
-                    database.commit_scan(old_scan, [old_file])
+                    database.commit_scan(old_scan, [])
                 rows = list(database.iter_root_files("default", "C:/repo"))
             self.assertEqual([row.folded_text for row in rows], ["new"])
 
@@ -997,6 +993,49 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                         "default", "C:/protected"
                     )],
                     ["protected.txt"],
+                )
+
+    def test_enforce_quota_skips_protected_root_even_when_it_is_oldest(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                for root, name in (
+                    ("C:/active", "active.txt"),
+                    ("C:/evictable", "evictable.txt"),
+                ):
+                    scan = database.begin_scan("default", root)
+                    database.commit_scan(scan, [CachedFile(
+                        f"{root}/{name}",
+                        name,
+                        FileSignature(None, None, 64_000, 10, 11),
+                        "text",
+                        name * 4_000,
+                        None,
+                    )])
+                database.connection.execute(
+                    "UPDATE roots SET last_access_ns = CASE canonical_path "
+                    "WHEN 'C:/active' THEN 1 ELSE 2 END"
+                )
+                database.connection.commit()
+
+                report = database.enforce_quota(
+                    "C:/active", max_bytes=8 * 1024
+                )
+
+                self.assertEqual(report.associations_removed, 1)
+                self.assertEqual(report.roots_removed, 1)
+                self.assertEqual(report.files_removed, 1)
+                self.assertEqual(
+                    [row[0] for row in database.connection.execute(
+                        "SELECT canonical_path FROM roots"
+                    )],
+                    ["C:/active"],
+                )
+                self.assertEqual(
+                    [row.relative_path for row in database.iter_root_files(
+                        "default", "C:/active"
+                    )],
+                    ["active.txt"],
                 )
 
     def test_enforce_quota_collects_orphans_without_evictable_roots(self):

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -3,6 +3,7 @@ import sqlite3
 import stat
 import tempfile
 import unittest
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -21,6 +22,113 @@ from cereja.system._context.cache_db import (
 
 
 class ContextCacheDatabaseTest(unittest.TestCase):
+    def test_begin_scan_is_in_memory_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                database._checkpoint_wal()
+                baseline = database.aggregate_size_bytes()
+
+                token = database.begin_scan("default", "C:/repo")
+
+                self.assertEqual(token.namespace, "default")
+                self.assertEqual(token.canonical_root, "C:/repo")
+                self.assertEqual(database.aggregate_size_bytes(), baseline)
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT COUNT(*) FROM roots"
+                    ).fetchone()[0],
+                    0,
+                )
+
+    def test_begin_scan_orders_tied_clock_values_by_begin_order(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            nonces = [
+                uuid.UUID("00000000-0000-0000-0000-000000000002"),
+                uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            ]
+            with ContextCacheDatabase(database_path) as database, \
+                 patch("cereja.system._context.cache_db.time.time_ns", return_value=7), \
+                 patch("cereja.system._context.cache_db.uuid.uuid4", side_effect=nonces):
+                old_scan = database.begin_scan("default", "C:/repo")
+                new_scan = database.begin_scan("default", "C:/repo")
+
+            self.assertLess(
+                (old_scan.started_ns, old_scan.nonce),
+                (new_scan.started_ns, new_scan.nonce),
+            )
+
+    def test_reader_after_preflight_leaves_root_generation_and_storage_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(seed, [])
+                database._checkpoint_wal()
+                baseline = database.aggregate_size_bytes()
+                generation = database.connection.execute(
+                    "SELECT scan_generation FROM roots WHERE canonical_path = 'C:/repo'"
+                ).fetchone()[0]
+                scans = database.begin_scans_if_admitted(
+                    "default", ["C:/repo"], 10 ** 9
+                )
+                reader = sqlite3.connect(database_path)
+                try:
+                    reader.execute("BEGIN")
+                    reader.execute("SELECT COUNT(*) FROM roots").fetchone()
+                    admitted = database.commit_scan(
+                        scans["C:/repo"], [], max_bytes=10 ** 9
+                    )
+                finally:
+                    reader.close()
+
+                self.assertIsNone(admitted)
+                self.assertEqual(database.aggregate_size_bytes(), baseline)
+                self.assertEqual(
+                    database.connection.execute(
+                        "SELECT scan_generation FROM roots WHERE canonical_path = 'C:/repo'"
+                    ).fetchone()[0],
+                    generation,
+                )
+
+    def test_bounded_commit_releases_exclusive_lock_before_returning(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as first:
+                scan = first.begin_scan("default", "C:/repo")
+                self.assertEqual(first.commit_scan(scan, [], max_bytes=10 ** 9), ())
+                with ContextCacheDatabase(database_path) as second:
+                    second.connection.execute("BEGIN IMMEDIATE")
+                    second.connection.rollback()
+
+    def test_equal_timestamp_uses_nonce_for_cross_connection_scan_order(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            old_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 1, 1),
+                "text", "old", None,
+            )
+            new_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(None, None, 1, 2, 2),
+                "text", "new", None,
+            )
+            nonces = [
+                uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                uuid.UUID("00000000-0000-0000-0000-000000000002"),
+            ]
+            with ContextCacheDatabase(database_path) as first, \
+                 ContextCacheDatabase(database_path) as second, \
+                 patch("cereja.system._context.cache_db.time.time_ns", return_value=7), \
+                 patch("cereja.system._context.cache_db.uuid.uuid4", side_effect=nonces):
+                old_scan = first.begin_scan("default", "C:/repo")
+                new_scan = second.begin_scan("default", "C:/repo")
+                second.commit_scan(new_scan, [new_file])
+                with self.assertRaises(CacheDatabaseError):
+                    first.commit_scan(old_scan, [old_file])
+                rows = list(first.iter_root_files("default", "C:/repo"))
+            self.assertEqual([row.folded_text for row in rows], ["new"])
+
     def test_commit_scan_at_physical_quota_is_read_only(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"
@@ -727,6 +835,85 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 [("default",)],
             )
             connection.close()
+
+    def test_open_migrates_valid_previous_layout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "context.sqlite3"
+            connection = sqlite3.connect(path)
+            connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
+            connection.execute("VACUUM")
+            connection.executescript(
+                f"""
+                PRAGMA application_id = {APPLICATION_ID};
+                PRAGMA user_version = {SCHEMA_VERSION};
+                CREATE TABLE metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                CREATE TABLE namespaces (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    last_access_ns INTEGER NOT NULL
+                );
+                CREATE TABLE roots (
+                    id INTEGER PRIMARY KEY,
+                    canonical_path TEXT NOT NULL UNIQUE,
+                    last_access_ns INTEGER NOT NULL,
+                    scan_generation INTEGER NOT NULL DEFAULT 0
+                );
+                CREATE TABLE namespace_roots (
+                    namespace_id INTEGER NOT NULL
+                        REFERENCES namespaces(id) ON DELETE CASCADE,
+                    root_id INTEGER NOT NULL
+                        REFERENCES roots(id) ON DELETE CASCADE,
+                    PRIMARY KEY (namespace_id, root_id)
+                );
+                CREATE TABLE files (
+                    id INTEGER PRIMARY KEY,
+                    canonical_path TEXT NOT NULL UNIQUE,
+                    device INTEGER,
+                    inode INTEGER,
+                    size_bytes INTEGER NOT NULL,
+                    mtime_ns INTEGER NOT NULL,
+                    ctime_ns INTEGER NOT NULL,
+                    state TEXT NOT NULL CHECK (
+                        state IN (
+                            'text', 'binary_file', 'invalid_utf8', 'file_too_large'
+                        )
+                    ),
+                    content_sha256 TEXT,
+                    folded_text TEXT,
+                    created_ns INTEGER NOT NULL,
+                    validated_ns INTEGER NOT NULL,
+                    last_access_ns INTEGER NOT NULL
+                );
+                CREATE TABLE root_files (
+                    root_id INTEGER NOT NULL
+                        REFERENCES roots(id) ON DELETE CASCADE,
+                    file_id INTEGER NOT NULL
+                        REFERENCES files(id) ON DELETE CASCADE,
+                    relative_path TEXT NOT NULL,
+                    last_seen_scan TEXT NOT NULL,
+                    PRIMARY KEY (root_id, file_id)
+                );
+                INSERT INTO namespaces (id, name, last_access_ns)
+                    VALUES (1, 'default', 1);
+                INSERT INTO roots (
+                    id, canonical_path, last_access_ns, scan_generation
+                ) VALUES (1, 'C:/legacy', 2, 4);
+                INSERT INTO namespace_roots (namespace_id, root_id)
+                    VALUES (1, 1);
+                """
+            )
+            connection.close()
+
+            with ContextCacheDatabase(path) as database:
+                root = database.connection.execute(
+                    "SELECT scan_generation, scan_started_ns, scan_nonce "
+                    "FROM roots WHERE canonical_path = 'C:/legacy'"
+                ).fetchone()
+
+            self.assertEqual(root, (4, 0, ""))
 
     @unittest.skipIf(os.name == "nt", "POSIX permissions are not portable on Windows")
     def test_open_restricts_new_database_and_cache_directory_permissions(self):

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -1955,12 +1955,44 @@ class ContextCacheDatabaseTest(unittest.TestCase):
     def test_open_does_not_chmod_existing_cache_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             directory = Path(temp_dir) / "existing"
-            directory.mkdir()
+            directory.mkdir(mode=0o700)
+            directory.chmod(0o700)
             path = directory / "context.sqlite3"
             with patch("cereja.system._context.cache_db.os.chmod") as chmod:
                 with ContextCacheDatabase(path):
                     pass
-            chmod.assert_not_called()
+            self.assertNotIn(
+                directory,
+                [call.args[0] for call in chmod.call_args_list],
+            )
+
+    @unittest.skipIf(os.name == "nt", "POSIX permissions are not portable on Windows")
+    def test_open_rejects_insecure_preexisting_cache_directory_permissions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir) / "existing"
+            directory.mkdir(mode=0o777)
+            directory.chmod(0o777)
+            path = directory / "context.sqlite3"
+
+            with self.assertRaisesRegex(CacheDatabaseError, "permissions"):
+                with ContextCacheDatabase(path):
+                    pass
+
+            self.assertEqual(stat.S_IMODE(directory.stat().st_mode), 0o777)
+            self.assertFalse(path.exists())
+
+    @unittest.skipIf(os.name == "nt", "POSIX permissions are not portable on Windows")
+    def test_open_accepts_secure_preexisting_cache_directory_permissions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir) / "existing"
+            directory.mkdir(mode=0o700)
+            directory.chmod(0o700)
+            path = directory / "context.sqlite3"
+
+            with ContextCacheDatabase(path):
+                pass
+
+            self.assertEqual(stat.S_IMODE(directory.stat().st_mode), 0o700)
 
     def test_open_does_not_create_missing_directory_ancestors(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_query.py
+++ b/tests/test_context_query.py
@@ -1,0 +1,56 @@
+import unittest
+
+from cereja.system._context.models import ContextResult, ContextSnippet, SkippedFile
+from cereja.system._context.query import build_search_result, finalize_response
+
+
+class ContextQueryTest(unittest.TestCase):
+    def test_build_search_result_preserves_and_semantics_and_score(self):
+        result, snippets_truncated = build_search_result(
+            path="C:/repo/a-auth.md",
+            root="C:/repo",
+            relative_path="a-auth.md",
+            size_bytes=27,
+            text="Auth cache\nCACHE auth again\n",
+            terms=("auth", "cache"),
+            max_snippets=1,
+            max_snippet_chars=40,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.score, 1004)
+        self.assertEqual(result.match_count, 4)
+        self.assertEqual(result.snippets, (ContextSnippet(1, "Auth cache"),))
+        self.assertTrue(snippets_truncated)
+
+    def test_build_search_result_rejects_missing_and_term(self):
+        result, truncated = build_search_result(
+            path="C:/repo/auth.md",
+            root="C:/repo",
+            relative_path="auth.md",
+            size_bytes=4,
+            text="auth",
+            terms=("auth", "cache"),
+            max_snippets=2,
+            max_snippet_chars=40,
+        )
+        self.assertIsNone(result)
+        self.assertFalse(truncated)
+
+    def test_finalize_response_sorts_and_bounds_results_and_skipped(self):
+        results = [
+            ContextResult("C:/z", "C:/", "z", 1, 2, 2, ()),
+            ContextResult("C:/a", "C:/", "a", 1, 2, 2, ()),
+        ]
+        response = finalize_response(
+            mode="search",
+            query="x",
+            roots=("C:/",),
+            results=results,
+            skipped=[SkippedFile("C:/z.bin", "binary_file"),
+                     SkippedFile("C:/a.bin", "binary_file")],
+            max_results=1,
+            snippets_truncated=False,
+        )
+        self.assertEqual(response.results[0].relative_path, "a")
+        self.assertEqual(response.skipped[0].path, "C:/a.bin")
+        self.assertTrue(response.truncated)

--- a/tests/test_context_search.py
+++ b/tests/test_context_search.py
@@ -11,6 +11,23 @@ from cereja.system import (
 
 
 class ContextSearchTest(unittest.TestCase):
+    def test_refresh_requires_cache(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaisesRegex(ValueError, "refresh_cache requires cache=True"):
+                search_text_context([root], "needle", refresh_cache=True)
+            with self.assertRaisesRegex(ValueError, "refresh_cache requires cache=True"):
+                list_text_context([root], refresh_cache=True)
+
+    def test_cache_false_keeps_direct_behavior(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            self.assertEqual(
+                search_text_context([root], "needle", cache=False),
+                search_text_context([root], "needle"),
+            )
+
     def test_requires_all_terms_and_limits_snippets(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -165,7 +182,7 @@ class ContextSearchTest(unittest.TestCase):
             path = root / "vanished.txt"
             path.write_text("needle", encoding="utf-8")
 
-            with patch("cereja.system._context_search.open", side_effect=FileNotFoundError):
+            with patch("cereja.system._context.search.open", side_effect=FileNotFoundError):
                 response = search_text_context([root], "needle")
 
             self.assertEqual(response.results, ())
@@ -177,7 +194,7 @@ class ContextSearchTest(unittest.TestCase):
             path = root / "private.txt"
             path.write_text("needle", encoding="utf-8")
 
-            with patch("cereja.system._context_search.open", side_effect=PermissionError):
+            with patch("cereja.system._context.search.open", side_effect=PermissionError):
                 response = search_text_context([root], "needle")
 
             self.assertEqual(response.results, ())


### PR DESCRIPTION
## Summary

- add an opt-in persistent SQLite cache for `cereja context search` and `list`
- expose cache refresh, info, and clear controls through the Python API and CLI
- preserve direct-search matching, scoring, ordering, snippets, and fallback behavior
- enforce bounded global storage with protected active roots, LRU eviction, orphan collection, and incremental maintenance
- fail closed for unsafe paths, incompatible/corrupt databases, and observable SQLite WAL/SHM sidecars
- add deterministic benchmark coverage and document that searched files remain read-only while the global cache is written

## Motivation

Repeated context searches reread, decode, and normalize the same repository files. This change adds an optional per-user cache outside searched roots while keeping cache failures non-fatal for search/list operations and preserving existing results.

## Root causes addressed in final hardening

- cache location was not rejected when nested under a searched root
- quota maintenance existed but was not integrated into the production orchestration path
- post-commit clear maintenance failures could be masked
- insecure preexisting POSIX cache-directory permissions were accepted
- cached matching and selection duplicated pure query semantics
- README wording did not distinguish read-only source files from the written global cache database

## Validation

- focused context tests: 137 passed, 8 skipped
- full suite on Python 3.11, 3.12, 3.13, and 3.14: 520 passed, 11 skipped on each interpreter
- strict flake8 command: 0 findings
- statistical flake8 command completed with `--exit-zero`
- benchmark: direct, cold, warm, and refresh responses all equal
- CLI smokes passed
- wheel and sdist built successfully and contain all six `_context` modules
- `git diff --check` clean
- independent final review found no Critical, Important, or Minor issues

## Notes

The implementation intentionally does not parse WAL files or add native platform primitives. Automatic handling remains conservative and fail-closed according to the approved design.