### PR TITLE
perf: finalize persistent context cache

### DIFF
--- a/benchmarks/context_cache_benchmark.py
+++ b/benchmarks/context_cache_benchmark.py
@@ -55,10 +55,10 @@ def _apply_mutation(root: Path, mutation: str) -> None:
         )
         return
     if mutation == "rename":
-        (root / "file_00000.py").rename(root / "renamed_00000.py")
+        (root / "file_00000.py").rename(root / "changed_00000.py")
         return
     if mutation == "remove":
-        sorted(root.glob("file_*.py"))[-1].unlink()
+        (root / "file_00000.py").unlink()
         return
     raise ValueError(f"unsupported mutation: {mutation}")
 
@@ -81,13 +81,13 @@ def _milliseconds(samples: list[int]) -> tuple[float, float]:
     )
 
 
-def _api_search(root: Path, cache: bool) -> None:
-    search_text_context(
+def _api_search(root: Path, cache: bool):
+    return search_text_context(
         [root], QUERY, extensions=[".py"], max_results=10, cache=cache
     )
 
 
-def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> None:
+def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> dict:
     command = [
         sys.executable,
         "-m",
@@ -105,7 +105,7 @@ def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> None:
     ]
     if cache:
         command.append("--cache")
-    subprocess.run(
+    result = subprocess.run(
         command,
         check=True,
         capture_output=True,
@@ -113,6 +113,7 @@ def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> None:
         cwd=Path(__file__).resolve().parents[1],
         env=environment,
     )
+    return json.loads(result.stdout)
 
 
 def _result_prefix(name: str, direct: list[int], cached: list[int]) -> dict[str, float]:
@@ -127,6 +128,105 @@ def _result_prefix(name: str, direct: list[int], cached: list[int]) -> dict[str,
     }
 
 
+def _sample_corpus(root: Path, name: str, files: int) -> Path:
+    corpus_root = root / name
+    corpus_root.mkdir()
+    _build_corpus(corpus_root, files)
+    return corpus_root
+
+
+def _cli_environment(root: Path, name: str) -> dict[str, str]:
+    local_app_data = root / name
+    local_app_data.mkdir()
+    environment = os.environ.copy()
+    environment["LOCALAPPDATA"] = str(local_app_data)
+    return environment
+
+
+def _response_entries(response) -> dict[str, tuple[str, ...]]:
+    if isinstance(response, dict):
+        return {
+            result["relative_path"]: tuple(
+                snippet["text"] for snippet in result["snippets"]
+            )
+            for result in response["results"]
+        }
+    return {
+        result.relative_path: tuple(snippet.text for snippet in result.snippets)
+        for result in response.results
+    }
+
+
+def _validate_cached_mutation(response, mutation: str) -> None:
+    entries = _response_entries(response)
+    if mutation == "unchanged" and "file_00000.py" in entries:
+        return
+    if mutation == "create" and "created.py" in entries:
+        return
+    if mutation == "modify" and any(
+            "needle modified" in text for text in entries.get("file_00000.py", ())
+    ):
+        return
+    if mutation == "rename" and (
+            "changed_00000.py" in entries and "file_00000.py" not in entries
+    ):
+        return
+    if mutation == "remove" and "file_00000.py" not in entries:
+        return
+    raise AssertionError(f"cached response did not reflect {mutation} mutation")
+
+
+def _api_direct_sample(root: Path, case: BenchmarkCase, index: int) -> int:
+    corpus_root = _sample_corpus(root, f"api-direct-{index}", case.files)
+    _apply_mutation(corpus_root, case.mutation)
+    return _time_call(lambda: _api_search(corpus_root, cache=False))
+
+
+def _api_cached_sample(root: Path, case: BenchmarkCase, index: int) -> int:
+    corpus_root = _sample_corpus(root, f"api-cached-{index}", case.files)
+    cache_path = root / f"api-cache-{index}.sqlite3"
+    with patch(
+            "cereja.system._context.cache.default_cache_path",
+            return_value=cache_path,
+    ):
+        _api_search(corpus_root, cache=True)
+        _apply_mutation(corpus_root, case.mutation)
+        response = None
+
+        def search():
+            nonlocal response
+            response = _api_search(corpus_root, cache=True)
+
+        elapsed = _time_call(search)
+    _validate_cached_mutation(response, case.mutation)
+    return elapsed
+
+
+def _cli_direct_sample(root: Path, case: BenchmarkCase, index: int) -> int:
+    corpus_root = _sample_corpus(root, f"cli-direct-{index}", case.files)
+    environment = _cli_environment(root, f"cli-direct-cache-{index}")
+    _apply_mutation(corpus_root, case.mutation)
+    return _time_call(
+        lambda: _cli_search(corpus_root, cache=False, environment=environment)
+    )
+
+
+def _cli_cached_sample(root: Path, case: BenchmarkCase, index: int) -> int:
+    corpus_root = _sample_corpus(root, f"cli-cached-{index}", case.files)
+    environment = _cli_environment(root, f"cli-cached-cache-{index}")
+    _cli_search(corpus_root, cache=True, environment=environment)
+    _apply_mutation(corpus_root, case.mutation)
+    response = None
+
+    def search():
+        nonlocal response
+        response = _cli_search(corpus_root, cache=True, environment=environment)
+
+    elapsed = _time_call(search)
+    _validate_cached_mutation(response, case.mutation)
+    return elapsed
+
+
 def run_case(case: BenchmarkCase, iterations: int = 15) -> dict:
     """Run one cache benchmark case in isolated API and CLI environments."""
     if case.files < 1:
@@ -138,47 +238,22 @@ def run_case(case: BenchmarkCase, iterations: int = 15) -> dict:
 
     with TemporaryDirectory() as temporary_directory:
         temporary_root = Path(temporary_directory)
-        corpus_root = temporary_root / "corpus"
-        corpus_root.mkdir()
-        _build_corpus(corpus_root, case.files)
-        api_cache_path = temporary_root / "api-cache" / "context.sqlite3"
-        local_app_data = temporary_root / "cli-local-app-data"
-        local_app_data.mkdir()
-        cli_environment = os.environ.copy()
-        cli_environment["LOCALAPPDATA"] = str(local_app_data)
-
-        with patch(
-                "cereja.system._context.cache.default_cache_path",
-                return_value=api_cache_path,
-        ):
-            _api_search(corpus_root, cache=True)
-            _cli_search(corpus_root, cache=True, environment=cli_environment)
-            _apply_mutation(corpus_root, case.mutation)
-
-            api_direct = [
-                _time_call(lambda: _api_search(corpus_root, cache=False))
-                for _ in range(iterations)
-            ]
-            api_cached = [
-                _time_call(lambda: _api_search(corpus_root, cache=True))
-                for _ in range(iterations)
-            ]
-            cli_direct = [
-                _time_call(
-                    lambda: _cli_search(
-                        corpus_root, cache=False, environment=cli_environment
-                    )
-                )
-                for _ in range(iterations)
-            ]
-            cli_cached = [
-                _time_call(
-                    lambda: _cli_search(
-                        corpus_root, cache=True, environment=cli_environment
-                    )
-                )
-                for _ in range(iterations)
-            ]
+        api_direct = [
+            _api_direct_sample(temporary_root, case, index)
+            for index in range(iterations)
+        ]
+        api_cached = [
+            _api_cached_sample(temporary_root, case, index)
+            for index in range(iterations)
+        ]
+        cli_direct = [
+            _cli_direct_sample(temporary_root, case, index)
+            for index in range(iterations)
+        ]
+        cli_cached = [
+            _cli_cached_sample(temporary_root, case, index)
+            for index in range(iterations)
+        ]
 
     result = {"files": case.files, "mutation": case.mutation}
     result.update(_result_prefix("api", api_direct, api_cached))

--- a/benchmarks/context_cache_benchmark.py
+++ b/benchmarks/context_cache_benchmark.py
@@ -88,10 +88,16 @@ def _api_search(root: Path, cache: bool):
 
 
 def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> dict:
+    cli_entrypoint = (
+        "import contextlib, io\n"
+        "with contextlib.redirect_stdout(io.StringIO()):\n"
+        "    from cereja.cli import main\n"
+        "raise SystemExit(main())\n"
+    )
     command = [
         sys.executable,
-        "-m",
-        "cereja",
+        "-c",
+        cli_entrypoint,
         "context",
         "search",
         "--root",

--- a/benchmarks/context_cache_benchmark.py
+++ b/benchmarks/context_cache_benchmark.py
@@ -1,0 +1,208 @@
+"""Reproducible API and CLI benchmarks for the text-context cache."""
+
+import argparse
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from time import perf_counter_ns
+from unittest.mock import patch
+
+from cereja.system import search_text_context
+
+
+QUERY = "needle"
+MUTATIONS = ("unchanged", "create", "modify", "rename", "remove")
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkCase:
+    """One reproducible corpus size and filesystem-mutation scenario."""
+
+    files: int
+    mutation: str
+
+
+def _build_corpus(root: Path, files: int) -> None:
+    for index in range(files):
+        (root / f"file_{index:05d}.py").write_text(
+            "# deterministic context benchmark\n"
+            f"VALUE_{index:05d} = 'needle {index:05d}'\n",
+            encoding="utf-8",
+        )
+
+
+def _apply_mutation(root: Path, mutation: str) -> None:
+    if mutation == "unchanged":
+        return
+    if mutation == "create":
+        (root / "created.py").write_text(
+            "# deterministic context benchmark\n"
+            "CREATED = 'needle created'\n",
+            encoding="utf-8",
+        )
+        return
+    if mutation == "modify":
+        (root / "file_00000.py").write_text(
+            "# deterministic context benchmark modified\n"
+            "VALUE_00000 = 'needle modified'\n",
+            encoding="utf-8",
+        )
+        return
+    if mutation == "rename":
+        (root / "file_00000.py").rename(root / "renamed_00000.py")
+        return
+    if mutation == "remove":
+        sorted(root.glob("file_*.py"))[-1].unlink()
+        return
+    raise ValueError(f"unsupported mutation: {mutation}")
+
+
+def _time_call(operation) -> int:
+    started = perf_counter_ns()
+    operation()
+    return perf_counter_ns() - started
+
+
+def _nearest_rank_p95(samples: list[int]) -> int:
+    ordered = sorted(samples)
+    return ordered[math.ceil(len(ordered) * 0.95) - 1]
+
+
+def _milliseconds(samples: list[int]) -> tuple[float, float]:
+    return (
+        statistics.median(samples) / 1_000_000,
+        _nearest_rank_p95(samples) / 1_000_000,
+    )
+
+
+def _api_search(root: Path, cache: bool) -> None:
+    search_text_context(
+        [root], QUERY, extensions=[".py"], max_results=10, cache=cache
+    )
+
+
+def _cli_search(root: Path, cache: bool, environment: dict[str, str]) -> None:
+    command = [
+        sys.executable,
+        "-m",
+        "cereja",
+        "context",
+        "search",
+        "--root",
+        str(root),
+        "--query",
+        QUERY,
+        "--extension",
+        ".py",
+        "--format",
+        "json",
+    ]
+    if cache:
+        command.append("--cache")
+    subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[1],
+        env=environment,
+    )
+
+
+def _result_prefix(name: str, direct: list[int], cached: list[int]) -> dict[str, float]:
+    direct_median, direct_p95 = _milliseconds(direct)
+    cached_median, cached_p95 = _milliseconds(cached)
+    return {
+        f"{name}_direct_median_ms": direct_median,
+        f"{name}_direct_p95_ms": direct_p95,
+        f"{name}_cached_median_ms": cached_median,
+        f"{name}_cached_p95_ms": cached_p95,
+        f"{name}_cached_direct_ratio": cached_median / direct_median,
+    }
+
+
+def run_case(case: BenchmarkCase, iterations: int = 15) -> dict:
+    """Run one cache benchmark case in isolated API and CLI environments."""
+    if case.files < 1:
+        raise ValueError("files must be at least one")
+    if case.mutation not in MUTATIONS:
+        raise ValueError(f"unsupported mutation: {case.mutation}")
+    if iterations < 1:
+        raise ValueError("iterations must be at least one")
+
+    with TemporaryDirectory() as temporary_directory:
+        temporary_root = Path(temporary_directory)
+        corpus_root = temporary_root / "corpus"
+        corpus_root.mkdir()
+        _build_corpus(corpus_root, case.files)
+        api_cache_path = temporary_root / "api-cache" / "context.sqlite3"
+        local_app_data = temporary_root / "cli-local-app-data"
+        local_app_data.mkdir()
+        cli_environment = os.environ.copy()
+        cli_environment["LOCALAPPDATA"] = str(local_app_data)
+
+        with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=api_cache_path,
+        ):
+            _api_search(corpus_root, cache=True)
+            _cli_search(corpus_root, cache=True, environment=cli_environment)
+            _apply_mutation(corpus_root, case.mutation)
+
+            api_direct = [
+                _time_call(lambda: _api_search(corpus_root, cache=False))
+                for _ in range(iterations)
+            ]
+            api_cached = [
+                _time_call(lambda: _api_search(corpus_root, cache=True))
+                for _ in range(iterations)
+            ]
+            cli_direct = [
+                _time_call(
+                    lambda: _cli_search(
+                        corpus_root, cache=False, environment=cli_environment
+                    )
+                )
+                for _ in range(iterations)
+            ]
+            cli_cached = [
+                _time_call(
+                    lambda: _cli_search(
+                        corpus_root, cache=True, environment=cli_environment
+                    )
+                )
+                for _ in range(iterations)
+            ]
+
+    result = {"files": case.files, "mutation": case.mutation}
+    result.update(_result_prefix("api", api_direct, api_cached))
+    result.update(_result_prefix("cli", cli_direct, cli_cached))
+    return result
+
+
+def _parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--files", type=int, action="append", required=True)
+    parser.add_argument("--mutation", choices=MUTATIONS, default="unchanged")
+    parser.add_argument("--iterations", type=int, default=15)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = _parse_arguments()
+    results = [
+        run_case(BenchmarkCase(files, arguments.mutation), arguments.iterations)
+        for files in arguments.files
+    ]
+    print(json.dumps(results, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -351,7 +351,7 @@ def _synchronize_inventory(
     for canonical_root, cached_files in by_root.items():
         if canonical_root not in scan_tokens:
             continue
-        if fast_path_eligible[canonical_root]:
+        if not refresh_cache and fast_path_eligible[canonical_root]:
             unchanged = _database_call(
                 database.publish_unchanged_scan,
                 scan_tokens[canonical_root],

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -262,6 +262,7 @@ def _synchronize_inventory(
         scan_tokens,
 ):
     by_root = {root: [] for root in canonical_roots}
+    fast_path_eligible = {root: True for root in canonical_roots}
     prepared = []
     skipped = []
     signed_files = []
@@ -273,9 +274,11 @@ def _synchronize_inventory(
         try:
             signature = _file_signature(path)
         except PermissionError:
+            fast_path_eligible[canonical_root] = False
             skipped.append(SkippedFile(normalized_path, "permission_denied"))
             continue
         except FileNotFoundError:
+            fast_path_eligible[canonical_root] = False
             skipped.append(SkippedFile(normalized_path, "disappeared"))
             continue
         signed_files.append((
@@ -328,9 +331,11 @@ def _synchronize_inventory(
                     content_sha256=cached.content_sha256,
                 )
         except PermissionError:
+            fast_path_eligible[canonical_root] = False
             skipped.append(SkippedFile(normalized_path, "permission_denied"))
             continue
         except FileNotFoundError:
+            fast_path_eligible[canonical_root] = False
             skipped.append(SkippedFile(normalized_path, "disappeared"))
             continue
 
@@ -346,11 +351,22 @@ def _synchronize_inventory(
     for canonical_root, cached_files in by_root.items():
         if canonical_root not in scan_tokens:
             continue
+        if fast_path_eligible[canonical_root]:
+            unchanged = _database_call(
+                database.publish_unchanged_scan,
+                scan_tokens[canonical_root],
+                cached_files,
+                max_bytes=max_cache_bytes,
+                max_file_bytes=max_file_bytes,
+            )
+            if unchanged:
+                continue
         admitted = _database_call(
             database.commit_scan,
             scan_tokens[canonical_root],
             cached_files,
             max_bytes=max_cache_bytes,
+            max_file_bytes=max_file_bytes,
         )
         if admitted is None:
             break

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -109,16 +109,15 @@ def _sqlite_identifier(value):
 
 
 def _read_cacheable_file(path, signature, max_file_bytes):
-    """Return persistent state, folded text, and digest for one file."""
-    if signature.size_bytes > max_file_bytes:
-        return "file_too_large", None, None
-    with open(path, "rb") as file:
-        data = file.read(max_file_bytes + 1)
-    if len(data) > max_file_bytes:
-        return "file_too_large", None, None
+    """Return a verified signature and persistent content for one file."""
+    signature, data = _read_stable_bytes(
+        path, signature, max_file_bytes
+    )
+    if data is None or len(data) > max_file_bytes:
+        return signature, "file_too_large", None, None
     digest = hashlib.sha256(data).hexdigest()
     state, text = _decode_file_data(data)
-    return state, None if text is None else text.casefold(), digest
+    return signature, state, None if text is None else text.casefold(), digest
 
 
 def _cached_file_is_reusable(cached, signature, max_file_bytes):
@@ -130,12 +129,32 @@ def _cached_file_is_reusable(cached, signature, max_file_bytes):
     return cached.state != "file_too_large"
 
 
-def _read_original_text(path, max_file_bytes):
-    with open(path, "rb") as file:
-        data = file.read(max_file_bytes + 1)
-    if len(data) > max_file_bytes:
-        return "file_too_large", None
-    return _decode_file_data(data)
+def _read_original_text(path, signature, max_file_bytes):
+    """Return a verified signature and decoded original text."""
+    signature, data = _read_stable_bytes(
+        path, signature, max_file_bytes
+    )
+    if data is None or len(data) > max_file_bytes:
+        return signature, "file_too_large", None
+    state, text = _decode_file_data(data)
+    return signature, state, text
+
+
+def _read_stable_bytes(path, signature, max_file_bytes):
+    """Read one signature-consistent file version, retrying once."""
+    for attempt in range(2):
+        if signature.size_bytes > max_file_bytes:
+            data = None
+        else:
+            with open(path, "rb") as file:
+                data = file.read(max_file_bytes + 1)
+        post_read_signature = _file_signature(path)
+        if post_read_signature == signature:
+            return signature, data
+        if attempt:
+            raise FileNotFoundError(path)
+        signature = post_read_signature
+    raise AssertionError("unreachable")
 
 
 def _decode_file_data(data):
@@ -288,7 +307,7 @@ def _synchronize_inventory(
             if not _cached_file_is_reusable(
                     cached, signature, max_file_bytes
             ):
-                state, folded_text, digest = _read_cacheable_file(
+                signature, state, folded_text, digest = _read_cacheable_file(
                     path, signature, max_file_bytes
                 )
                 cached = CachedFile(
@@ -352,6 +371,7 @@ def _query_prepared_files(
         max_file_bytes,
 ):
     candidates = []
+    candidate_signatures = {}
     skipped = list(transient_skips)
     snippets_truncated = False
     for item in prepared:
@@ -381,12 +401,14 @@ def _query_prepared_files(
         )
         if candidate is not None:
             candidates.append(candidate)
+            candidate_signatures[candidate.path] = cached.signature
 
     ordered_candidates = order_context_results(candidates, mode)
     selected = select_context_results(candidates, mode, max_results)
     if mode == "search":
         selected, reopen_skips, reopened_truncated = _reopen_winners(
             ordered_candidates,
+            candidate_signatures,
             terms,
             max_snippets,
             max_snippet_chars,
@@ -411,6 +433,7 @@ def _query_prepared_files(
 
 def _reopen_winners(
         candidates,
+        candidate_signatures,
         terms,
         max_snippets,
         max_snippet_chars,
@@ -424,8 +447,11 @@ def _reopen_winners(
         if len(results) == max_results:
             break
         try:
-            signature = _file_signature(winner.path)
-            state, text = _read_original_text(winner.path, max_file_bytes)
+            signature, state, text = _read_original_text(
+                winner.path,
+                candidate_signatures[winner.path],
+                max_file_bytes,
+            )
             if state != "text":
                 skipped.append(SkippedFile(winner.path, state))
                 continue

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -6,7 +6,8 @@ import sqlite3
 from dataclasses import dataclass
 
 from cereja.system._repository_files import (
-    _iter_repository_files_with_canonical_paths as iter_repository_files,
+    _iter_prepared_repository_files as iter_repository_files,
+    _prepare_repository_roots,
 )
 
 from .cache_db import (
@@ -194,14 +195,13 @@ def _collect_cached_context(
     """Collect context using signature-validated persistent file content."""
     root_values = tuple(roots)
     normalized_roots = tuple(_normalized_path(root) for root in root_values)
-    # Canonicalization is bounded by N inventory files + R explicit roots +
-    # one cache path. The inventory iterator supplies each file's value below.
-    canonical_roots_by_key = {}
-    for root in root_values:
-        root_key = _path_key(root)
-        if root_key not in canonical_roots_by_key:
-            canonical_roots_by_key[root_key] = _canonical_path(root)
-    canonical_roots = tuple(dict.fromkeys(canonical_roots_by_key.values()))
+    # Canonicalization is bounded by N final inventory files + R distinct
+    # normalized explicit-root inputs + one cache path. Canonical root aliases
+    # are removed before traversal, which supplies each file/root value below.
+    prepared_roots = _prepare_repository_roots(root_values)
+    canonical_roots = tuple(
+        item.canonical_path for item in prepared_roots
+    )
     cache_path = default_cache_path()
     canonical_cache_path = _canonical_path(cache_path)
     if any(
@@ -217,7 +217,7 @@ def _collect_cached_context(
     # Traversal can fail for invalid roots and must complete before any scan can
     # remove stale associations.
     inventory = tuple(iter_repository_files(
-        root_values, extensions=extensions
+        prepared_roots, extensions=extensions
     ))
 
     try:
@@ -232,11 +232,7 @@ def _collect_cached_context(
                 )
             inventory_roots = {root: False for root in canonical_roots}
             for repository_file in inventory:
-                inventory_roots[
-                    canonical_roots_by_key[
-                        _path_key(repository_file.root.path)
-                    ]
-                ] = True
+                inventory_roots[repository_file.canonical_root] = True
             roots_to_sync = _database_call(
                 database.roots_requiring_scan,
                 DEFAULT_NAMESPACE,
@@ -252,7 +248,6 @@ def _collect_cached_context(
                 database,
                 inventory,
                 canonical_roots,
-                canonical_roots_by_key,
                 max_file_bytes,
                 refresh_cache,
                 DEFAULT_MAX_BYTES,
@@ -285,7 +280,6 @@ def _synchronize_inventory(
         database,
         inventory,
         canonical_roots,
-        canonical_roots_by_key,
         max_file_bytes,
         refresh_cache,
         max_cache_bytes,
@@ -300,9 +294,7 @@ def _synchronize_inventory(
         path = repository_file.path.path
         normalized_path = _normalized_path(path)
         normalized_root = _normalized_path(repository_file.root.path)
-        canonical_root = canonical_roots_by_key[
-            _path_key(repository_file.root.path)
-        ]
+        canonical_root = repository_file.canonical_root
         try:
             signature = _file_signature(path)
         except PermissionError:
@@ -535,7 +527,3 @@ def _database_call(operation, *args, **kwargs):
 
 def _normalized_path(value):
     return os.path.abspath(os.fspath(value)).replace(os.sep, "/")
-
-
-def _path_key(value):
-    return os.path.normcase(os.path.abspath(os.fspath(value)))

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -5,7 +5,9 @@ import os
 import sqlite3
 from dataclasses import dataclass
 
-from cereja.system._repository_files import iter_repository_files
+from cereja.system._repository_files import (
+    _iter_repository_files_with_canonical_paths as iter_repository_files,
+)
 
 from .cache_db import (
     SCHEMA_VERSION,
@@ -37,6 +39,17 @@ class _PreparedFile:
     path: str
     root: str
     cached: CachedFile
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedInventoryFile:
+    path: str
+    normalized_path: str
+    canonical_path: str
+    normalized_root: str
+    canonical_root: str
+    relative_path: str
+    signature: FileSignature
 
 
 def get_context_cache_info() -> ContextCacheInfo:
@@ -81,8 +94,7 @@ def _canonical_path(path):
     return os.path.normcase(os.path.realpath(os.fspath(path)))
 
 
-def _path_is_within_root(path, canonical_root):
-    canonical_path = _canonical_path(path)
+def _canonical_path_is_within_root(canonical_path, canonical_root):
     try:
         return os.path.commonpath((canonical_path, canonical_root)) == canonical_root
     except ValueError:
@@ -182,10 +194,20 @@ def _collect_cached_context(
     """Collect context using signature-validated persistent file content."""
     root_values = tuple(roots)
     normalized_roots = tuple(_normalized_path(root) for root in root_values)
-    canonical_roots = tuple(dict.fromkeys(_canonical_path(root) for root in root_values))
+    # Canonicalization is bounded by N inventory files + R explicit roots +
+    # one cache path. The inventory iterator supplies each file's value below.
+    canonical_roots_by_key = {}
+    for root in root_values:
+        root_key = _path_key(root)
+        if root_key not in canonical_roots_by_key:
+            canonical_roots_by_key[root_key] = _canonical_path(root)
+    canonical_roots = tuple(dict.fromkeys(canonical_roots_by_key.values()))
     cache_path = default_cache_path()
+    canonical_cache_path = _canonical_path(cache_path)
     if any(
-            _path_is_within_root(cache_path, canonical_root)
+            _canonical_path_is_within_root(
+                canonical_cache_path, canonical_root
+            )
             for canonical_root in canonical_roots
     ):
         raise CacheDatabaseUnavailable(
@@ -194,7 +216,9 @@ def _collect_cached_context(
 
     # Traversal can fail for invalid roots and must complete before any scan can
     # remove stale associations.
-    inventory = tuple(iter_repository_files(root_values, extensions=extensions))
+    inventory = tuple(iter_repository_files(
+        root_values, extensions=extensions
+    ))
 
     try:
         with ContextCacheDatabase(cache_path) as database:
@@ -208,7 +232,11 @@ def _collect_cached_context(
                 )
             inventory_roots = {root: False for root in canonical_roots}
             for repository_file in inventory:
-                inventory_roots[_canonical_path(repository_file.root.path)] = True
+                inventory_roots[
+                    canonical_roots_by_key[
+                        _path_key(repository_file.root.path)
+                    ]
+                ] = True
             roots_to_sync = _database_call(
                 database.roots_requiring_scan,
                 DEFAULT_NAMESPACE,
@@ -224,6 +252,7 @@ def _collect_cached_context(
                 database,
                 inventory,
                 canonical_roots,
+                canonical_roots_by_key,
                 max_file_bytes,
                 refresh_cache,
                 DEFAULT_MAX_BYTES,
@@ -256,6 +285,7 @@ def _synchronize_inventory(
         database,
         inventory,
         canonical_roots,
+        canonical_roots_by_key,
         max_file_bytes,
         refresh_cache,
         max_cache_bytes,
@@ -269,8 +299,10 @@ def _synchronize_inventory(
     for repository_file in inventory:
         path = repository_file.path.path
         normalized_path = _normalized_path(path)
-        canonical_path = _canonical_path(path)
-        canonical_root = _canonical_path(repository_file.root.path)
+        normalized_root = _normalized_path(repository_file.root.path)
+        canonical_root = canonical_roots_by_key[
+            _path_key(repository_file.root.path)
+        ]
         try:
             signature = _file_signature(path)
         except PermissionError:
@@ -281,41 +313,36 @@ def _synchronize_inventory(
             fast_path_eligible[canonical_root] = False
             skipped.append(SkippedFile(normalized_path, "disappeared"))
             continue
-        signed_files.append((
-            repository_file,
-            path,
-            normalized_path,
-            canonical_path,
-            canonical_root,
-            signature,
+        signed_files.append(_PreparedInventoryFile(
+            path=path,
+            normalized_path=normalized_path,
+            canonical_path=repository_file.canonical_path,
+            normalized_root=normalized_root,
+            canonical_root=canonical_root,
+            relative_path=repository_file.relative_path,
+            signature=signature,
         ))
 
     cached_by_path = {}
     if not refresh_cache and signed_files:
         cached_by_path = _database_call(
             database.get_cached_contents,
-            (item[3] for item in signed_files),
+            (item.canonical_path for item in signed_files),
         )
 
-    for (
-            repository_file,
-            path,
-            normalized_path,
-            canonical_path,
-            canonical_root,
-            signature,
-    ) in signed_files:
+    for item in signed_files:
+        signature = item.signature
         try:
-            cached = cached_by_path.get(canonical_path)
+            cached = cached_by_path.get(item.canonical_path)
             if not _cached_file_is_reusable(
                     cached, signature, max_file_bytes
             ):
                 signature, state, folded_text, digest = _read_cacheable_file(
-                    path, signature, max_file_bytes
+                    item.path, signature, max_file_bytes
                 )
                 cached = CachedFile(
-                    canonical_path=canonical_path,
-                    relative_path=repository_file.relative_path,
+                    canonical_path=item.canonical_path,
+                    relative_path=item.relative_path,
                     signature=signature,
                     state=state,
                     folded_text=folded_text,
@@ -323,26 +350,30 @@ def _synchronize_inventory(
                 )
             else:
                 cached = CachedFile(
-                    canonical_path=canonical_path,
-                    relative_path=repository_file.relative_path,
+                    canonical_path=item.canonical_path,
+                    relative_path=item.relative_path,
                     signature=signature,
                     state=cached.state,
                     folded_text=cached.folded_text,
                     content_sha256=cached.content_sha256,
                 )
         except PermissionError:
-            fast_path_eligible[canonical_root] = False
-            skipped.append(SkippedFile(normalized_path, "permission_denied"))
+            fast_path_eligible[item.canonical_root] = False
+            skipped.append(SkippedFile(
+                item.normalized_path, "permission_denied"
+            ))
             continue
         except FileNotFoundError:
-            fast_path_eligible[canonical_root] = False
-            skipped.append(SkippedFile(normalized_path, "disappeared"))
+            fast_path_eligible[item.canonical_root] = False
+            skipped.append(SkippedFile(
+                item.normalized_path, "disappeared"
+            ))
             continue
 
-        by_root[canonical_root].append(cached)
+        by_root[item.canonical_root].append(cached)
         prepared.append(_PreparedFile(
-            path=normalized_path,
-            root=_normalized_path(repository_file.root.path),
+            path=item.normalized_path,
+            root=item.normalized_root,
             cached=cached,
         ))
 
@@ -504,3 +535,7 @@ def _database_call(operation, *args, **kwargs):
 
 def _normalized_path(value):
     return os.path.abspath(os.fspath(value)).replace(os.sep, "/")
+
+
+def _path_key(value):
+    return os.path.normcase(os.path.abspath(os.fspath(value)))

--- a/cereja/system/_context/cache.py
+++ b/cereja/system/_context/cache.py
@@ -121,6 +121,15 @@ def _read_cacheable_file(path, signature, max_file_bytes):
     return state, None if text is None else text.casefold(), digest
 
 
+def _cached_file_is_reusable(cached, signature, max_file_bytes):
+    """Return whether cached content satisfies the current file constraints."""
+    if cached is None or cached.signature != signature:
+        return False
+    if signature.size_bytes > max_file_bytes:
+        return cached.state == "file_too_large"
+    return cached.state != "file_too_large"
+
+
 def _read_original_text(path, max_file_bytes):
     with open(path, "rb") as file:
         data = file.read(max_file_bytes + 1)
@@ -236,6 +245,7 @@ def _synchronize_inventory(
     by_root = {root: [] for root in canonical_roots}
     prepared = []
     skipped = []
+    signed_files = []
     for repository_file in inventory:
         path = repository_file.path.path
         normalized_path = _normalized_path(path)
@@ -243,13 +253,41 @@ def _synchronize_inventory(
         canonical_root = _canonical_path(repository_file.root.path)
         try:
             signature = _file_signature(path)
-            cached = None if refresh_cache else _database_call(
-                database.get_cached_content,
-                canonical_path,
-                signature,
-                max_file_bytes,
-            )
-            if cached is None:
+        except PermissionError:
+            skipped.append(SkippedFile(normalized_path, "permission_denied"))
+            continue
+        except FileNotFoundError:
+            skipped.append(SkippedFile(normalized_path, "disappeared"))
+            continue
+        signed_files.append((
+            repository_file,
+            path,
+            normalized_path,
+            canonical_path,
+            canonical_root,
+            signature,
+        ))
+
+    cached_by_path = {}
+    if not refresh_cache and signed_files:
+        cached_by_path = _database_call(
+            database.get_cached_contents,
+            (item[3] for item in signed_files),
+        )
+
+    for (
+            repository_file,
+            path,
+            normalized_path,
+            canonical_path,
+            canonical_root,
+            signature,
+    ) in signed_files:
+        try:
+            cached = cached_by_path.get(canonical_path)
+            if not _cached_file_is_reusable(
+                    cached, signature, max_file_bytes
+            ):
                 state, folded_text, digest = _read_cacheable_file(
                     path, signature, max_file_bytes
                 )
@@ -265,7 +303,7 @@ def _synchronize_inventory(
                 cached = CachedFile(
                     canonical_path=canonical_path,
                     relative_path=repository_file.relative_path,
-                    signature=cached.signature,
+                    signature=signature,
                     state=cached.state,
                     folded_text=cached.folded_text,
                     content_sha256=cached.content_sha256,

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -22,6 +22,7 @@ SCHEMA_VERSION = 1
 DEFAULT_NAMESPACE = "default"
 DEFAULT_MAX_BYTES = 256 * 1024 * 1024
 BUSY_TIMEOUT_MS = 500
+_BATCH_LOOKUP_CHUNK_SIZE = 900
 
 _SQLITE_HEADER = b"SQLite format 3\x00"
 _SQLITE_PAGE_SIZE_OFFSET = 16
@@ -1346,6 +1347,46 @@ class ContextCacheDatabase:
         if row[7] == "file_too_large" and signature.size_bytes <= max_file_bytes:
             return None
         return _cached_file_from_row(tuple(row[:10]))
+
+    def get_cached_contents(
+        self, canonical_paths: Iterable[str]
+    ) -> dict[str, CachedFile]:
+        """Return cached content for canonical paths without root associations."""
+        paths = tuple(dict.fromkeys(canonical_paths))
+        if not paths:
+            return {}
+
+        cached_by_path: dict[str, CachedFile] = {}
+        timestamp = time.time_ns()
+        updated = False
+        for start in range(0, len(paths), _BATCH_LOOKUP_CHUNK_SIZE):
+            chunk = paths[start:start + _BATCH_LOOKUP_CHUNK_SIZE]
+            placeholders = ", ".join("?" for _ in chunk)
+            rows = self.connection.execute(
+                f"""SELECT canonical_path, '', device, inode, size_bytes,
+                           mtime_ns, ctime_ns, state, folded_text, content_sha256
+                    FROM files
+                    WHERE canonical_path IN ({placeholders})""",
+                chunk,
+            ).fetchall()
+            if not rows:
+                continue
+            cached_by_path.update(
+                (str(row[0]), _cached_file_from_row(tuple(row)))
+                for row in rows
+            )
+            self.connection.execute(
+                f"""UPDATE files SET last_access_ns = ?
+                    WHERE canonical_path IN ({placeholders})""",
+                (timestamp, *chunk),
+            )
+            updated = True
+        if updated:
+            self.connection.commit()
+        return {
+            path: cached_by_path[path]
+            for path in paths if path in cached_by_path
+        }
 
     def aggregate_size_bytes(self) -> int:
         """Return the current byte size of the database and WAL sidecars."""

--- a/cereja/system/_context/cache_db.py
+++ b/cereja/system/_context/cache_db.py
@@ -1044,14 +1044,22 @@ class ContextCacheDatabase:
         scan_token: ScanToken,
         files: Iterable[CachedFile],
         max_bytes: int | None = None,
+        max_file_bytes: int | None = None,
     ) -> tuple[CachedFile, ...] | None:
         """Atomically publish the deterministic prefix admitted by quota."""
         if max_bytes is not None and max_bytes < 0:
             raise ValueError("max_bytes must not be negative")
+        if max_file_bytes is not None and max_file_bytes < 0:
+            raise ValueError("max_file_bytes must not be negative")
         if not isinstance(scan_token, ScanToken):
             raise CacheDatabaseError("context cache scan token is invalid")
         namespace = scan_token.namespace
         canonical_root = scan_token.canonical_root
+        scan_marker = scan_token.nonce
+        if max_file_bytes is not None:
+            scan_marker = (
+                f"{scan_token.nonce}|max_file_bytes={max_file_bytes}"
+            )
 
         cached_files = tuple(files)
         connection = self.connection
@@ -1166,7 +1174,7 @@ class ContextCacheDatabase:
                        ON CONFLICT(root_id, file_id) DO UPDATE SET
                            relative_path = excluded.relative_path,
                            last_seen_scan = excluded.last_seen_scan""",
-                    (root_id, file_id, cached_file.relative_path, scan_token.nonce),
+                    (root_id, file_id, cached_file.relative_path, scan_marker),
                 )
                 if (max_bytes is not None
                         and self._projected_aggregate_size() > max_bytes):
@@ -1180,7 +1188,7 @@ class ContextCacheDatabase:
             connection.execute(
                 """DELETE FROM root_files
                    WHERE root_id = ? AND last_seen_scan <> ?""",
-                (root_id, scan_token.nonce),
+                (root_id, scan_marker),
             )
             connection.execute(
                 """UPDATE roots SET
@@ -1223,6 +1231,151 @@ class ContextCacheDatabase:
                     raise primary_error from cleanup_error
                 raise cleanup_error
         return tuple(admitted)
+
+    def publish_unchanged_scan(
+        self,
+        scan_token: ScanToken,
+        files: Iterable[CachedFile],
+        max_bytes: int,
+        max_file_bytes: int,
+    ) -> bool:
+        """Publish metadata only when the root snapshot is exactly unchanged."""
+        if max_bytes < 0:
+            raise ValueError("max_bytes must not be negative")
+        if max_file_bytes < 0:
+            raise ValueError("max_file_bytes must not be negative")
+        if not isinstance(scan_token, ScanToken):
+            raise CacheDatabaseError("context cache scan token is invalid")
+
+        cached_files = tuple(files)
+        connection = self.connection
+        if (self.aggregate_size_bytes() >= max_bytes
+                or self._projected_aggregate_size() > max_bytes):
+            return False
+
+        primary_error = None
+        secondary_errors = []
+        try:
+            connection.execute("PRAGMA locking_mode = EXCLUSIVE")
+            connection.execute("PRAGMA cache_spill = OFF")
+            try:
+                connection.execute("BEGIN EXCLUSIVE")
+            except sqlite3.OperationalError as error:
+                if "locked" in str(error).casefold():
+                    return False
+                raise
+            if (self.aggregate_size_bytes() >= max_bytes
+                    or self._projected_aggregate_size() > max_bytes):
+                connection.rollback()
+                return False
+
+            current_root = connection.execute(
+                """SELECT id, scan_started_ns FROM roots
+                   WHERE canonical_path = ?""",
+                (scan_token.canonical_root,),
+            ).fetchone()
+            if current_root is None:
+                connection.rollback()
+                return False
+            if int(current_root[1]) >= scan_token.started_ns:
+                raise CacheDatabaseError("context cache scan token is stale")
+
+            namespace_row = connection.execute(
+                """SELECT n.id FROM namespace_roots AS nr
+                   JOIN namespaces AS n ON n.id = nr.namespace_id
+                   WHERE n.name = ? AND nr.root_id = ?""",
+                (scan_token.namespace, current_root[0]),
+            ).fetchone()
+            if namespace_row is None:
+                connection.rollback()
+                return False
+
+            rows = connection.execute(
+                """SELECT f.canonical_path, rf.relative_path,
+                          f.device, f.inode, f.size_bytes,
+                          f.mtime_ns, f.ctime_ns, f.state,
+                          f.content_sha256, rf.last_seen_scan
+                   FROM root_files AS rf
+                   JOIN files AS f ON f.id = rf.file_id
+                   WHERE rf.root_id = ?
+                   ORDER BY f.canonical_path, rf.relative_path""",
+                (current_root[0],),
+            ).fetchall()
+            limit_marker = f"|max_file_bytes={max_file_bytes}"
+            if not rows or any(
+                    not str(row[9]).endswith(limit_marker) for row in rows):
+                connection.rollback()
+                return False
+            cached_snapshot = tuple(sorted((
+                (
+                    item.canonical_path,
+                    item.relative_path,
+                    item.signature.device,
+                    item.signature.inode,
+                    item.signature.size_bytes,
+                    item.signature.mtime_ns,
+                    item.signature.ctime_ns,
+                    item.state,
+                    item.content_sha256,
+                ) for item in cached_files
+            ), key=lambda item: (item[0], item[1])))
+            published_snapshot = tuple(sorted(
+                (tuple(row[:9]) for row in rows),
+                key=lambda item: (item[0], item[1]),
+            ))
+            if cached_snapshot != published_snapshot:
+                connection.rollback()
+                return False
+
+            timestamp = time.time_ns()
+            connection.execute(
+                "UPDATE namespaces SET last_access_ns = ? WHERE id = ?",
+                (timestamp, namespace_row[0]),
+            )
+            connection.execute(
+                """UPDATE roots SET
+                       scan_generation = scan_generation + 1,
+                       scan_started_ns = ?, scan_nonce = ?, last_access_ns = ?
+                   WHERE id = ?""",
+                (
+                    scan_token.started_ns,
+                    scan_token.nonce,
+                    timestamp,
+                    current_root[0],
+                ),
+            )
+            if self._projected_aggregate_size() > max_bytes:
+                connection.rollback()
+                return False
+            connection.commit()
+        except BaseException as error:
+            primary_error = error
+            if connection.in_transaction:
+                try:
+                    connection.rollback()
+                except BaseException as rollback_error:
+                    secondary_errors.append(rollback_error)
+            raise
+        finally:
+            try:
+                connection.execute("PRAGMA cache_spill = ON")
+            except BaseException as error:
+                secondary_errors.append(error)
+            try:
+                self._restore_normal_locking()
+            except BaseException as error:
+                secondary_errors.append(error)
+            if secondary_errors:
+                cleanup_error = secondary_errors[0]
+                if len(secondary_errors) > 1:
+                    cleanup_error = BaseExceptionGroup(
+                        "context cache transaction cleanup failed",
+                        secondary_errors,
+                    )
+                if primary_error is not None:
+                    raise primary_error from cleanup_error
+                raise cleanup_error
+        return True
 
     def _restore_normal_locking(self) -> None:
         """Restore normal locking and force release on the next file access."""

--- a/cereja/system/_directory_entries.py
+++ b/cereja/system/_directory_entries.py
@@ -1,0 +1,25 @@
+"""Private non-recursive directory enumeration helpers."""
+
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+
+def iter_directory_entries(
+        path,
+        *,
+        include_hidden=False,
+        raise_errors=False,
+):
+    """Yield os.DirEntry values for one directory without recursion."""
+    try:
+        with os.scandir(path) as entries:
+            for entry in entries:
+                if include_hidden or not entry.name.startswith("."):
+                    yield entry
+    except OSError as error:
+        if raise_errors:
+            raise
+        logger.error("%s", error)

--- a/cereja/system/_path.py
+++ b/cereja/system/_path.py
@@ -33,6 +33,7 @@ from typing import List, Union
 from pathlib import Path as Path_
 import glob
 from ..utils.decorators import on_except
+from ._directory_entries import iter_directory_entries
 
 logger = logging.getLogger(__name__)
 
@@ -487,13 +488,24 @@ class Path(os.PathLike):
         if not self.is_dir:
             raise NotADirectoryError(f"check that the path '{self.path}' is correct")
         try:
-            return [
-                self.__class__(p).stem if only_name else self.__class__(p)
-                for p in glob.glob(
+            if search_match == "*" and recursive is False:
+                paths = (
+                    entry.path
+                    for entry in iter_directory_entries(
+                        self.path,
+                        include_hidden=include_hidden,
+                        raise_errors=raise_errors,
+                    )
+                )
+            else:
+                paths = glob.glob(
                     self.join(search_match).path,
                     recursive=recursive,
                     include_hidden=include_hidden,
                 )
+            return [
+                self.__class__(p).stem if only_name else self.__class__(p)
+                for p in paths
             ]
         except PermissionError as err:
             if raise_errors:

--- a/cereja/system/_repository_files.py
+++ b/cereja/system/_repository_files.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from fnmatch import fnmatchcase
 import os
 from pathlib import Path as NativePath
+import stat
 
+from cereja.system._directory_entries import iter_directory_entries
 from cereja.system._path import Path
 
 __all__ = ["RepositoryFile", "iter_repository_files"]
@@ -35,6 +37,14 @@ class _CanonicalRepositoryFile:
     relative_path: str
     canonical_path: str
     canonical_root: str
+
+
+@dataclass(frozen=True, slots=True)
+class _DirectoryEntrySnapshot:
+    name: str
+    path: str
+    is_link: bool
+    is_directory: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,10 +93,9 @@ def _iter_prepared_repository_files(prepared_roots, *, extensions=None):
     for prepared_root in prepared_roots:
         root = prepared_root.root
         inherited = _ancestor_ignore_rules(root)
-        for file_path in _walk_files(root, inherited):
-            if normalized_extensions is not None:
-                if file_path.suffix.casefold() not in normalized_extensions:
-                    continue
+        for file_path in _walk_files(
+                root, inherited, normalized_extensions
+        ):
             lexical_path = os.path.normcase(os.path.abspath(file_path.path))
             if lexical_path in seen_lexical_paths:
                 continue
@@ -144,27 +153,63 @@ def _ancestor_ignore_rules(root):
     return rules
 
 
-def _walk_files(root, inherited_rules):
+def _walk_files(root, inherited_rules, normalized_extensions=None):
     found = []
 
     def visit(directory, rules):
         active_rules = rules + _load_ignore_rules(directory)
-        entries = directory.list_dir(include_hidden=True, raise_errors=True)
+        entries = []
+        for entry in iter_directory_entries(
+                directory.path,
+                include_hidden=True,
+                raise_errors=True,
+        ):
+            is_link = _directory_entry_is_link(entry)
+            is_directory = (
+                False
+                if is_link
+                else entry.is_dir(follow_symlinks=False)
+            )
+            entries.append(_DirectoryEntrySnapshot(
+                name=entry.name,
+                path=entry.path,
+                is_link=is_link,
+                is_directory=is_directory,
+            ))
         entries.sort(key=lambda entry: (entry.name.casefold(), entry.name))
         for entry in entries:
-            is_directory = entry.is_dir and not entry.is_link
-            if entry.is_link or _is_builtin_ignored(entry, is_directory):
+            if entry.is_link or _is_builtin_ignored(
+                    entry, entry.is_directory
+            ):
                 continue
-            if _is_ignored(entry, is_directory, active_rules):
+            if _is_ignored(entry, entry.is_directory, active_rules):
                 continue
-            if is_directory:
-                visit(entry, active_rules)
+            if entry.is_directory:
+                visit(Path(entry.path), active_rules)
             else:
-                found.append(entry)
+                if normalized_extensions is not None:
+                    suffix = NativePath(entry.name).suffix.casefold()
+                    if suffix not in normalized_extensions:
+                        continue
+                found.append(Path(entry.path))
 
     visit(root, inherited_rules)
     found.sort(key=lambda item: NativePath(item.path).relative_to(NativePath(root.path)).as_posix())
     return found
+
+
+def _directory_entry_is_link(entry):
+    if entry.is_symlink():
+        return True
+    if os.name != "nt":
+        return False
+    attributes = getattr(
+        entry.stat(follow_symlinks=False),
+        "st_file_attributes",
+        0,
+    ) or 0
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attributes & reparse_point)
 
 
 def _load_ignore_rules(directory, root=None):

--- a/cereja/system/_repository_files.py
+++ b/cereja/system/_repository_files.py
@@ -23,11 +23,18 @@ class RepositoryFile:
 
 
 @dataclass(frozen=True, slots=True)
+class _CanonicalRepositoryRoot:
+    root: Path
+    canonical_path: str
+
+
+@dataclass(frozen=True, slots=True)
 class _CanonicalRepositoryFile:
     root: Path
     path: Path
     relative_path: str
     canonical_path: str
+    canonical_root: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,20 +48,40 @@ class _IgnoreRule:
 
 def iter_repository_files(roots, *, extensions=None):
     """Yield filtered files from explicit roots in deterministic order."""
-    for item in _iter_repository_files_with_canonical_paths(
-            roots, extensions=extensions
+    prepared_roots = _prepare_repository_roots(roots)
+    for item in _iter_prepared_repository_files(
+            prepared_roots, extensions=extensions
     ):
         yield RepositoryFile(item.root, item.path, item.relative_path)
 
 
-def _iter_repository_files_with_canonical_paths(roots, *, extensions=None):
+def _prepare_repository_roots(roots):
+    """Validate and canonicalize normalized traversal roots once."""
+    prepared = []
+    seen_lexical = set()
+    seen_canonical = set()
+    for root_value in roots:
+        root = root_value if isinstance(root_value, Path) else Path(root_value)
+        _validate_root(root)
+        lexical = os.path.normcase(os.path.abspath(root.path))
+        if lexical in seen_lexical:
+            continue
+        seen_lexical.add(lexical)
+        canonical = os.path.normcase(os.path.realpath(root.path))
+        if canonical in seen_canonical:
+            continue
+        seen_canonical.add(canonical)
+        prepared.append(_CanonicalRepositoryRoot(root, canonical))
+    return tuple(prepared)
+
+
+def _iter_prepared_repository_files(prepared_roots, *, extensions=None):
     """Yield repository files with one reusable canonical-path resolution."""
     normalized_extensions = _normalize_extensions(extensions)
     seen = set()
     seen_lexical_paths = set()
-    for root_value in roots:
-        root = root_value if isinstance(root_value, Path) else Path(root_value)
-        _validate_root(root)
+    for prepared_root in prepared_roots:
+        root = prepared_root.root
         inherited = _ancestor_ignore_rules(root)
         for file_path in _walk_files(root, inherited):
             if normalized_extensions is not None:
@@ -74,6 +101,7 @@ def _iter_repository_files_with_canonical_paths(roots, *, extensions=None):
                 path=file_path,
                 relative_path=relative,
                 canonical_path=canonical,
+                canonical_root=prepared_root.canonical_path,
             )
 
 

--- a/cereja/system/_repository_files.py
+++ b/cereja/system/_repository_files.py
@@ -23,6 +23,14 @@ class RepositoryFile:
 
 
 @dataclass(frozen=True, slots=True)
+class _CanonicalRepositoryFile:
+    root: Path
+    path: Path
+    relative_path: str
+    canonical_path: str
+
+
+@dataclass(frozen=True, slots=True)
 class _IgnoreRule:
     pattern: str
     negated: bool
@@ -33,22 +41,40 @@ class _IgnoreRule:
 
 def iter_repository_files(roots, *, extensions=None):
     """Yield filtered files from explicit roots in deterministic order."""
+    for item in _iter_repository_files_with_canonical_paths(
+            roots, extensions=extensions
+    ):
+        yield RepositoryFile(item.root, item.path, item.relative_path)
+
+
+def _iter_repository_files_with_canonical_paths(roots, *, extensions=None):
+    """Yield repository files with one reusable canonical-path resolution."""
     normalized_extensions = _normalize_extensions(extensions)
     seen = set()
+    seen_lexical_paths = set()
     for root_value in roots:
         root = root_value if isinstance(root_value, Path) else Path(root_value)
         _validate_root(root)
         inherited = _ancestor_ignore_rules(root)
         for file_path in _walk_files(root, inherited):
-            canonical = os.path.normcase(os.path.realpath(file_path.path))
-            if canonical in seen:
-                continue
             if normalized_extensions is not None:
                 if file_path.suffix.casefold() not in normalized_extensions:
                     continue
+            lexical_path = os.path.normcase(os.path.abspath(file_path.path))
+            if lexical_path in seen_lexical_paths:
+                continue
+            seen_lexical_paths.add(lexical_path)
+            canonical = os.path.normcase(os.path.realpath(file_path.path))
+            if canonical in seen:
+                continue
             seen.add(canonical)
             relative = NativePath(file_path.path).relative_to(NativePath(root.path)).as_posix()
-            yield RepositoryFile(root=root, path=file_path, relative_path=relative)
+            yield _CanonicalRepositoryFile(
+                root=root,
+                path=file_path,
+                relative_path=relative,
+                canonical_path=canonical,
+            )
 
 
 def _validate_root(root):

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -691,6 +691,55 @@ class ContextCacheTest(unittest.TestCase):
             self.assertEqual(response.results[0].snippets[0].text, "Auth cache")
             self.assertEqual(reads, ["auth.txt"])
 
+    def test_warm_cache_validates_all_files_with_one_batched_lookup(self):
+        """A per-file cache query must not return during a warm scan."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            for name in ("first.txt", "second.txt", "third.txt"):
+                (root / name).write_text("cached content", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_batched_lookup = ContextCacheDatabase.get_cached_contents
+            original_individual_lookup = ContextCacheDatabase.get_cached_content
+            batched_lookups = []
+            individual_lookups = []
+
+            def record_batched_lookup(database, canonical_paths):
+                canonical_paths = tuple(canonical_paths)
+                batched_lookups.append(canonical_paths)
+                return original_batched_lookup(database, canonical_paths)
+
+            def record_individual_lookup(*args, **kwargs):
+                individual_lookups.append((args, kwargs))
+                return original_individual_lookup(*args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "missing", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "get_cached_contents",
+                    new=record_batched_lookup,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "get_cached_content",
+                    new=record_individual_lookup,
+                ):
+                    reads = self._record_cache_reads(
+                        lambda: search_text_context([root], "missing", cache=True)
+                    )
+
+            expected_paths = {
+                cache_module._canonical_path(root / name)
+                for name in ("first.txt", "second.txt", "third.txt")
+            }
+            self.assertEqual(reads, [])
+            self.assertEqual(len(batched_lookups), 1)
+            self.assertEqual(set(batched_lookups[0]), expected_paths)
+            self.assertEqual(individual_lookups, [])
+
     def test_casefold_length_change_preserves_direct_truncation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
@@ -961,6 +1010,34 @@ class ContextCacheTest(unittest.TestCase):
                 )
                 self.assertEqual(refreshed_reads, ["changed.txt", "stable.txt"])
 
+    def test_warm_cache_reprocesses_when_file_limit_crosses_file_size(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("content", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context(
+                    [root], "missing", cache=True, max_file_bytes=10
+                )
+                reduced_limit_reads = self._record_cache_reads(
+                    lambda: search_text_context(
+                        [root], "missing", cache=True, max_file_bytes=3
+                    )
+                )
+                restored_limit_reads = self._record_cache_reads(
+                    lambda: search_text_context(
+                        [root], "content", cache=True, max_file_bytes=10
+                    )
+                )
+
+            self.assertEqual(reduced_limit_reads, ["target.txt"])
+            self.assertEqual(restored_limit_reads, ["target.txt"])
+
     def test_transient_read_failure_is_reported_but_not_persisted(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
@@ -991,6 +1068,50 @@ class ContextCacheTest(unittest.TestCase):
             self.assertEqual(first.skipped[0].reason, "disappeared")
             self.assertEqual(second.results[0].relative_path, "target.txt")
 
+    def test_synchronization_publishes_only_admitted_root_scans(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "outer"
+            inner = Path(temp_dir) / "inner"
+            outer.mkdir()
+            inner.mkdir()
+            (outer / "outer.txt").write_text("outer", encoding="utf-8")
+            (inner / "inner.txt").write_text("inner", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            outer_root = cache_module._canonical_path(outer)
+            original_begin = ContextCacheDatabase.begin_scans_if_admitted
+            original_commit = ContextCacheDatabase.commit_scan
+            commit_calls = []
+
+            def admit_only_outer(database, namespace, roots, max_bytes):
+                tokens = original_begin(database, namespace, roots, max_bytes)
+                return {outer_root: tokens[outer_root]}
+
+            def record_commit(*args, **kwargs):
+                commit_calls.append((args, kwargs))
+                return original_commit(*args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch.object(
+                ContextCacheDatabase,
+                "begin_scans_if_admitted",
+                new=admit_only_outer,
+            ), patch.object(
+                ContextCacheDatabase,
+                "commit_scan",
+                new=record_commit,
+            ):
+                response = search_text_context(
+                    [outer, inner], "missing", cache=True
+                )
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(
+                [call[0][1].canonical_root for call in commit_calls],
+                [outer_root],
+            )
+
     def test_failed_inventory_does_not_destructively_synchronize_root(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"
@@ -1011,14 +1132,26 @@ class ContextCacheTest(unittest.TestCase):
                     yield next(iter(original_inventory(*args, **kwargs)))
                     raise OSError("inventory failed")
 
+                commit_calls = []
+                original_commit = ContextCacheDatabase.commit_scan
+
+                def record_commit(*args, **kwargs):
+                    commit_calls.append((args, kwargs))
+                    return original_commit(*args, **kwargs)
+
                 with patch(
                     "cereja.system._context.cache.iter_repository_files",
                     side_effect=failing_inventory,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "commit_scan",
+                    new=record_commit,
                 ), warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter("always")
                     with self.assertRaisesRegex(OSError, "inventory failed"):
                         search_text_context([root], "needle", cache=True)
                 self.assertFalse(caught)
+                self.assertEqual(commit_calls, [])
 
             with ContextCacheDatabase(cache_path) as database:
                 cached = tuple(database.iter_root_files(

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -1471,6 +1471,48 @@ class ContextCacheTest(unittest.TestCase):
                 )
                 self.assertEqual(refreshed_reads, ["changed.txt", "stable.txt"])
 
+    def test_refresh_republishes_derived_text_when_file_identity_matches(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("Current Needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            canonical_target = cache_module._canonical_path(target)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "needle", cache=True)
+                with ContextCacheDatabase(cache_path) as database:
+                    database.connection.execute(
+                        "UPDATE files SET folded_text = 'stale derived text' "
+                        "WHERE canonical_path = ?",
+                        (canonical_target,),
+                    )
+                    database.connection.commit()
+
+                refreshed = search_text_context(
+                    [root], "needle", cache=True, refresh_cache=True
+                )
+                with ContextCacheDatabase(cache_path) as database:
+                    stored_text = database.connection.execute(
+                        "SELECT folded_text FROM files WHERE canonical_path = ?",
+                        (canonical_target,),
+                    ).fetchone()[0]
+                warm = search_text_context([root], "needle", cache=True)
+
+            self.assertEqual(
+                [item.relative_path for item in refreshed.results],
+                ["target.txt"],
+            )
+            self.assertEqual(stored_text, "current needle")
+            self.assertEqual(
+                [item.relative_path for item in warm.results],
+                ["target.txt"],
+            )
+
     def test_warm_cache_reprocesses_when_file_limit_crosses_file_size(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -968,6 +968,52 @@ class ContextCacheTest(unittest.TestCase):
             self.assertEqual(set(batched_lookups[0]), expected_paths)
             self.assertEqual(individual_lookups, [])
 
+    def test_cached_search_canonicalizes_each_file_and_root_once(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "repo"
+            inner = outer / "nested"
+            inner.mkdir(parents=True)
+            outer_file = outer / "outer.txt"
+            inner_file = inner / "inner.txt"
+            outer_file.write_text("cached", encoding="utf-8")
+            inner_file.write_text("cached", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_realpath = os.path.realpath
+            canonicalized = []
+
+            def record_realpath(path, *args, **kwargs):
+                canonicalized.append(os.fspath(path))
+                return original_realpath(path, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([outer, inner], "missing", cache=True)
+                with patch(
+                    "cereja.system._context.cache.os.path.realpath",
+                    side_effect=record_realpath,
+                ):
+                    search_text_context(
+                        [outer, inner], "missing", cache=True
+                    )
+
+            normalized_calls = [
+                os.path.normcase(os.path.abspath(path))
+                for path in canonicalized
+            ]
+            expected_once = [
+                os.path.normcase(os.path.abspath(os.fspath(path)))
+                for path in (
+                    outer,
+                    inner,
+                    cache_path,
+                    outer_file,
+                    inner_file,
+                )
+            ]
+            self.assertCountEqual(normalized_calls, expected_once)
+
     def test_unchanged_warm_root_selects_fast_publication_path(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -155,6 +155,45 @@ class ContextCacheTest(unittest.TestCase):
                 self.assertFalse(Path(f"{cache_path}-wal").exists())
                 self.assertFalse(Path(f"{cache_path}-shm").exists())
 
+    def test_cache_containment_uses_traversal_normalized_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            root = base / "repo"
+            root.mkdir()
+            (root / "guide.md").write_text("needle", encoding="utf-8")
+            input_root = base / "link" / ".." / "repo"
+            cache_path = root / "context.sqlite3"
+            misleading_root = base / "outside"
+            original_realpath = os.path.realpath
+
+            def simulated_realpath(path, *args, **kwargs):
+                if os.path.normcase(os.fspath(path)) == os.path.normcase(
+                        os.fspath(input_root)
+                ):
+                    return os.fspath(misleading_root)
+                return original_realpath(path, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache.os.path.realpath",
+                side_effect=simulated_realpath,
+            ), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                response = search_text_context(
+                    [input_root], "needle", cache=True
+                )
+
+            self.assertEqual(
+                [item.relative_path for item in response.results],
+                ["guide.md"],
+            )
+            self.assertTrue(
+                any(item.category is ContextCacheWarning for item in caught)
+            )
+            self.assertFalse(cache_path.exists())
+
     def test_info_reports_metadata_without_content(self):
         self.assertTrue(hasattr(system_module, "get_context_cache_info"))
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1013,6 +1052,58 @@ class ContextCacheTest(unittest.TestCase):
                 )
             ]
             self.assertCountEqual(normalized_calls, expected_once)
+
+    def test_canonical_root_aliases_are_traversed_only_once(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir)
+            primary = base / "primary"
+            alias = base / "alias"
+            primary.mkdir()
+            alias.mkdir()
+            primary_file = primary / "shared.txt"
+            alias_file = alias / "shared.txt"
+            primary_file.write_text("cached", encoding="utf-8")
+            alias_file.write_text("cached", encoding="utf-8")
+            cache_path = base / "cache" / "context.sqlite3"
+            original_realpath = os.path.realpath
+            primary_key = os.path.normcase(os.path.abspath(primary))
+            alias_key = os.path.normcase(os.path.abspath(alias))
+            canonicalized = []
+
+            def simulated_realpath(path, *args, **kwargs):
+                lexical = os.path.normcase(
+                    os.path.abspath(os.fspath(path))
+                )
+                canonicalized.append(lexical)
+                if lexical == alias_key:
+                    return original_realpath(primary, *args, **kwargs)
+                if lexical.startswith(alias_key + os.sep):
+                    relative = os.path.relpath(lexical, alias_key)
+                    return original_realpath(
+                        primary / relative, *args, **kwargs
+                    )
+                return original_realpath(path, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache.os.path.realpath",
+                side_effect=simulated_realpath,
+            ):
+                search_text_context(
+                    [primary, alias], "missing", cache=True
+                )
+
+            expected_once = [
+                os.path.normcase(os.path.abspath(os.fspath(path)))
+                for path in (primary, alias, cache_path, primary_file)
+            ]
+            self.assertCountEqual(canonicalized, expected_once)
+            self.assertNotIn(
+                os.path.normcase(os.path.abspath(alias_file)),
+                canonicalized,
+            )
 
     def test_unchanged_warm_root_selects_fast_publication_path(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -20,6 +20,26 @@ from cereja.system._context.cache_db import (
 from cereja.system._context.models import ContextCacheWarning
 
 
+class _AfterReadMutation:
+    """Wrap a real binary file and mutate its path after one read."""
+
+    def __init__(self, file, mutation):
+        self._file = file
+        self._mutation = mutation
+
+    def __enter__(self):
+        self._file.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._file.__exit__(*args)
+
+    def read(self, *args, **kwargs):
+        data = self._file.read(*args, **kwargs)
+        self._mutation()
+        return data
+
+
 def _active_sidecar_snapshot(sidecars, modes=None):
     """Read active sidecars, using stable metadata for locked Windows SHM."""
     snapshots = []
@@ -679,9 +699,9 @@ class ContextCacheTest(unittest.TestCase):
                 original_read = cache_module._read_original_text
                 reads = []
 
-                def recording_read(path, max_file_bytes):
+                def recording_read(path, signature, max_file_bytes):
                     reads.append(Path(path).name)
-                    return original_read(path, max_file_bytes)
+                    return original_read(path, signature, max_file_bytes)
 
                 with patch(
                     "cereja.system._context.cache._read_original_text",
@@ -690,6 +710,214 @@ class ContextCacheTest(unittest.TestCase):
                     response = search_text_context([root], "auth", cache=True)
             self.assertEqual(response.results[0].snippets[0].text, "Auth cache")
             self.assertEqual(reads, ["auth.txt"])
+
+    def test_cache_read_retries_from_fresh_signature_before_publication(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("stale needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_open = open
+            mutated = False
+
+            def replace_after_read():
+                nonlocal mutated
+                mutated = True
+                with original_open(target, "wb") as file:
+                    file.write(b"fresh content")
+
+            def racing_open(path, mode="r", *args, **kwargs):
+                if (
+                        mode == "rb"
+                        and cache_module._canonical_path(path)
+                        == cache_module._canonical_path(target)
+                        and not mutated
+                ):
+                    return _AfterReadMutation(
+                        original_open(path, mode, *args, **kwargs),
+                        replace_after_read,
+                    )
+                return original_open(path, mode, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache.open",
+                side_effect=racing_open,
+                create=True,
+            ):
+                response = search_text_context(
+                    [root], "stale needle", cache=True
+                )
+
+            canonical_path = cache_module._canonical_path(target)
+            with ContextCacheDatabase(cache_path) as database:
+                cached = database.get_cached_contents((canonical_path,))[
+                    canonical_path
+                ]
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(
+                cached.signature, cache_module._file_signature(target)
+            )
+            self.assertEqual(cached.folded_text, "fresh content")
+
+    def test_disappearing_file_is_not_committed_after_read(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("stale needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_open = open
+            original_stat = os.stat
+            disappeared = False
+
+            def remove_after_read():
+                nonlocal disappeared
+                disappeared = True
+
+            target_key = os.path.normcase(os.path.abspath(target))
+
+            def racing_stat(path, *args, **kwargs):
+                path_key = os.path.normcase(os.path.abspath(os.fspath(path)))
+                if disappeared and path_key == target_key:
+                    raise FileNotFoundError(path)
+                return original_stat(path, *args, **kwargs)
+
+            def racing_open(path, mode="r", *args, **kwargs):
+                if (
+                        mode == "rb"
+                        and cache_module._canonical_path(path)
+                        == cache_module._canonical_path(target)
+                        and not disappeared
+                ):
+                    return _AfterReadMutation(
+                        original_open(path, mode, *args, **kwargs),
+                        remove_after_read,
+                    )
+                return original_open(path, mode, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache.open",
+                side_effect=racing_open,
+                create=True,
+            ), patch(
+                "cereja.system._context.cache.os.stat",
+                side_effect=racing_stat,
+            ):
+                response = search_text_context(
+                    [root], "stale needle", cache=True
+                )
+
+            canonical_path = cache_module._canonical_path(target)
+            with ContextCacheDatabase(cache_path) as database:
+                cached = database.get_cached_contents((canonical_path,))
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(response.skipped[0].reason, "disappeared")
+            self.assertNotIn(canonical_path, cached)
+
+    def test_repeatedly_mutating_file_is_skipped_after_one_retry(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("needle one", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_open = open
+            replacements = iter((
+                b"needle second version",
+                b"needle third version that changed",
+            ))
+            mutations = 0
+
+            def replace_after_read():
+                nonlocal mutations
+                mutations += 1
+                with original_open(target, "wb") as file:
+                    file.write(next(replacements))
+
+            def racing_open(path, mode="r", *args, **kwargs):
+                if (
+                        mode == "rb"
+                        and cache_module._canonical_path(path)
+                        == cache_module._canonical_path(target)
+                        and mutations < 2
+                ):
+                    return _AfterReadMutation(
+                        original_open(path, mode, *args, **kwargs),
+                        replace_after_read,
+                    )
+                return original_open(path, mode, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ), patch(
+                "cereja.system._context.cache.open",
+                side_effect=racing_open,
+                create=True,
+            ):
+                response = search_text_context([root], "needle", cache=True)
+
+            canonical_path = cache_module._canonical_path(target)
+            with ContextCacheDatabase(cache_path) as database:
+                cached = database.get_cached_contents((canonical_path,))
+
+            self.assertEqual(response.results, ())
+            self.assertEqual(response.skipped[0].reason, "disappeared")
+            self.assertNotIn(canonical_path, cached)
+
+    def test_winner_mutation_during_read_never_returns_stale_snippet(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("stale needle", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_open = open
+            mutated = False
+
+            def replace_after_read():
+                nonlocal mutated
+                mutated = True
+                with original_open(target, "wb") as file:
+                    file.write(b"fresh content")
+
+            def racing_open(path, mode="r", *args, **kwargs):
+                if (
+                        mode == "rb"
+                        and cache_module._canonical_path(path)
+                        == cache_module._canonical_path(target)
+                        and not mutated
+                ):
+                    return _AfterReadMutation(
+                        original_open(path, mode, *args, **kwargs),
+                        replace_after_read,
+                    )
+                return original_open(path, mode, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "stale needle", cache=True)
+                with patch(
+                    "cereja.system._context.cache.open",
+                    side_effect=racing_open,
+                    create=True,
+                ):
+                    response = search_text_context(
+                        [root], "stale needle", cache=True
+                    )
+
+            self.assertEqual(response.results, ())
 
     def test_warm_cache_validates_all_files_with_one_batched_lookup(self):
         """A per-file cache query must not return during a warm scan."""

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -968,6 +968,239 @@ class ContextCacheTest(unittest.TestCase):
             self.assertEqual(set(batched_lookups[0]), expected_paths)
             self.assertEqual(individual_lookups, [])
 
+    def test_unchanged_warm_root_selects_fast_publication_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "first.txt").write_text("cached", encoding="utf-8")
+            (root / "second.txt").write_text("cached", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_fast = ContextCacheDatabase.publish_unchanged_scan
+            original_commit = ContextCacheDatabase.commit_scan
+            fast_results = []
+            commits = []
+
+            def record_fast(database, *args, **kwargs):
+                result = original_fast(database, *args, **kwargs)
+                fast_results.append((args[0].canonical_root, result))
+                return result
+
+            def record_commit(database, *args, **kwargs):
+                commits.append(args[0].canonical_root)
+                return original_commit(database, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "missing", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "publish_unchanged_scan",
+                    new=record_fast,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "commit_scan",
+                    new=record_commit,
+                ):
+                    search_text_context([root], "missing", cache=True)
+
+            self.assertEqual(
+                fast_results,
+                [(cache_module._canonical_path(root), True)],
+            )
+            self.assertEqual(commits, [])
+
+    def test_root_mutations_and_size_limit_transitions_use_commit_scan(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            target = root / "target.txt"
+            target.write_text("content", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_fast = ContextCacheDatabase.publish_unchanged_scan
+            original_commit = ContextCacheDatabase.commit_scan
+            fast_results = []
+            commits = []
+
+            def record_fast(database, *args, **kwargs):
+                result = original_fast(database, *args, **kwargs)
+                fast_results.append(result)
+                return result
+
+            def record_commit(database, *args, **kwargs):
+                commits.append(args[0].canonical_root)
+                return original_commit(database, *args, **kwargs)
+
+            def assert_commit(**search_options):
+                fast_results.clear()
+                commits.clear()
+                search_text_context(
+                    [root], "missing", cache=True, **search_options
+                )
+                self.assertEqual(fast_results, [False])
+                self.assertEqual(
+                    commits, [cache_module._canonical_path(root)]
+                )
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context(
+                    [root], "missing", cache=True, max_file_bytes=10
+                )
+                with patch.object(
+                    ContextCacheDatabase,
+                    "publish_unchanged_scan",
+                    new=record_fast,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "commit_scan",
+                    new=record_commit,
+                ):
+                    assert_commit(max_file_bytes=20)
+
+                    created = root / "created.txt"
+                    created.write_text("created", encoding="utf-8")
+                    assert_commit(max_file_bytes=20)
+
+                    target.write_text("changed content", encoding="utf-8")
+                    assert_commit(max_file_bytes=20)
+
+                    renamed = root / "renamed.txt"
+                    created.rename(renamed)
+                    assert_commit(max_file_bytes=20)
+
+                    renamed.unlink()
+                    assert_commit(max_file_bytes=20)
+
+                    assert_commit(max_file_bytes=3)
+                    assert_commit(max_file_bytes=20)
+
+    def test_incomplete_inventory_never_selects_fast_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "repo"
+            root.mkdir()
+            (root / "cached.txt").write_text("cached", encoding="utf-8")
+            blocked = root / "blocked.txt"
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_signature = cache_module._file_signature
+            original_fast = ContextCacheDatabase.publish_unchanged_scan
+            original_commit = ContextCacheDatabase.commit_scan
+            fast_calls = []
+            commits = []
+
+            def selective_signature(path):
+                if Path(path) == blocked:
+                    raise PermissionError(path)
+                return original_signature(path)
+
+            def record_fast(database, *args, **kwargs):
+                fast_calls.append(args[0].canonical_root)
+                return original_fast(database, *args, **kwargs)
+
+            def record_commit(database, *args, **kwargs):
+                commits.append(args[0].canonical_root)
+                return original_commit(database, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([root], "missing", cache=True)
+                blocked.write_text("blocked", encoding="utf-8")
+                with patch(
+                    "cereja.system._context.cache._file_signature",
+                    side_effect=selective_signature,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "publish_unchanged_scan",
+                    new=record_fast,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "commit_scan",
+                    new=record_commit,
+                ):
+                    response = search_text_context(
+                        [root], "missing", cache=True
+                    )
+
+            self.assertEqual(fast_calls, [])
+            self.assertEqual(
+                commits, [cache_module._canonical_path(root)]
+            )
+            self.assertEqual(
+                [(Path(item.path).name, item.reason) for item in response.skipped],
+                [("blocked.txt", "permission_denied")],
+            )
+
+    def test_overlapping_roots_choose_fast_path_independently(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outer = Path(temp_dir) / "repo"
+            inner = outer / "nested"
+            inner.mkdir(parents=True)
+            outer_file = outer / "outer.txt"
+            outer_file.write_text("outer", encoding="utf-8")
+            (inner / "inner.txt").write_text("inner", encoding="utf-8")
+            cache_path = Path(temp_dir) / "cache" / "context.sqlite3"
+            original_fast = ContextCacheDatabase.publish_unchanged_scan
+            original_commit = ContextCacheDatabase.commit_scan
+            fast_results = []
+            commits = []
+
+            def record_fast(database, *args, **kwargs):
+                result = original_fast(database, *args, **kwargs)
+                fast_results.append((args[0].canonical_root, result))
+                return result
+
+            def record_commit(database, *args, **kwargs):
+                commits.append(args[0].canonical_root)
+                return original_commit(database, *args, **kwargs)
+
+            with patch(
+                "cereja.system._context.cache.default_cache_path",
+                return_value=cache_path,
+            ):
+                search_text_context([outer], "missing", cache=True)
+                search_text_context([inner], "missing", cache=True)
+                with patch.object(
+                    ContextCacheDatabase,
+                    "publish_unchanged_scan",
+                    new=record_fast,
+                ), patch.object(
+                    ContextCacheDatabase,
+                    "commit_scan",
+                    new=record_commit,
+                ):
+                    search_text_context([outer], "missing", cache=True)
+                    search_text_context([inner], "missing", cache=True)
+                    self.assertEqual(
+                        fast_results,
+                        [
+                            (cache_module._canonical_path(outer), True),
+                            (cache_module._canonical_path(inner), True),
+                        ],
+                    )
+                    self.assertEqual(commits, [])
+
+                    fast_results.clear()
+                    commits.clear()
+                    outer_file.write_text("changed", encoding="utf-8")
+                    search_text_context([outer], "missing", cache=True)
+                    search_text_context([inner], "missing", cache=True)
+
+            self.assertEqual(
+                fast_results,
+                [
+                    (cache_module._canonical_path(outer), False),
+                    (cache_module._canonical_path(inner), True),
+                ],
+            )
+            self.assertEqual(
+                commits, [cache_module._canonical_path(outer)]
+            )
+
     def test_casefold_length_change_preserves_direct_truncation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir) / "repo"

--- a/tests/test_context_cache_benchmark.py
+++ b/tests/test_context_cache_benchmark.py
@@ -1,0 +1,80 @@
+"""Tests for the reproducible context-cache benchmark."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from benchmarks.context_cache_benchmark import (
+    BenchmarkCase,
+    _apply_mutation,
+    _build_corpus,
+    run_case,
+)
+
+
+class ContextCacheBenchmarkTests(TestCase):
+    def test_build_corpus_uses_deterministic_utf8_python_files(self):
+        """Changing the corpus layout would make benchmark runs incomparable."""
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+
+            _build_corpus(root, 3)
+
+            self.assertEqual(
+                [path.name for path in sorted(root.glob("*.py"))],
+                ["file_00000.py", "file_00001.py", "file_00002.py"],
+            )
+            self.assertEqual(
+                (root / "file_00000.py").read_text(encoding="utf-8"),
+                "# deterministic context benchmark\n"
+                "VALUE_00000 = 'needle 00000'\n",
+            )
+
+    def test_run_case_returns_stable_schema_for_each_mutation(self):
+        """Removing a timing result must fail rather than silently changing JSON."""
+        expected_keys = {
+            "files",
+            "mutation",
+            "api_direct_median_ms",
+            "api_direct_p95_ms",
+            "api_cached_median_ms",
+            "api_cached_p95_ms",
+            "api_cached_direct_ratio",
+            "cli_direct_median_ms",
+            "cli_direct_p95_ms",
+            "cli_cached_median_ms",
+            "cli_cached_p95_ms",
+            "cli_cached_direct_ratio",
+        }
+
+        for mutation in ("unchanged", "create", "modify", "rename", "remove"):
+            with self.subTest(mutation=mutation), patch(
+                    "benchmarks.context_cache_benchmark._time_call",
+                    side_effect=lambda operation: (operation(), 1_000_000)[1],
+            ):
+                result = run_case(BenchmarkCase(files=3, mutation=mutation), iterations=1)
+
+            self.assertEqual(set(result), expected_keys)
+            self.assertEqual(result["files"], 3)
+            self.assertEqual(result["mutation"], mutation)
+
+    def test_apply_mutation_changes_the_expected_corpus_entry(self):
+        """Wrong mutation behavior would hide cache invalidation regressions."""
+        expectations = {
+            "unchanged": (3, True, True),
+            "create": (4, True, True),
+            "modify": (3, True, True),
+            "rename": (3, False, True),
+            "remove": (2, True, False),
+        }
+        for mutation, (count, first_exists, last_exists) in expectations.items():
+            with self.subTest(mutation=mutation), TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                _build_corpus(root, 3)
+
+                _apply_mutation(root, mutation)
+
+                self.assertEqual(len(list(root.glob("*.py"))), count)
+                self.assertEqual((root / "file_00000.py").exists(), first_exists)
+                self.assertEqual((root / "file_00002.py").exists(), last_exists)

--- a/tests/test_context_cache_benchmark.py
+++ b/tests/test_context_cache_benchmark.py
@@ -59,6 +59,19 @@ class ContextCacheBenchmarkTests(TestCase):
             self.assertEqual(result["files"], 3)
             self.assertEqual(result["mutation"], mutation)
 
+    def test_run_case_rebuilds_mutated_scenario_for_each_sample(self):
+        """Every timed sample must receive a fresh filesystem mutation."""
+        with patch(
+                "benchmarks.context_cache_benchmark._apply_mutation",
+                wraps=_apply_mutation,
+        ) as apply_mutation, patch(
+                "benchmarks.context_cache_benchmark._time_call",
+                side_effect=lambda operation: (operation(), 1_000_000)[1],
+        ):
+            run_case(BenchmarkCase(files=3, mutation="rename"), iterations=2)
+
+        self.assertEqual(apply_mutation.call_count, 8)
+
     def test_apply_mutation_changes_the_expected_corpus_entry(self):
         """Wrong mutation behavior would hide cache invalidation regressions."""
         expectations = {
@@ -66,7 +79,7 @@ class ContextCacheBenchmarkTests(TestCase):
             "create": (4, True, True),
             "modify": (3, True, True),
             "rename": (3, False, True),
-            "remove": (2, True, False),
+            "remove": (2, False, True),
         }
         for mutation, (count, first_exists, last_exists) in expectations.items():
             with self.subTest(mutation=mutation), TemporaryDirectory() as temp_dir:

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -912,6 +912,105 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                     "C:/repo/sub/a.txt", signature, 100
                 ))
 
+    def test_get_cached_contents_returns_empty_mapping_for_empty_input(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            with ContextCacheDatabase(database_path) as database:
+                self.assertEqual(database.get_cached_contents([]), {})
+
+    def test_get_cached_contents_deduplicates_paths_and_returns_cached_states(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_files = (
+                CachedFile(
+                    "C:/repo/text.txt", "text.txt",
+                    FileSignature(1, 2, 3, 4, 5), "text", "cached text",
+                    "text-digest",
+                ),
+                CachedFile(
+                    "C:/repo/binary.bin", "binary.bin",
+                    FileSignature(6, 7, 8, 9, 10), "binary_file", None,
+                    None,
+                ),
+            )
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, cached_files)
+
+                results = database.get_cached_contents((
+                    "C:/repo/binary.bin",
+                    "C:/repo/missing.txt",
+                    "C:/repo/text.txt",
+                    "C:/repo/binary.bin",
+                ))
+
+            self.assertEqual(list(results), [
+                "C:/repo/binary.bin", "C:/repo/text.txt",
+            ])
+            self.assertEqual(results["C:/repo/text.txt"], CachedFile(
+                "C:/repo/text.txt", "", FileSignature(1, 2, 3, 4, 5),
+                "text", "cached text", "text-digest",
+            ))
+            self.assertEqual(results["C:/repo/binary.bin"], CachedFile(
+                "C:/repo/binary.bin", "", FileSignature(6, 7, 8, 9, 10),
+                "binary_file", None, None,
+            ))
+
+    def test_get_cached_contents_chunks_large_input_and_refreshes_access(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            paths = [f"C:/repo/{index}.txt" for index in range(1_001)]
+            cached_files = [CachedFile(
+                path, f"{index}.txt",
+                FileSignature(None, None, index + 1, index + 2, index + 3),
+                "text", str(index), None,
+            ) for index, path in enumerate(paths)]
+            with ContextCacheDatabase(database_path) as database:
+                scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(scan, cached_files)
+                database.connection.execute(
+                    "UPDATE files SET last_access_ns = 1"
+                )
+                database.connection.commit()
+
+                results = database.get_cached_contents(paths)
+                access_times = database.connection.execute(
+                    "SELECT DISTINCT last_access_ns FROM files"
+                ).fetchall()
+
+            self.assertEqual(list(results), paths)
+            self.assertEqual(len(results), len(paths))
+            self.assertEqual(len(access_times), 1)
+            self.assertGreater(access_times[0][0], 1)
+
+    def test_get_cached_contents_ignores_multiple_root_associations(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/sub/a.txt", "sub/a.txt",
+                FileSignature(None, None, 1, 10, 11), "text", "a", None,
+            )
+            with ContextCacheDatabase(database_path) as database:
+                parent_scan = database.begin_scan("default", "C:/repo")
+                database.commit_scan(parent_scan, [cached_file])
+                child_scan = database.begin_scan("default", "C:/repo/sub")
+                database.commit_scan(child_scan, [CachedFile(
+                    cached_file.canonical_path, "a.txt", cached_file.signature,
+                    cached_file.state, cached_file.folded_text,
+                    cached_file.content_sha256,
+                )])
+
+                results = database.get_cached_contents([
+                    cached_file.canonical_path,
+                ])
+
+            self.assertEqual(results, {
+                cached_file.canonical_path: CachedFile(
+                    cached_file.canonical_path, "", cached_file.signature,
+                    "text", "a", None,
+                ),
+            })
+
     def test_iter_root_files_refreshes_root_lru_timestamp(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"

--- a/tests/test_context_cache_db.py
+++ b/tests/test_context_cache_db.py
@@ -729,6 +729,317 @@ class ContextCacheDatabaseTest(unittest.TestCase):
                 [("kept.txt", "kept")],
             )
 
+    def test_publish_unchanged_scan_updates_only_publication_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_files = (
+                CachedFile(
+                    "C:/repo/a.txt",
+                    "a.txt",
+                    FileSignature(1, 2, 3, 4, 5),
+                    "text",
+                    "alpha",
+                    "digest-a",
+                ),
+                CachedFile(
+                    "C:/repo/b.bin",
+                    "b.bin",
+                    FileSignature(6, 7, 8, 9, 10),
+                    "binary_file",
+                    None,
+                    "digest-b",
+                ),
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(
+                    seed, cached_files, max_file_bytes=100
+                )
+                token = database.begin_scan("default", "C:/repo")
+                before_files = database.connection.execute(
+                    "SELECT * FROM files ORDER BY canonical_path"
+                ).fetchall()
+                before_associations = database.connection.execute(
+                    "SELECT * FROM root_files ORDER BY file_id"
+                ).fetchall()
+                before_generation = database.connection.execute(
+                    "SELECT scan_generation FROM roots"
+                ).fetchone()[0]
+                statements = []
+                timestamp = token.started_ns + 100
+                original_projection = database._projected_aggregate_size
+                with patch(
+                    "cereja.system._context.cache_db.time.time_ns",
+                    return_value=timestamp,
+                ), patch.object(
+                    database,
+                    "_projected_aggregate_size",
+                    wraps=original_projection,
+                ) as projected:
+                    database.connection.set_trace_callback(statements.append)
+                    unchanged = database.publish_unchanged_scan(
+                        token,
+                        cached_files,
+                        max_bytes=10 ** 9,
+                        max_file_bytes=100,
+                    )
+                    database.connection.set_trace_callback(None)
+
+                metadata = database.connection.execute(
+                    """SELECT n.last_access_ns, r.last_access_ns,
+                              r.scan_generation, r.scan_started_ns, r.scan_nonce
+                       FROM namespaces AS n
+                       JOIN namespace_roots AS nr ON nr.namespace_id = n.id
+                       JOIN roots AS r ON r.id = nr.root_id
+                       WHERE n.name = 'default'
+                         AND r.canonical_path = 'C:/repo'"""
+                ).fetchone()
+                after_files = database.connection.execute(
+                    "SELECT * FROM files ORDER BY canonical_path"
+                ).fetchall()
+                after_associations = database.connection.execute(
+                    "SELECT * FROM root_files ORDER BY file_id"
+                ).fetchall()
+
+                self.assertTrue(unchanged)
+                self.assertEqual(
+                    metadata,
+                    (
+                        timestamp,
+                        timestamp,
+                        before_generation + 1,
+                        token.started_ns,
+                        token.nonce,
+                    ),
+                )
+                self.assertEqual(after_files, before_files)
+                self.assertEqual(after_associations, before_associations)
+                self.assertEqual(projected.call_count, 3)
+                normalized = [" ".join(item.casefold().split()) for item in statements]
+                forbidden = (
+                    "insert into files",
+                    "update files",
+                    "insert into root_files",
+                    "update root_files",
+                    "delete from root_files",
+                    "savepoint",
+                )
+                self.assertFalse(any(
+                    marker in statement
+                    for marker in forbidden
+                    for statement in normalized
+                ))
+                shared = _CachePathLock(database_path)
+                shared.acquire(False, wait=False)
+                shared.release()
+
+    def test_publish_unchanged_scan_rejects_snapshot_mismatches(self):
+        original = CachedFile(
+            "C:/repo/a.txt",
+            "a.txt",
+            FileSignature(1, 2, 3, 4, 5),
+            "text",
+            "alpha",
+            "digest-a",
+        )
+        mismatches = {
+            "canonical path": CachedFile(
+                "C:/repo/b.txt", "a.txt", original.signature,
+                original.state, original.folded_text, original.content_sha256,
+            ),
+            "relative path": CachedFile(
+                original.canonical_path, "renamed.txt", original.signature,
+                original.state, original.folded_text, original.content_sha256,
+            ),
+            "device": CachedFile(
+                original.canonical_path, original.relative_path,
+                FileSignature(9, 2, 3, 4, 5), original.state,
+                original.folded_text, original.content_sha256,
+            ),
+            "inode": CachedFile(
+                original.canonical_path, original.relative_path,
+                FileSignature(1, 9, 3, 4, 5), original.state,
+                original.folded_text, original.content_sha256,
+            ),
+            "size": CachedFile(
+                original.canonical_path, original.relative_path,
+                FileSignature(1, 2, 9, 4, 5), original.state,
+                original.folded_text, original.content_sha256,
+            ),
+            "mtime": CachedFile(
+                original.canonical_path, original.relative_path,
+                FileSignature(1, 2, 3, 9, 5), original.state,
+                original.folded_text, original.content_sha256,
+            ),
+            "ctime": CachedFile(
+                original.canonical_path, original.relative_path,
+                FileSignature(1, 2, 3, 4, 9), original.state,
+                original.folded_text, original.content_sha256,
+            ),
+            "state": CachedFile(
+                original.canonical_path, original.relative_path,
+                original.signature, "invalid_utf8", None,
+                original.content_sha256,
+            ),
+            "digest": CachedFile(
+                original.canonical_path, original.relative_path,
+                original.signature, original.state, original.folded_text,
+                "digest-b",
+            ),
+        }
+        for label, candidate in mismatches.items():
+            with self.subTest(label=label), \
+                    tempfile.TemporaryDirectory() as temp_dir:
+                database_path = Path(temp_dir) / "context.sqlite3"
+                with ContextCacheDatabase(database_path) as database:
+                    seed = database.begin_scan("default", "C:/repo")
+                    database.commit_scan(
+                        seed, [original], max_file_bytes=100
+                    )
+                    token = database.begin_scan("default", "C:/repo")
+                    metadata = database.connection.execute(
+                        "SELECT scan_generation, scan_started_ns, scan_nonce "
+                        "FROM roots"
+                    ).fetchone()
+
+                    self.assertFalse(database.publish_unchanged_scan(
+                        token,
+                        [candidate],
+                        max_bytes=10 ** 9,
+                        max_file_bytes=100,
+                    ))
+
+                    self.assertEqual(database.connection.execute(
+                        "SELECT scan_generation, scan_started_ns, scan_nonce "
+                        "FROM roots"
+                    ).fetchone(), metadata)
+
+    def test_publish_unchanged_scan_rejects_missing_association_and_stale_token(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(1, 2, 3, 4, 5),
+                "text", "alpha", "digest-a",
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(
+                    seed, [cached_file], max_file_bytes=100
+                )
+                fresh = database.begin_scan("default", "C:/repo")
+                database.connection.execute("DELETE FROM namespace_roots")
+                database.connection.commit()
+                self.assertFalse(database.publish_unchanged_scan(
+                    fresh,
+                    [cached_file],
+                    max_bytes=10 ** 9,
+                    max_file_bytes=100,
+                ))
+
+                database.connection.execute(
+                    """INSERT INTO namespace_roots (namespace_id, root_id)
+                       SELECT n.id, r.id FROM namespaces AS n, roots AS r
+                       WHERE n.name = 'default'
+                         AND r.canonical_path = 'C:/repo'"""
+                )
+                database.connection.commit()
+                with self.assertRaises(CacheDatabaseError):
+                    database.publish_unchanged_scan(
+                        seed,
+                        [cached_file],
+                        max_bytes=10 ** 9,
+                        max_file_bytes=100,
+                    )
+
+    def test_publish_unchanged_scan_preserves_quota_and_atomic_rollback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(1, 2, 3, 4, 5),
+                "text", "alpha", "digest-a",
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(
+                    seed, [cached_file], max_file_bytes=100
+                )
+                refused = database.begin_scan("default", "C:/repo")
+                baseline = database.connection.execute(
+                    """SELECT n.last_access_ns, r.last_access_ns,
+                              r.scan_generation, r.scan_started_ns, r.scan_nonce
+                       FROM namespaces AS n
+                       JOIN namespace_roots AS nr ON nr.namespace_id = n.id
+                       JOIN roots AS r ON r.id = nr.root_id
+                       WHERE n.name = 'default'
+                         AND r.canonical_path = 'C:/repo'"""
+                ).fetchone()
+
+                self.assertFalse(database.publish_unchanged_scan(
+                    refused,
+                    [cached_file],
+                    max_bytes=0,
+                    max_file_bytes=100,
+                ))
+                self.assertEqual(database.connection.execute(
+                    """SELECT n.last_access_ns, r.last_access_ns,
+                              r.scan_generation, r.scan_started_ns, r.scan_nonce
+                       FROM namespaces AS n
+                       JOIN namespace_roots AS nr ON nr.namespace_id = n.id
+                       JOIN roots AS r ON r.id = nr.root_id
+                       WHERE n.name = 'default'
+                         AND r.canonical_path = 'C:/repo'"""
+                ).fetchone(), baseline)
+
+                failed = database.begin_scan("default", "C:/repo")
+                projection = database._projected_aggregate_size()
+                with patch.object(
+                    database,
+                    "_projected_aggregate_size",
+                    side_effect=(projection, projection, RuntimeError("boom")),
+                ), self.assertRaisesRegex(RuntimeError, "boom"):
+                    database.publish_unchanged_scan(
+                        failed,
+                        [cached_file],
+                        max_bytes=10 ** 9,
+                        max_file_bytes=100,
+                    )
+                self.assertEqual(database.connection.execute(
+                    """SELECT n.last_access_ns, r.last_access_ns,
+                              r.scan_generation, r.scan_started_ns, r.scan_nonce
+                       FROM namespaces AS n
+                       JOIN namespace_roots AS nr ON nr.namespace_id = n.id
+                       JOIN roots AS r ON r.id = nr.root_id
+                       WHERE n.name = 'default'
+                         AND r.canonical_path = 'C:/repo'"""
+                ).fetchone(), baseline)
+                self.assertEqual(
+                    database.connection.execute(
+                        "PRAGMA locking_mode"
+                    ).fetchone()[0],
+                    "normal",
+                )
+
+    def test_publish_unchanged_scan_rejects_size_limit_transition(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = Path(temp_dir) / "context.sqlite3"
+            cached_file = CachedFile(
+                "C:/repo/a.txt", "a.txt", FileSignature(1, 2, 3, 4, 5),
+                "text", "alpha", "digest-a",
+            )
+            with ContextCacheDatabase(database_path) as database:
+                seed = database.begin_scan("default", "C:/repo")
+                database.commit_scan(
+                    seed, [cached_file], max_file_bytes=10
+                )
+                token = database.begin_scan("default", "C:/repo")
+
+                self.assertFalse(database.publish_unchanged_scan(
+                    token,
+                    [cached_file],
+                    max_bytes=10 ** 9,
+                    max_file_bytes=20,
+                ))
+
     def test_abandoned_scan_does_not_delete_existing_associations(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir) / "context.sqlite3"

--- a/tests/test_directory_entries.py
+++ b/tests/test_directory_entries.py
@@ -1,0 +1,73 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cereja.system._directory_entries import iter_directory_entries
+
+
+class DirectoryEntriesTest(unittest.TestCase):
+    def test_lists_one_directory_and_filters_dotfiles_by_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "Zulu.txt").write_text("z", encoding="utf-8")
+            (root / "árvore.txt").write_text("a", encoding="utf-8")
+            (root / ".hidden.txt").write_text("hidden", encoding="utf-8")
+            (root / "child").mkdir()
+
+            names = [entry.name for entry in iter_directory_entries(root)]
+
+            self.assertCountEqual(names, ["Zulu.txt", "árvore.txt", "child"])
+
+    def test_can_include_hidden_entries(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / ".hidden.txt").write_text("hidden", encoding="utf-8")
+
+            names = [
+                entry.name
+                for entry in iter_directory_entries(root, include_hidden=True)
+            ]
+
+            self.assertEqual(names, [".hidden.txt"])
+
+    def test_permission_error_returns_no_entries_by_default(self):
+        denied = PermissionError("denied")
+        with self.assertLogs(
+                "cereja.system._directory_entries", level="ERROR"
+        ) as logs, patch("os.scandir", side_effect=denied):
+            entries = list(iter_directory_entries("blocked"))
+
+        self.assertEqual(entries, [])
+        self.assertIn("denied", logs.output[0])
+
+    def test_permission_error_is_raised_when_requested(self):
+        denied = PermissionError("denied")
+        with patch("os.scandir", side_effect=denied):
+            with self.assertRaisesRegex(PermissionError, "denied"):
+                list(iter_directory_entries("blocked", raise_errors=True))
+
+    def test_os_errors_return_no_entries_by_default(self):
+        errors = (
+            FileNotFoundError("gone"),
+            NotADirectoryError("replaced"),
+            OSError("enumeration failed"),
+        )
+        for error in errors:
+            with self.subTest(error=type(error).__name__):
+                with self.assertLogs(
+                        "cereja.system._directory_entries", level="ERROR"
+                ), patch("os.scandir", side_effect=error):
+                    entries = list(iter_directory_entries("broken"))
+
+                self.assertEqual(entries, [])
+
+    def test_non_permission_os_errors_are_raised_when_requested(self):
+        failed = FileNotFoundError("gone")
+        with patch("os.scandir", side_effect=failed):
+            with self.assertRaisesRegex(FileNotFoundError, "gone"):
+                list(iter_directory_entries("broken", raise_errors=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_path_directory_entries.py
+++ b/tests/test_path_directory_entries.py
@@ -1,0 +1,123 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path as NativePath
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cereja.system._path import Path
+
+
+class PathDirectoryEntriesTest(unittest.TestCase):
+    def test_simple_list_dir_matches_scandir_order_and_path_results(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = NativePath(temp_dir)
+            (root / "Zulu.TXT").write_text("z", encoding="utf-8")
+            (root / "alpha.txt").write_text("a", encoding="utf-8")
+            (root / "árvore.md").write_text("unicode", encoding="utf-8")
+            (root / ".hidden.txt").write_text("hidden", encoding="utf-8")
+            (root / "child").mkdir()
+            expected = [
+                NativePath(entry.path).as_posix()
+                for entry in os.scandir(root)
+                if not entry.name.startswith(".")
+            ]
+
+            results = Path(root).list_dir()
+
+            self.assertCountEqual([item.path for item in results], expected)
+            self.assertTrue(all(isinstance(item, Path) for item in results))
+
+    def test_simple_list_dir_preserves_primitive_order(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            emitted = [
+                SimpleNamespace(path=root.join(name).path)
+                for name in ("Zulu.txt", "alpha.txt", "árvore.txt")
+            ]
+            with patch(
+                    "cereja.system._path.iter_directory_entries",
+                    return_value=iter(emitted),
+            ):
+                results = root.list_dir()
+
+            self.assertEqual(
+                [item.name for item in results],
+                ["Zulu.txt", "alpha.txt", "árvore.txt"],
+            )
+
+    def test_simple_list_dir_supports_hidden_and_only_name(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = NativePath(temp_dir)
+            (root / ".archive.tar.gz").write_text("hidden", encoding="utf-8")
+            (root / "visible.tar.gz").write_text("visible", encoding="utf-8")
+
+            names = Path(root).list_dir(
+                only_name=True,
+                include_hidden=True,
+            )
+
+            self.assertCountEqual(names, [".archive.tar", "visible.tar"])
+
+    def test_simple_list_dir_suppresses_enumeration_races_by_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            failed = FileNotFoundError("gone")
+            with self.assertLogs(
+                    "cereja.system._directory_entries", level="ERROR"
+            ), patch("os.scandir", side_effect=failed):
+                self.assertEqual(root.list_dir(), [])
+
+            with patch("os.scandir", side_effect=failed):
+                with self.assertRaisesRegex(FileNotFoundError, "gone"):
+                    root.list_dir(raise_errors=True)
+
+    def test_simple_list_dir_delegates_permission_policy_to_primitive(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            denied = PermissionError("denied")
+            with self.assertLogs(
+                    "cereja.system._path", level="ERROR"
+            ) as logs, patch(
+                "cereja.system._path.iter_directory_entries",
+                side_effect=denied,
+            ):
+                self.assertEqual(root.list_dir(), [])
+                with self.assertRaisesRegex(PermissionError, "denied"):
+                    root.list_dir(raise_errors=True)
+            self.assertIn("denied", logs.output[0])
+
+    def test_patterns_and_recursive_calls_keep_glob_fallback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            matched = root.join("match.txt").path
+            cases = (("*.txt", False), ("*", True), ("**/*.txt", True))
+            for search_match, recursive in cases:
+                with self.subTest(search_match=search_match, recursive=recursive):
+                    with patch(
+                            "cereja.system._path.iter_directory_entries",
+                            side_effect=AssertionError("unexpected scandir fast path"),
+                    ), patch(
+                            "cereja.system._path.glob.glob",
+                            return_value=[matched],
+                    ) as glob_call:
+                        results = root.list_dir(
+                            search_match,
+                            recursive=recursive,
+                            include_hidden=True,
+                        )
+
+                    self.assertEqual([item.path for item in results], [matched])
+                    glob_call.assert_called_once_with(
+                        root.join(search_match).path,
+                        recursive=recursive,
+                        include_hidden=True,
+                    )
+
+    def test_empty_directory_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertEqual(Path(temp_dir).list_dir(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_files.py
+++ b/tests/test_repository_files.py
@@ -2,8 +2,49 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from cereja.system import RepositoryFile, iter_repository_files
+from cereja.system._path import Path as CerejaPath
+from cereja.system import _repository_files as repository_files_module
+
+
+class FakeDirectoryEntry:
+    def __init__(
+            self,
+            path,
+            *,
+            directory=False,
+            symlink=False,
+            file_attributes=0,
+            metadata_error=None,
+    ):
+        self.path = os.fspath(path)
+        self.name = Path(path).name
+        self._directory = directory
+        self._symlink = symlink
+        self._file_attributes = file_attributes
+        self._metadata_error = metadata_error
+        self.calls = []
+
+    def is_symlink(self):
+        self.calls.append(("is_symlink",))
+        if self._metadata_error is not None:
+            raise self._metadata_error
+        return self._symlink
+
+    def is_dir(self, *, follow_symlinks=True):
+        self.calls.append(("is_dir", follow_symlinks))
+        if self._metadata_error is not None:
+            raise self._metadata_error
+        return self._directory
+
+    def stat(self, *, follow_symlinks=True):
+        self.calls.append(("stat", follow_symlinks))
+        if self._metadata_error is not None:
+            raise self._metadata_error
+        return SimpleNamespace(st_file_attributes=self._file_attributes)
 
 
 class RepositoryFilesTest(unittest.TestCase):
@@ -57,6 +98,35 @@ class RepositoryFilesTest(unittest.TestCase):
 
             self.assertEqual([item.relative_path for item in files], ["guide.MD"])
 
+    def test_honors_nested_ignore_bases_negation_and_final_order(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / ".gitignore").write_text("*.tmp\n", encoding="utf-8")
+            (root / "root.tmp").write_text("ignored", encoding="utf-8")
+            src = root / "src"
+            src.mkdir()
+            (src / ".gitignore").write_text(
+                "*.secret\n!important.secret\n",
+                encoding="utf-8",
+            )
+            (src / "hidden.secret").write_text("ignored", encoding="utf-8")
+            (src / "important.secret").write_text("kept", encoding="utf-8")
+            (src / "Zulu.txt").write_text("z", encoding="utf-8")
+            (src / "alpha.txt").write_text("a", encoding="utf-8")
+
+            files = list(iter_repository_files([root]))
+
+            self.assertEqual(
+                [item.relative_path for item in files],
+                [
+                    ".gitignore",
+                    "src/.gitignore",
+                    "src/Zulu.txt",
+                    "src/alpha.txt",
+                    "src/important.secret",
+                ],
+            )
+
     def test_rejects_missing_root_and_file_root(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -89,6 +159,102 @@ class RepositoryFilesTest(unittest.TestCase):
                 [item.relative_path for item in files],
                 ["real/inside.txt", "target.txt"],
             )
+
+    def test_walk_uses_direntry_metadata_and_defers_path_construction(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = CerejaPath(temp_dir)
+            child_path = Path(temp_dir) / "child"
+            entries = [
+                FakeDirectoryEntry(Path(temp_dir) / ".git", directory=True),
+                FakeDirectoryEntry(Path(temp_dir) / "ignored.tmp"),
+                FakeDirectoryEntry(Path(temp_dir) / "linked.txt", symlink=True),
+                FakeDirectoryEntry(Path(temp_dir) / "wrong.md"),
+                FakeDirectoryEntry(child_path, directory=True),
+                FakeDirectoryEntry(Path(temp_dir) / "keep.TXT"),
+            ]
+            child_entry = FakeDirectoryEntry(child_path / "inside.txt")
+            by_directory = {
+                root.path: entries,
+                CerejaPath(child_path).path: [child_entry],
+            }
+            created = []
+
+            def scan(path, **kwargs):
+                self.assertEqual(kwargs, {
+                    "include_hidden": True,
+                    "raise_errors": True,
+                })
+                return iter(by_directory[CerejaPath(path).path])
+
+            def make_path(path):
+                created.append(CerejaPath(path).path)
+                return CerejaPath(path)
+
+            ignore = repository_files_module._IgnoreRule(
+                "*.tmp", False, False, False, root.path
+            )
+            with patch.object(
+                    repository_files_module,
+                    "iter_directory_entries",
+                    side_effect=scan,
+            ), patch.object(
+                    repository_files_module,
+                    "Path",
+                    side_effect=make_path,
+            ):
+                found = repository_files_module._walk_files(
+                    root,
+                    (ignore,),
+                    frozenset({".txt"}),
+                )
+
+            self.assertEqual(
+                [
+                    Path(item.path).relative_to(temp_dir).as_posix()
+                    for item in found
+                ],
+                ["child/inside.txt", "keep.TXT"],
+            )
+            self.assertEqual(
+                [Path(path).relative_to(temp_dir).as_posix() for path in created],
+                ["child", "child/inside.txt", "keep.TXT"],
+            )
+            for entry in entries:
+                self.assertIn(("is_symlink",), entry.calls)
+            self.assertNotIn(("is_dir", False), entries[2].calls)
+            for entry in (*entries[:2], *entries[3:], child_entry):
+                self.assertIn(("is_dir", False), entry.calls)
+
+    def test_walk_propagates_direntry_metadata_errors(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = CerejaPath(temp_dir)
+            failed = FakeDirectoryEntry(
+                Path(temp_dir) / "vanished.txt",
+                metadata_error=OSError("metadata unavailable"),
+            )
+            with patch.object(
+                    repository_files_module,
+                    "iter_directory_entries",
+                    return_value=iter((failed,)),
+            ):
+                with self.assertRaisesRegex(OSError, "metadata unavailable"):
+                    repository_files_module._walk_files(root, (), None)
+
+    def test_windows_reparse_point_is_treated_as_link(self):
+        entry = FakeDirectoryEntry(
+            "junction",
+            directory=True,
+            file_attributes=0x400,
+        )
+
+        with patch.object(repository_files_module.os, "name", "nt"):
+            is_link = repository_files_module._directory_entry_is_link(entry)
+
+        self.assertTrue(is_link)
+        self.assertEqual(
+            entry.calls,
+            [("is_symlink",), ("stat", False)],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_files.py
+++ b/tests/test_repository_files.py
@@ -3,10 +3,22 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from cereja.system import iter_repository_files
+from cereja.system import RepositoryFile, iter_repository_files
 
 
 class RepositoryFilesTest(unittest.TestCase):
+    def test_repository_file_constructor_remains_backward_compatible(self):
+        item = RepositoryFile(
+            root="root",
+            path="path",
+            relative_path="relative.txt",
+        )
+
+        self.assertEqual(
+            (item.root, item.path, item.relative_path),
+            ("root", "path", "relative.txt"),
+        )
+
     def test_is_ordered_and_honors_parent_gitignore(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir) / "repo"


### PR DESCRIPTION
## Objetivo\nIntegrar a implementação de performance do cache persistente de contexto.\n\n## Escopo\n- sincronização incremental;\n- reutilização de metadados e conteúdo inalterados;\n- criação, modificação, rename e remoção;\n- fast-path de raízes inalteradas;\n- publicação transacional e locks;\n- travessia com os.scandir;\n- cobertura de API, CLI, equivalência e benchmark.\n\n## Validação local\n- testes focados: 172 passed, 9 skipped;\n- CLI/equivalência/benchmark: 57 passed;\n- suíte oficial unittest: 568 passed, 11 skipped;\n- lint estrito versionado: passou;\n- benchmarks controlados em 16, 128 e 512 arquivos.\n\n## Pendências\n- matriz pesada não executada por risco operacional do BSOD;\n- minidump informado indisponível;\n- Linux não disponível;\n- ganhos dependem do tamanho do corpus.\n\nA refatoração estrutural de cereja.system._context está fora deste PR.