### PR TITLE
docs: add context cache usage guide

### DIFF
--- a/cereja/cli.py
+++ b/cereja/cli.py
@@ -150,7 +150,13 @@ def create_parser() -> argparse.ArgumentParser:
     tree_parser.set_defaults(handler=_handle_tree)
 
     context_parser = subparsers.add_parser(
-        "context", help="Search or list bounded textual context."
+        "context",
+        help="Search or list bounded textual context.",
+        description=(
+            "Search or list bounded textual context. These operations open "
+            "source files read-only; the optional cache does not modify "
+            "searched files."
+        ),
     )
     context_subparsers = context_parser.add_subparsers(
         dest="context_command", required=True
@@ -177,19 +183,22 @@ def create_parser() -> argparse.ArgumentParser:
     context_list_parser.set_defaults(handler=_handle_context_list)
 
     context_cache_parser = context_subparsers.add_parser(
-        "cache", help="Manage the textual context cache."
+        "cache",
+        help="Manage the textual context cache.",
+        description="Inspect or clear the global per-user context cache.",
+        epilog="Example: cereja context cache info --format json",
     )
     context_cache_subparsers = context_cache_parser.add_subparsers(
         dest="context_cache_command", required=True
     )
     context_cache_info_parser = context_cache_subparsers.add_parser(
-        "info", help="Show textual context cache information."
+        "info", help="Show cache metadata and physical sizes."
     )
     _add_context_cache_format_option(context_cache_info_parser)
     context_cache_info_parser.set_defaults(handler=_handle_context_cache_info)
 
     context_cache_clear_parser = context_cache_subparsers.add_parser(
-        "clear", help="Clear the textual context cache."
+        "clear", help="Clear the default context-cache namespace."
     )
     _add_context_cache_format_option(context_cache_clear_parser)
     context_cache_clear_parser.set_defaults(handler=_handle_context_cache_clear)
@@ -305,11 +314,14 @@ def _add_context_common_options(parser: argparse.ArgumentParser) -> None:
         help="Maximum bytes read from each file."
     )
     parser.add_argument(
-        "--cache", action="store_true", help="Use the persistent context cache."
+        "--cache", action="store_true",
+        help="Use and write the global per-user cache."
     )
     parser.add_argument(
         "--refresh-cache", action="store_true",
-        help="Refresh cached file content before querying."
+        help=(
+            "Reprocess the current roots and extensions; requires --cache."
+        )
     )
 
 

--- a/docs/guides/context-cache.md
+++ b/docs/guides/context-cache.md
@@ -197,4 +197,3 @@ be misleading.
 The cache is useful for repeated searches over stable or moderately changing
 repositories. Direct mode can be preferable for a one-off search, a very small
 directory, or an environment where persistent per-user storage is unwanted.
-

--- a/docs/guides/context-cache.md
+++ b/docs/guides/context-cache.md
@@ -1,0 +1,200 @@
+# Persistent Context Cache
+
+The `cereja context` commands can use an optional persistent SQLite cache to
+avoid reading, decoding, and normalizing unchanged files on every call. The
+cache is disabled by default, so existing commands retain their original
+behavior unless `--cache` or `cache=True` is supplied.
+
+The searched source files are opened read-only and are never modified. When
+enabled, the feature writes a global per-user cache outside the searched
+roots.
+
+## Search with the Cache
+
+Enable the cache with `--cache`:
+
+```bash
+cereja context search \
+  --root path/to/project \
+  --query "authentication token" \
+  --cache
+```
+
+The first call populates the cache. Later calls reuse entries whose filesystem
+signatures have not changed. Search results, scores, ordering, snippets, and
+skipped-file reporting remain equivalent to a direct search.
+
+Multiple roots and extension filters work normally:
+
+```bash
+cereja context search \
+  --root docs \
+  --root cereja \
+  --query "context cache" \
+  --extension md \
+  --extension py \
+  --cache
+```
+
+Use `--format json` when the result will be consumed by another command:
+
+```bash
+cereja context search \
+  --root . \
+  --query "context cache" \
+  --cache \
+  --format json
+```
+
+## List Files with the Cache
+
+The list command supports the same opt-in cache:
+
+```bash
+cereja context list --root path/to/project --cache
+```
+
+It returns file metadata without exposing cached content.
+
+## Refresh the Current Scope
+
+Use `--refresh-cache` to ignore reusable entries and reprocess the roots and
+extensions selected by the current command:
+
+```bash
+cereja context search \
+  --root path/to/project \
+  --query "authentication token" \
+  --cache \
+  --refresh-cache
+```
+
+`--refresh-cache` requires `--cache`. Refreshing one scope does not rebuild
+unrelated cached roots.
+
+## Inspect the Cache
+
+Display the cache path, physical sizes, schema version, file counts, root
+count, and last-access time:
+
+```bash
+cereja context cache info
+```
+
+For structured output:
+
+```bash
+cereja context cache info --format json
+```
+
+The information command reports metadata only. It does not expose cached file
+content or provide arbitrary database access.
+
+## Clear the Cache
+
+Clear the default context-cache namespace:
+
+```bash
+cereja context cache clear
+```
+
+Request a structured removal and size report with:
+
+```bash
+cereja context cache clear --format json
+```
+
+The report includes removed associations, roots, files, and physical bytes
+before and after maintenance. A lock or post-commit maintenance failure is
+reported as an error instead of being presented as a complete success.
+
+## Python API
+
+Enable caching with `cache=True`:
+
+```python
+from cereja.system import search_text_context
+
+response = search_text_context(
+    ["path/to/project"],
+    "authentication token",
+    cache=True,
+)
+
+for result in response.results:
+    print(result.relative_path, result.score)
+```
+
+Force reprocessing for the current scope with `refresh_cache=True`:
+
+```python
+response = search_text_context(
+    ["path/to/project"],
+    "authentication token",
+    cache=True,
+    refresh_cache=True,
+)
+```
+
+The list API accepts the same cache options:
+
+```python
+from cereja.system import list_text_context
+
+response = list_text_context(
+    ["path/to/project"],
+    cache=True,
+)
+```
+
+Inspect or clear the cache programmatically:
+
+```python
+from cereja.system import clear_context_cache, get_context_cache_info
+
+info = get_context_cache_info()
+print(info.path, info.database_bytes)
+
+report = clear_context_cache()
+print(report.files_removed, report.after_bytes)
+```
+
+Passing `refresh_cache=True` without `cache=True` raises `ValueError`.
+
+## Storage Location and Limit
+
+The default database path depends on the operating system:
+
+- Windows: `%LOCALAPPDATA%\Cereja\cache\context.sqlite3`
+- Linux: `$XDG_CACHE_HOME/cereja/context.sqlite3`, or
+  `~/.cache/cereja/context.sqlite3`
+- macOS: `~/Library/Caches/Cereja/context.sqlite3`
+
+The physical limit is 256 MiB across the main database, WAL, and shared-memory
+files. Under pressure, the cache removes least-recently-used roots and
+unreferenced file records. Roots involved in the current operation are
+protected from eviction. If the active scope cannot be admitted within the
+limit, the result remains complete by using the direct in-memory data for the
+files that were not cached.
+
+## Failure and Safety Behavior
+
+Search and list operations treat the cache as an optimization. If it is
+unavailable, Cereja emits `ContextCacheWarning` and repeats the operation using
+the direct filesystem flow.
+
+The cache refuses unsafe directories, symbolic links, unknown database
+identities, unsupported schemas, recognized corruption, and observable SQLite
+WAL or shared-memory sidecars. These cases are handled conservatively: Cereja
+does not automatically replace, rename, remove, or repair the existing storage.
+
+Administrative operations are stricter. For example, `clear` reports a cache
+lock as an error because pretending that an explicit cleanup succeeded would
+be misleading.
+
+## When to Use It
+
+The cache is useful for repeated searches over stable or moderately changing
+repositories. Direct mode can be preferable for a one-off search, a very small
+directory, or an environment where persistent per-user storage is unwanted.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ print(path.list_files())
 getting-started
 cli
 guides/files-and-paths
+guides/context-cache
 guides/display-progress
 guides/compression-and-encryption
 guides/text-and-data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -544,6 +544,41 @@ class CliTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("--query", result.stderr)
 
+    def test_context_cache_flags_explain_persistent_writes_and_refresh_scope(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "cereja", "context", "search", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        help_text = " ".join(result.stdout.split())
+        self.assertIn("global per-user cache", help_text)
+        self.assertIn("requires --cache", help_text)
+        self.assertIn("current roots and extensions", help_text)
+
+    def test_context_cache_help_explains_safety_and_administration(self):
+        context = subprocess.run(
+            [sys.executable, "-m", "cereja", "context", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        cache = subprocess.run(
+            [sys.executable, "-m", "cereja", "context", "cache", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(context.returncode, 0)
+        self.assertEqual(cache.returncode, 0)
+        self.assertIn("does not modify searched files", context.stdout)
+        self.assertIn("cache info --format json", cache.stdout)
+        self.assertIn("metadata and physical sizes", cache.stdout)
+        self.assertIn("default context-cache namespace", cache.stdout)
+
     def test_context_search_forwards_cache_flags(self):
         response = ContextResponse(1, "search", "needle", ("C:/repo",), (), (), False)
         with patch("cereja.cli.search_text_context", return_value=response) as search:


### PR DESCRIPTION
## Summary

- add a dedicated persistent context-cache usage guide to the Sphinx documentation
- link the guide from the main documentation index
- improve `cereja context` help with cache safety, persistence, refresh scope, administration descriptions, and a short example
- add CLI regression tests for the new help text

## Motivation

The persistent cache controls were discoverable but the CLI help did not explain that the cache writes global per-user storage, leaves searched files unchanged, or requires `--cache` when refreshing. Detailed operational guidance was also limited to the README.

## User impact

Users can now learn the common cache workflow from either `--help` or a focused guide covering CLI and Python API usage, inspection, clearing, storage limits, fallback, and safety behavior.

## Validation

- TDD: two new help tests failed before the parser changes and passed afterward
- `python -m unittest tests.test_cli -v`: 40 passed
- `python -m unittest discover -s tests`: 522 passed, 11 skipped
- `sphinx-build -W -b html docs docs/_build/html`: passed
- strict flake8 for changed Python files: 0 findings
- `git diff --check`: clean